### PR TITLE
fix: Convert docs symlink to real folder for Windows compatibility

### DIFF
--- a/firmware_new/docs
+++ b/firmware_new/docs
@@ -1,1 +1,0 @@
-/home/orangepi/Desktop/OHT_V2/docs/05-IMPLEMENTATION/FIRMWARE

--- a/firmware_new/docs/01-QUALITY_POLICY/QP-001_Security_Policy.md
+++ b/firmware_new/docs/01-QUALITY_POLICY/QP-001_Security_Policy.md
@@ -1,0 +1,210 @@
+# 🔐 Security Policy - OHT-50 Firmware
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07
+
+---
+
+## 📋 **SUPPORTED VERSIONS**
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | ✅ Yes             |
+| < 1.0   | ❌ No              |
+
+---
+
+## 🛡️ **SECURITY FEATURES**
+
+### **Current Security**
+
+✅ **Basic Authentication**: API authentication support  
+✅ **Input Validation**: Request parameter validation  
+✅ **Audit Logging**: Security event logging  
+✅ **Auto Cleanup**: Process và port cleanup  
+⚠️ **HTTPS Support**: Optional (not enabled by default)  
+⚠️ **Rate Limiting**: Basic (can be enhanced)
+
+### **Planned Security (Future)**
+
+- [ ] OAuth2/JWT authentication
+- [ ] Role-based access control (RBAC)
+- [ ] API rate limiting (advanced)
+- [ ] Intrusion detection
+- [ ] Encrypted communication (TLS)
+
+---
+
+## 🚨 **REPORTING VULNERABILITIES**
+
+### **How to Report**
+
+🔒 **DO NOT** create public GitHub issues for security vulnerabilities!
+
+**Report privately:**
+
+1. **Email:** security@oht50.com
+2. **PGP Key:** Available at https://oht50.com/pgp
+3. **Include:**
+   - Description of vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+### **Response Timeline**
+
+- **24 hours:** Initial acknowledgment
+- **7 days:** Assessment và triage
+- **30 days:** Fix released (if confirmed)
+- **60 days:** Public disclosure (coordinated)
+
+---
+
+## ⚠️ **KNOWN SECURITY CONSIDERATIONS**
+
+### **1. Default Configuration**
+
+❌ **Not Production-Ready Out-of-the-Box**
+
+```yaml
+# Default config (INSECURE):
+auth:
+  enabled: false           # ❌ Auth disabled
+  
+network:
+  https: false             # ❌ HTTP only
+  rate_limit: basic        # ⚠️ Basic rate limiting
+```
+
+**Recommended Production Config:**
+
+```yaml
+auth:
+  enabled: true
+  method: jwt
+  
+network:
+  https: true
+  rate_limit: advanced
+  
+logging:
+  audit_enabled: true
+```
+
+### **2. Network Exposure**
+
+⚠️ **Default:** API exposed on `0.0.0.0:8080` (all interfaces)
+
+**Recommendation:** Bind to specific interface
+
+```c
+// Edit http_server.c
+#define HTTP_BIND_ADDRESS "127.0.0.1"  // Localhost only
+```
+
+### **3. Hardware Access**
+
+⚠️ **GPIO/UART Access:** Requires root or dialout group
+
+**Recommendation:** Use dedicated service user
+
+```bash
+sudo useradd -r -s /bin/false oht50service
+sudo usermod -a -G dialout,gpio oht50service
+```
+
+---
+
+## 🔒 **SECURITY BEST PRACTICES**
+
+### **Deployment Security**
+
+```bash
+# 1. Use non-root user
+sudo useradd -r oht50
+sudo chown oht50:oht50 /usr/local/bin/oht50_main
+
+# 2. Enable firewall
+sudo ufw enable
+sudo ufw allow 8080/tcp  # Only if needed externally
+
+# 3. Use systemd security features
+[Service]
+User=oht50
+Group=oht50
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+NoNewPrivileges=yes
+```
+
+### **Network Security**
+
+```bash
+# Use reverse proxy (nginx/apache)
+# Example nginx config:
+server {
+    listen 443 ssl;
+    server_name oht50.example.com;
+    
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+    
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+---
+
+## 📊 **SECURITY AUDIT**
+
+### **Self-Assessment Checklist**
+
+```bash
+# Authentication
+[ ] API authentication enabled
+[ ] Strong passwords enforced
+[ ] Session timeout configured
+
+# Network
+[ ] HTTPS enabled (production)
+[ ] Firewall configured
+[ ] Rate limiting active
+
+# Access Control
+[ ] Least privilege principle
+[ ] No unnecessary permissions
+[ ] Audit logging enabled
+
+# Code
+[ ] Input validation implemented
+[ ] No hardcoded secrets
+[ ] Dependencies updated
+[ ] Security patches applied
+```
+
+---
+
+## 🏆 **SECURITY HALL OF FAME**
+
+Contributors who report valid security vulnerabilities:
+
+- (No reports yet - be the first!)
+
+---
+
+## 📞 **CONTACT**
+
+**Security Team:**
+- 📧 **Email:** security@oht50.com
+- 🔐 **PGP:** https://oht50.com/pgp
+- 💬 **Private Slack:** Request invite via email
+
+---
+
+**Version:** 1.0.1  
+**Maintained By:** OHT-50 Security Team
+

--- a/firmware_new/docs/01-QUALITY_POLICY/QP-002_License.md
+++ b/firmware_new/docs/01-QUALITY_POLICY/QP-002_License.md
@@ -1,0 +1,205 @@
+# 📜 License - OHT-50 Firmware
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07
+
+---
+
+## MIT License
+
+Copyright (c) 2025 OHT-50 Development Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## 📋 **Third-Party Licenses**
+
+This project includes third-party libraries and components with their own licenses:
+
+### **Unity Test Framework**
+
+- **License:** MIT License
+- **Copyright:** (c) 2007-2022 Mike Karlesky, Mark VanderVoord, Greg Williams
+- **Website:** https://github.com/ThrowTheSwitch/Unity
+- **Location:** `third_party/unity/`
+
+```
+MIT License
+
+Copyright (c) 2007-2022 Mike Karlesky, Mark VanderVoord, Greg Williams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### **OpenSSL**
+
+- **License:** Apache License 2.0 and SSLeay License (dual-licensed)
+- **Copyright:** The OpenSSL Project
+- **Website:** https://www.openssl.org/
+- **Usage:** SSL/TLS support (optional)
+
+**Note:** OpenSSL is dynamically linked and not included in this repository.
+
+---
+
+## 🔓 **Open Source Attribution**
+
+This project is built on the shoulders of giants. We acknowledge and thank:
+
+| **Component** | **License** | **Website** |
+|---------------|-------------|-------------|
+| Unity | MIT | https://github.com/ThrowTheSwitch/Unity |
+| OpenSSL | Apache 2.0 | https://www.openssl.org/ |
+| pthread | LGPL | Part of glibc |
+| CMake | BSD-3-Clause | https://cmake.org/ |
+
+---
+
+## 📝 **Usage Permissions**
+
+### ✅ **You CAN:**
+
+- ✅ Use the software for commercial purposes
+- ✅ Modify the software
+- ✅ Distribute the software
+- ✅ Sublicense the software
+- ✅ Use the software privately
+
+### 📋 **You MUST:**
+
+- 📋 Include the license and copyright notice
+- 📋 State changes if you modify the code
+- 📋 Include the original license in distributions
+
+### ❌ **You CANNOT:**
+
+- ❌ Hold the authors liable
+- ❌ Use the authors' names for endorsement without permission
+
+---
+
+## 🛡️ **Warranty Disclaimer**
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+
+**This means:**
+
+⚠️ No warranty for hardware compatibility  
+⚠️ No warranty for production use  
+⚠️ No warranty for safety-critical applications  
+⚠️ No warranty for any damages or losses
+
+**Use at your own risk.**
+
+---
+
+## 🔐 **Security & Safety**
+
+### **Safety-Critical Applications**
+
+⚠️ **WARNING**: This firmware is designed for industrial automation but has NOT been certified for safety-critical applications such as:
+
+- Medical devices
+- Life support systems
+- Nuclear facilities
+- Aviation systems
+- Critical infrastructure
+
+If you plan to use this firmware in safety-critical applications:
+
+1. Conduct thorough safety analysis (FMEA, FTA)
+2. Obtain proper certifications (IEC 61508, ISO 26262, etc.)
+3. Implement additional safety measures
+4. Consult with safety engineers
+5. Perform extensive testing and validation
+
+### **Security Considerations**
+
+This firmware includes basic security features but may require additional hardening for production deployment:
+
+- 🔒 Authentication: Basic (consider adding OAuth2/JWT)
+- 🔒 Encryption: Optional HTTPS (consider enabling in production)
+- 🔒 Input Validation: Basic (review for your use case)
+- 🔒 Audit Logging: Basic (consider enhancing for compliance)
+
+See [SECURITY.md](SECURITY.md) for detailed security guidelines.
+
+---
+
+## 🏢 **Commercial Support**
+
+While the software is free and open-source, commercial support is available:
+
+- 🔧 **Custom Development**: Feature development, customization
+- 🛠️ **Integration Services**: System integration, deployment
+- 🎓 **Training**: On-site training, workshops
+- 📞 **Priority Support**: 24/7 support, SLA agreements
+- 🔐 **Security Audits**: Professional security assessment
+
+**Contact:** commercial@oht50.com
+
+---
+
+## 🤝 **Contributing**
+
+By contributing to this project, you agree that your contributions will be licensed under the MIT License.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
+---
+
+## 📞 **Contact**
+
+For licensing questions:
+
+- **Email:** legal@oht50.com
+- **Website:** https://oht50.com/legal
+- **GitHub:** https://github.com/your-org/OHT-50-firmware
+
+---
+
+## 📚 **Additional Resources**
+
+- [MIT License FAQ](https://opensource.org/licenses/MIT)
+- [Open Source Initiative](https://opensource.org/)
+- [Choose a License](https://choosealicense.com/)
+
+---
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07  
+**Maintained By:** OHT-50 Legal Team
+

--- a/firmware_new/docs/01-QUALITY_POLICY/QP-003_Quality_Policy.md
+++ b/firmware_new/docs/01-QUALITY_POLICY/QP-003_Quality_Policy.md
@@ -1,0 +1,200 @@
+# Quality Policy - OHT-50 Firmware
+
+**Phiên bản:** 1.0.0  
+**Ngày tạo:** 2025-01-28  
+**Tuân thủ:** ISO 9001:2015  
+**Phạm vi:** OHT-50 Master Module Firmware Development
+
+---
+
+## 📋 **TỔNG QUAN**
+
+Quality Policy này định nghĩa cam kết của team firmware trong việc duy trì và cải thiện chất lượng sản phẩm theo chuẩn ISO 9001:2015.
+
+---
+
+## 🎯 **MỤC TIÊU CHẤT LƯỢNG**
+
+### **Primary Objectives**
+- **Code Quality:** Đạt 90%+ test coverage
+- **Safety Compliance:** 100% safety requirements compliance
+- **Performance:** Đáp ứng tất cả performance targets
+- **Documentation:** 100% API và technical documentation
+- **Reliability:** 99.9% system uptime
+
+### **Quality Metrics**
+- **Defect Rate:** < 1% trong production
+- **Response Time:** < 100ms cho critical operations
+- **Build Success Rate:** > 95%
+- **Code Review Coverage:** 100%
+- **Documentation Completeness:** 100%
+
+---
+
+## 🔧 **QUALITY MANAGEMENT PRINCIPLES**
+
+### **1. Customer Focus**
+- Hiểu rõ requirements của end users
+- Đảm bảo safety và reliability
+- Cung cấp comprehensive documentation
+- Responsive support và maintenance
+
+### **2. Leadership Commitment**
+- Management commitment to quality
+- Resource allocation cho quality activities
+- Regular quality reviews và assessments
+- Continuous improvement culture
+
+### **3. Process Approach**
+- Standardized development processes
+- Clear procedures và guidelines
+- Process monitoring và measurement
+- Process improvement initiatives
+
+### **4. Continuous Improvement**
+- Regular quality assessments
+- Root cause analysis
+- Corrective và preventive actions
+- Innovation và best practices adoption
+
+---
+
+## 📊 **QUALITY ASSURANCE PROCESSES**
+
+### **Development Quality**
+- **Code Review:** Mandatory cho tất cả changes
+- **Static Analysis:** Automated code quality checks
+- **Unit Testing:** Minimum 90% coverage
+- **Integration Testing:** End-to-end validation
+- **Performance Testing:** Load và stress testing
+
+### **Safety Quality**
+- **Safety Review:** All safety-critical code
+- **Risk Assessment:** Regular risk evaluations
+- **Compliance Validation:** Standards compliance
+- **Safety Testing:** Comprehensive safety tests
+
+### **Documentation Quality**
+- **Technical Documentation:** Complete API docs
+- **User Documentation:** Clear user guides
+- **Process Documentation:** Standard procedures
+- **Quality Records:** Audit trail maintenance
+
+---
+
+## 🚨 **QUALITY CONTROL CHECKPOINTS**
+
+### **Pre-Development**
+- [ ] Requirements validation
+- [ ] Design review
+- [ ] Safety assessment
+- [ ] Resource allocation
+
+### **During Development**
+- [ ] Code review completion
+- [ ] Unit test execution
+- [ ] Static analysis pass
+- [ ] Documentation update
+
+### **Pre-Release**
+- [ ] Integration testing
+- [ ] Performance validation
+- [ ] Safety validation
+- [ ] Documentation review
+
+### **Post-Release**
+- [ ] Monitoring và feedback
+- [ ] Issue tracking
+- [ ] Performance monitoring
+- [ ] Continuous improvement
+
+---
+
+## 📈 **QUALITY IMPROVEMENT INITIATIVES**
+
+### **Short-term (3 months)**
+- Implement automated testing
+- Enhance code review process
+- Improve documentation standards
+- Establish quality metrics
+
+### **Medium-term (6 months)**
+- Advanced static analysis
+- Performance optimization
+- Safety enhancement
+- Process automation
+
+### **Long-term (12 months)**
+- AI-powered quality analysis
+- Predictive quality monitoring
+- Advanced safety features
+- Industry best practices adoption
+
+---
+
+## 🔍 **QUALITY MONITORING**
+
+### **Key Performance Indicators**
+- **Code Quality:** Static analysis scores
+- **Test Coverage:** Unit test coverage percentage
+- **Build Success:** Build success rate
+- **Defect Rate:** Production defect rate
+- **Response Time:** System response times
+- **Uptime:** System availability
+
+### **Quality Reporting**
+- **Weekly:** Quality metrics review
+- **Monthly:** Quality assessment report
+- **Quarterly:** Quality improvement plan
+- **Annually:** Quality policy review
+
+---
+
+## 📋 **RESPONSIBILITIES**
+
+### **Development Team**
+- Follow coding standards
+- Complete code reviews
+- Write comprehensive tests
+- Maintain documentation
+
+### **QA Team**
+- Execute test procedures
+- Validate quality metrics
+- Report quality issues
+- Recommend improvements
+
+### **Management**
+- Support quality initiatives
+- Allocate resources
+- Review quality reports
+- Approve quality policies
+
+---
+
+## 🔄 **CONTINUOUS IMPROVEMENT**
+
+### **Quality Improvement Process**
+1. **Identify Opportunities:** Quality assessments
+2. **Analyze Root Causes:** Issue investigation
+3. **Implement Solutions:** Process improvements
+4. **Monitor Results:** Performance tracking
+5. **Standardize:** Best practices adoption
+
+### **Quality Tools**
+- **Static Analysis:** Clang-tidy, SonarQube
+- **Testing Frameworks:** Unit tests, integration tests
+- **Documentation:** Doxygen, Markdown
+- **Monitoring:** Performance monitoring, logging
+
+---
+
+**Changelog v1.0:**
+- ✅ Created quality policy document
+- ✅ Added quality objectives và metrics
+- ✅ Added quality management principles
+- ✅ Added quality assurance processes
+- ✅ Added quality control checkpoints
+- ✅ Added continuous improvement initiatives
+
+**🚨 Lưu ý:** Quality policy phải được review định kỳ và cập nhật theo yêu cầu thay đổi.

--- a/firmware_new/docs/01-QUALITY_POLICY/README.md
+++ b/firmware_new/docs/01-QUALITY_POLICY/README.md
@@ -1,0 +1,68 @@
+# 📜 01-QUALITY_POLICY (Chính Sách Chất Lượng)
+
+**Theo ISO 9001:2015 Section 5.2 - Quality Policy**
+
+---
+
+## 🎯 **MỤC ĐÍCH**
+
+Thư mục này chứa các **chính sách chất lượng** của dự án OHT-50 Firmware, bao gồm:
+- Chính sách bảo mật
+- Giấy phép sử dụng
+- Cam kết chất lượng
+- Chính sách tuân thủ
+
+---
+
+## 📄 **DANH SÁCH TÀI LIỆU**
+
+| **Mã** | **Tên tài liệu** | **Mô tả** | **Version** |
+|--------|------------------|-----------|-------------|
+| **QP-001** | Security_Policy.md | Chính sách bảo mật và vulnerability reporting | 1.0.1 |
+| **QP-002** | License.md | Giấy phép MIT và third-party licenses | 1.0.1 |
+| **QP-003** | Quality_Policy.md | Chính sách chất lượng theo ISO 9001:2015 | 1.0.0 |
+
+---
+
+## 🔐 **QP-001: Security Policy**
+
+**Nội dung:**
+- Supported versions
+- Security features (Auth, Validation, Audit)
+- Vulnerability reporting (private, 24h response)
+- Known security risks
+- Best practices cho production
+- Security audit checklist
+
+**Khi nào đọc:** Trước khi deploy production, khi có security concerns
+
+---
+
+## ⚖️ **QP-002: License**
+
+**Nội dung:**
+- MIT License full text
+- Third-party licenses (Unity, OpenSSL)
+- Usage permissions (CAN, MUST, CANNOT)
+- Warranty disclaimer
+- Safety warnings
+- Commercial support
+
+**Khi nào đọc:** Trước khi sử dụng firmware, khi phân phối
+
+---
+
+## ✅ **TUÂN THỦ**
+
+Các chính sách trong folder này **BẮT BUỘC** phải tuân thủ khi:
+- ✅ Deploy lên production
+- ✅ Phân phối firmware
+- ✅ Commercial use
+- ✅ Security incidents
+
+---
+
+**Version:** 1.0  
+**Last Updated:** 2025-10-07  
+**Maintained By:** Quality Team
+

--- a/firmware_new/docs/02-IMPLEMENTATION/01-QMS/README.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/01-QMS/README.md
@@ -1,0 +1,239 @@
+# Quality Management System (QMS) - OHT-50 Firmware
+
+**Phiên bản:** 2.0  
+**Ngày cập nhật:** 2025-01-28  
+**Mục tiêu:** Quality Management System documentation cho OHT-50 firmware
+
+---
+
+## 📋 **QMS Overview**
+
+### **Quality Management System:**
+- **ISO 9001:2015 Compliance:** Quality management standards
+- **Quality Policy:** Firmware quality objectives
+- **Quality Procedures:** Standardized processes
+- **Quality Metrics:** Performance indicators
+- **Continuous Improvement:** Quality enhancement processes
+
+---
+
+## 📚 **QMS Documentation**
+
+### **Quality Policies:**
+- [Quality Policy](01-policies/quality_policy.md) - Main quality policy document
+- [Quality Objectives](01-policies/quality_objectives.md) - Quality goals and targets
+- [Quality Manual](01-policies/quality_manual.md) - Comprehensive quality manual
+
+### **Quality Procedures:**
+- [Quality Procedures](02-procedures/) - Standardized quality procedures
+- [Quality Work Instructions](03-work-instructions/) - Detailed work instructions
+- [Quality Forms](04-forms/) - Quality management forms
+
+### **Quality Records:**
+- [Quality Records](05-records/) - Quality documentation records
+- [Quality Audits](06-audits/) - Quality audit reports
+- [Quality Reviews](07-reviews/) - Quality review reports
+
+---
+
+## 🎯 **Quality Objectives**
+
+### **Primary Objectives:**
+- **Code Quality:** 90%+ test coverage
+- **Safety Compliance:** 100% safety requirements compliance
+- **Performance:** Meet all performance targets
+- **Documentation:** 100% API and technical documentation
+- **Reliability:** 99.9% system uptime
+
+### **Quality Metrics:**
+- **Defect Rate:** < 1% in production
+- **Response Time:** < 100ms for critical operations
+- **Build Success Rate:** > 95%
+- **Code Review Coverage:** 100%
+- **Documentation Completeness:** 100%
+
+---
+
+## 🔧 **Quality Management Principles**
+
+### **1. Customer Focus:**
+- Understand end user requirements
+- Ensure safety and reliability
+- Provide comprehensive documentation
+- Responsive support and maintenance
+
+### **2. Leadership Commitment:**
+- Management commitment to quality
+- Resource allocation for quality activities
+- Regular quality reviews and assessments
+- Continuous improvement culture
+
+### **3. Process Approach:**
+- Standardized development processes
+- Clear procedures and guidelines
+- Process monitoring and measurement
+- Process improvement initiatives
+
+### **4. Continuous Improvement:**
+- Regular quality assessments
+- Root cause analysis
+- Corrective and preventive actions
+- Innovation and best practices adoption
+
+---
+
+## 📊 **Quality Assurance Processes**
+
+### **Development Quality:**
+- **Code Review:** Mandatory for all changes
+- **Static Analysis:** Automated code quality checks
+- **Unit Testing:** Minimum 90% coverage
+- **Integration Testing:** End-to-end validation
+- **Performance Testing:** Load and stress testing
+
+### **Safety Quality:**
+- **Safety Review:** All safety-critical code
+- **Risk Assessment:** Regular risk evaluations
+- **Compliance Validation:** Standards compliance
+- **Safety Testing:** Comprehensive safety tests
+
+### **Documentation Quality:**
+- **Technical Documentation:** Complete API docs
+- **User Documentation:** Clear user guides
+- **Process Documentation:** Standard procedures
+- **Quality Records:** Audit trail maintenance
+
+---
+
+## 🚨 **Quality Control Checkpoints**
+
+### **Pre-Development:**
+- [ ] Requirements validation
+- [ ] Design review
+- [ ] Safety assessment
+- [ ] Resource allocation
+
+### **During Development:**
+- [ ] Code review completion
+- [ ] Unit test execution
+- [ ] Static analysis pass
+- [ ] Documentation update
+
+### **Pre-Release:**
+- [ ] Integration testing
+- [ ] Performance validation
+- [ ] Safety validation
+- [ ] Documentation review
+
+### **Post-Release:**
+- [ ] Monitoring and feedback
+- [ ] Issue tracking
+- [ ] Performance monitoring
+- [ ] Continuous improvement
+
+---
+
+## 📈 **Quality Improvement Initiatives**
+
+### **Short-term (3 months):**
+- Implement automated testing
+- Enhance code review process
+- Improve documentation standards
+- Establish quality metrics
+
+### **Medium-term (6 months):**
+- Advanced static analysis
+- Performance optimization
+- Safety enhancement
+- Process automation
+
+### **Long-term (12 months):**
+- AI-powered quality analysis
+- Predictive quality monitoring
+- Advanced safety features
+- Industry best practices adoption
+
+---
+
+## 🔍 **Quality Monitoring**
+
+### **Key Performance Indicators:**
+- **Code Quality:** Static analysis scores
+- **Test Coverage:** Unit test coverage percentage
+- **Build Success:** Build success rate
+- **Defect Rate:** Production defect rate
+- **Response Time:** System response times
+- **Uptime:** System availability
+
+### **Quality Reporting:**
+- **Weekly:** Quality metrics review
+- **Monthly:** Quality assessment report
+- **Quarterly:** Quality improvement plan
+- **Annually:** Quality policy review
+
+---
+
+## 👥 **Responsibilities**
+
+### **Development Team:**
+- Follow coding standards
+- Complete code reviews
+- Write comprehensive tests
+- Maintain documentation
+
+### **QA Team:**
+- Execute test procedures
+- Validate quality metrics
+- Report quality issues
+- Recommend improvements
+
+### **Management:**
+- Support quality initiatives
+- Allocate resources
+- Review quality reports
+- Approve quality policies
+
+---
+
+## 🔄 **Continuous Improvement**
+
+### **Quality Improvement Process:**
+1. **Identify Opportunities:** Quality assessments
+2. **Analyze Root Causes:** Issue investigation
+3. **Implement Solutions:** Process improvements
+4. **Monitor Results:** Performance tracking
+5. **Standardize:** Best practices adoption
+
+### **Quality Tools:**
+- **Static Analysis:** Clang-tidy, SonarQube
+- **Testing Frameworks:** Unit tests, integration tests
+- **Documentation:** Doxygen, Markdown
+- **Monitoring:** Performance monitoring, logging
+
+---
+
+## 📚 **Related Documents**
+
+### **Firmware Documentation:**
+- [Firmware README](../README.md) - Main firmware documentation
+- [HAL Documentation](../02-HAL/) - Hardware Abstraction Layer
+- [Safety Documentation](../04-SAFETY/) - Safety systems
+- [Quality Documentation](../05-QUALITY/) - Quality assurance
+
+### **Project Documentation:**
+- [Project README](../../../README.md) - Main project documentation
+- [SLC Planning](../../../03-ARCHITECTURE/architecture/SLC_PLANNING_OHT-50.md) - System Life Cycle planning
+- [Requirements](../../../02-REQUIREMENTS/) - Project requirements
+
+---
+
+**Changelog v2.0:**
+- ✅ Updated QMS documentation structure
+- ✅ Added comprehensive quality objectives
+- ✅ Added quality management principles
+- ✅ Added quality assurance processes
+- ✅ Added quality control checkpoints
+- ✅ Added continuous improvement initiatives
+- ✅ Integrated with firmware documentation cleanup
+
+**🚨 Lưu ý:** QMS documentation đã được updated để reflect firmware documentation cleanup và integration với project structure.

--- a/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/README_IMPLEMENTED_MODULES.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/README_IMPLEMENTED_MODULES.md
@@ -1,0 +1,318 @@
+# IMPLEMENTED MODULES OVERVIEW - OHT-50 Master Module
+
+**Phiên bản:** v1.0.0  
+**Ngày tạo:** 2025-01-28  
+**Mục tiêu:** Tổng quan về các module đã implement trong OHT-50 Master Module firmware
+
+---
+
+## 📋 **TỔNG QUAN HIỆN TRẠNG**
+
+### **Trạng thái tổng thể:** ⚠️ **PARTIALLY IMPLEMENTED**
+- **RS485 HAL:** ✅ IMPLEMENTED (cơ bản)
+- **Module Discovery:** ✅ IMPLEMENTED (cơ bản)
+- **Module Management:** ✅ IMPLEMENTED (cơ bản)
+- **Build System:** ❌ FAILED (linker errors)
+- **Testing System:** ❌ FAILED (safety tests)
+
+---
+
+## 🎯 **CÁC MODULE ĐÃ IMPLEMENT**
+
+### **1. RS485 HAL Layer** ✅ **IMPLEMENTED (cơ bản)**
+
+**Mục tiêu:** Hardware Abstraction Layer cho RS485/Modbus RTU communication
+
+**Chức năng chính:**
+- ✅ RS485 serial communication
+- ✅ Modbus RTU protocol implementation
+- ✅ Thread-safe operations
+- ✅ Error handling và retry mechanism
+- ✅ Statistics collection
+
+**Trạng thái:**
+- ✅ Core functionality hoàn thiện
+- ✅ Thread-safe implementation
+- ✅ Basic error handling
+- ⚠️ Cần optimization và advanced features
+
+**Tài liệu:** [REQ_RS485_HAL_SPECIFICATION.md](./REQ_RS485_HAL_SPECIFICATION.md)
+
+---
+
+### **2. Module Discovery System** ✅ **IMPLEMENTED (cơ bản)**
+
+**Mục tiêu:** Tự động phát hiện và đăng ký các slave modules trên RS485 bus
+
+**Chức năng chính:**
+- ✅ Auto-discovery protocol
+- ✅ Module registry management
+- ✅ Health monitoring system
+- ✅ Event handling system
+- ✅ Hot-swap capability
+
+**Trạng thái:**
+- ✅ Core discovery functionality
+- ✅ Module registry management
+- ✅ Health monitoring system
+- ⚠️ Cần advanced health assessment
+
+**Tài liệu:** [REQ_MODULE_DISCOVERY_SPECIFICATION.md](./REQ_MODULE_DISCOVERY_SPECIFICATION.md)
+
+---
+
+### **3. Module Management System** ✅ **IMPLEMENTED (cơ bản)**
+
+**Mục tiêu:** Quản lý tổng thể tất cả slave modules trong hệ thống OHT-50
+
+**Chức năng chính:**
+- ✅ Module lifecycle management
+- ✅ Unified module interface
+- ✅ Module state management
+- ✅ Module coordination
+- ✅ Error handling và recovery
+
+**Trạng thái:**
+- ✅ Core module management functionality
+- ✅ Unified module interface
+- ✅ State management system
+- ⚠️ Cần advanced module coordination
+
+**Tài liệu:** [REQ_MODULE_MANAGEMENT_SPECIFICATION.md](./REQ_MODULE_MANAGEMENT_SPECIFICATION.md)
+
+---
+
+### **4. Build System** ❌ **FAILED (linker errors)**
+
+**Mục tiêu:** Reliable build system cho OHT-50 Master Module firmware
+
+**Chức năng chính:**
+- ✅ CMake build system setup
+- ✅ Cross-compilation support
+- ✅ Modular build configuration
+- ❌ Linker errors
+- ❌ Symbol resolution issues
+
+**Trạng thái:**
+- ✅ CMake build system setup
+- ✅ Basic compilation configuration
+- ❌ Linker errors cần khắc phục
+- ❌ Library dependency issues
+
+**Tài liệu:** [REQ_BUILD_STATUS_SPECIFICATION.md](./REQ_BUILD_STATUS_SPECIFICATION.md)
+
+---
+
+### **5. Testing System** ❌ **FAILED (safety tests)**
+
+**Mục tiêu:** Comprehensive testing framework cho OHT-50 Master Module firmware
+
+**Chức năng chính:**
+- ✅ Basic unit testing framework
+- ✅ Integration testing support
+- ✅ Mock framework
+- ❌ Safety test failures
+- ❌ Compliance issues
+
+**Trạng thái:**
+- ✅ Basic testing framework
+- ✅ Unit testing support
+- ❌ Safety test failures cần khắc phục
+- ❌ Test coverage gaps
+
+**Tài liệu:** [REQ_TESTING_SYSTEM_SPECIFICATION.md](./REQ_TESTING_SYSTEM_SPECIFICATION.md)
+
+---
+
+## 🔧 **KIẾN TRÚC TỔNG THỂ**
+
+### **System Architecture:**
+```
+┌─────────────────────────────────────┐
+│         Application Layer           │
+│     (API, UI, Control Logic)       │
+├─────────────────────────────────────┤
+│         Module Manager              │
+│     (Unified Module Interface)     │
+├─────────────────────────────────────┤
+│      Module Discovery               │
+│     (Auto-discovery System)        │
+├─────────────────────────────────────┤
+│      Communication Manager          │
+│     (RS485/Modbus Interface)       │
+├─────────────────────────────────────┤
+│         RS485 HAL Layer             │
+│     (Hardware Interface)           │
+├─────────────────────────────────────┤
+│         Build System                │
+│     (CMake, Cross-compilation)     │
+├─────────────────────────────────────┤
+│         Testing System              │
+│     (Unit, Integration, Safety)    │
+└─────────────────────────────────────┘
+```
+
+### **Module Interaction Flow:**
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant MM as Module Manager
+    participant MD as Module Discovery
+    participant CM as Comm Manager
+    participant HAL as RS485 HAL
+    
+    App->>MM: Module Operation Request
+    MM->>MD: Check Module Status
+    MD->>CM: Discover Modules
+    CM->>HAL: RS485 Communication
+    HAL-->>CM: Module Response
+    CM-->>MD: Discovery Results
+    MD-->>MM: Module Status
+    MM-->>App: Operation Complete
+```
+
+---
+
+## 📊 **METRICS VÀ KPI**
+
+### **Implementation Metrics:**
+- **Code Coverage:** ~70% (cần đạt >90%)
+- **Test Pass Rate:** ~60% (cần đạt 100%)
+- **Build Success Rate:** 0% (cần đạt 100%)
+- **Safety Compliance:** 0% (cần đạt 100%)
+- **Performance:** Đạt yêu cầu cơ bản
+
+### **Quality Metrics:**
+- **Bug Density:** Medium (cần giảm)
+- **Technical Debt:** High (cần giảm)
+- **Documentation:** Partial (cần hoàn thiện)
+- **Code Review:** Partial (cần tăng cường)
+- **Testing Coverage:** Partial (cần tăng cường)
+
+---
+
+## 🚨 **VẤN ĐỀ HIỆN TẠI**
+
+### **Critical Issues:**
+1. **Build System:** Linker errors cần khắc phục ngay
+2. **Testing System:** Safety test failures cần khắc phục
+3. **Code Quality:** Technical debt cần giảm
+4. **Documentation:** Cần hoàn thiện documentation
+5. **Testing Coverage:** Cần tăng cường test coverage
+
+### **High Priority Fixes:**
+1. **Fix linker errors** - Resolve build system issues
+2. **Fix safety tests** - Resolve safety test failures
+3. **Improve test coverage** - Increase test coverage
+4. **Complete documentation** - Finish documentation
+5. **Code review** - Increase code review coverage
+
+### **Medium Priority Improvements:**
+1. **Performance optimization** - Optimize performance
+2. **Advanced features** - Add advanced features
+3. **Monitoring** - Add advanced monitoring
+4. **Analytics** - Add analytics capabilities
+5. **Debugging tools** - Add debugging tools
+
+---
+
+## 🎯 **ROADMAP VÀ KẾ HOẠCH**
+
+### **Phase 1: Critical Fixes (1-2 weeks)**
+- [ ] Fix build system linker errors
+- [ ] Fix safety test failures
+- [ ] Improve test coverage
+- [ ] Complete basic documentation
+- [ ] Code review và cleanup
+
+### **Phase 2: Quality Improvement (2-4 weeks)**
+- [ ] Performance optimization
+- [ ] Advanced error handling
+- [ ] Advanced monitoring features
+- [ ] Comprehensive testing
+- [ ] Complete documentation
+
+### **Phase 3: Advanced Features (4-8 weeks)**
+- [ ] Advanced module coordination
+- [ ] Advanced safety features
+- [ ] Advanced analytics
+- [ ] Advanced debugging tools
+- [ ] Advanced monitoring
+
+### **Phase 4: Production Ready (8-12 weeks)**
+- [ ] Production deployment
+- [ ] Performance validation
+- [ ] Safety validation
+- [ ] Compliance validation
+- [ ] User acceptance testing
+
+---
+
+## 👥 **TEAM RESPONSIBILITIES**
+
+### **EMBED Team:**
+- **RS485 HAL Layer** - Hardware interface
+- **Build System** - Build configuration
+- **Platform Support** - Platform compatibility
+
+### **FW Team:**
+- **Module Discovery** - Auto-discovery system
+- **Module Management** - Module coordination
+- **Communication Manager** - RS485 communication
+
+### **QA Team:**
+- **Testing System** - Test framework
+- **Safety Testing** - Safety validation
+- **Quality Assurance** - Quality metrics
+
+### **DevOps Team:**
+- **Build System** - CI/CD pipeline
+- **Deployment** - Deployment automation
+- **Monitoring** - System monitoring
+
+---
+
+## 📚 **TÀI LIỆU LIÊN QUAN**
+
+### **Technical Specifications:**
+- [REQ_RS485_HAL_SPECIFICATION.md](./REQ_RS485_HAL_SPECIFICATION.md)
+- [REQ_MODULE_DISCOVERY_SPECIFICATION.md](./REQ_MODULE_DISCOVERY_SPECIFICATION.md)
+- [REQ_MODULE_MANAGEMENT_SPECIFICATION.md](./REQ_MODULE_MANAGEMENT_SPECIFICATION.md)
+- [REQ_BUILD_STATUS_SPECIFICATION.md](./REQ_BUILD_STATUS_SPECIFICATION.md)
+- [REQ_TESTING_SYSTEM_SPECIFICATION.md](./REQ_TESTING_SYSTEM_SPECIFICATION.md)
+
+### **Related Documents:**
+- [QA_QC_FIRMWARE_REPORT.md](../../05-QUALITY/01-qa-reports/QA_QC_FIRMWARE_REPORT.md)
+- [TEST_VALIDATION_REPORT.md](../../05-QUALITY/02-testing/TEST_VALIDATION_REPORT.md)
+- [SAFETY_CONFIGURATION_GUIDE.md](../../04-SAFETY/03-safety-configuration/SAFETY_CONFIGURATION_GUIDE.md)
+
+---
+
+## 🎯 **KẾT LUẬN**
+
+### **Điểm mạnh:**
+- ✅ Core functionality hoàn thiện cho 3 module chính
+- ✅ Thread-safe implementation
+- ✅ Modular architecture
+- ✅ Basic error handling
+- ✅ Event-driven design
+
+### **Cần cải thiện:**
+- ❌ Build system issues
+- ❌ Testing system issues
+- ⚠️ Performance optimization
+- ⚠️ Advanced features
+- ⚠️ Documentation completeness
+
+### **Khuyến nghị:**
+1. **Ưu tiên critical fixes** - Fix build và testing issues
+2. **Quality improvement** - Improve code quality và testing
+3. **Advanced features** - Add advanced features
+4. **Documentation** - Complete documentation
+5. **Production readiness** - Prepare for production deployment
+
+---
+
+**📅 Next Review:** Sau khi hoàn thành Phase 1  
+**👥 Responsible:** All Teams  
+**📊 Success Metrics:** 100% build success, 100% test pass rate, >90% coverage

--- a/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_BUILD_STATUS_SPECIFICATION.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_BUILD_STATUS_SPECIFICATION.md
@@ -1,0 +1,613 @@
+# BUILD SYSTEM SPECIFICATION - OHT-50 Master Module
+
+**Phiên bản:** v1.0.0  
+**Ngày tạo:** 2025-01-28  
+**Team:** DevOps Team  
+**Trạng thái:** ❌ FAILED (linker errors)  
+**Mục tiêu:** Định nghĩa chi tiết yêu cầu kỹ thuật và chức năng của Build System
+
+---
+
+## 🎯 **TỔNG QUAN**
+
+### **Mục tiêu:**
+- Cung cấp reliable build system cho OHT-50 Master Module firmware
+- Đảm bảo consistent build process across development environments
+- Hỗ trợ multiple build configurations và target platforms
+- Cung cấp automated testing và validation
+
+### **Phạm vi:**
+- CMake-based build system
+- Cross-compilation support
+- Automated testing integration
+- Build artifact management
+- Continuous Integration support
+
+---
+
+## 🔧 **KIẾN TRÚC KỸ THUẬT**
+
+### **1. Build System Architecture**
+
+#### **Build System Components:**
+```
+┌─────────────────────────────────────┐
+│         Build Configuration         │
+│     (CMakeLists.txt, Config)       │
+├─────────────────────────────────────┤
+│         CMake Build System          │
+│     (Cross-compilation, Linking)   │
+├─────────────────────────────────────┤
+│         Toolchain Support           │
+│     (GCC, Clang, ARM GCC)         │
+├─────────────────────────────────────┤
+│         Target Platform             │
+│     (Orange Pi 5B, RK3588)        │
+└─────────────────────────────────────┘
+```
+
+#### **Build Process Flow:**
+```mermaid
+graph TD
+    A[Source Code] --> B[CMake Configuration]
+    B --> C[Compilation]
+    C --> D[Linking]
+    D --> E[Binary Generation]
+    E --> F[Testing]
+    F --> G[Artifact Creation]
+    G --> H[Deployment]
+    
+    C --> I[Compilation Errors]
+    D --> J[Linking Errors]
+    F --> K[Test Failures]
+    
+    I --> L[Error Resolution]
+    J --> L
+    K --> L
+    L --> B
+```
+
+### **2. Build Configuration Structure**
+
+#### **2.1 CMake Configuration**
+```cmake
+# Main CMakeLists.txt Structure
+cmake_minimum_required(VERSION 3.16)
+project(OHT50_Firmware VERSION 1.0.0 LANGUAGES C)
+
+# Build Configuration
+set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Target Platform Configuration
+set(TARGET_PLATFORM "Orange Pi 5B")
+set(TARGET_ARCH "aarch64")
+set(TARGET_OS "Linux")
+
+# Compiler Configuration
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+
+# Build Options
+option(BUILD_TESTS "Build test suite" ON)
+option(BUILD_DOCS "Build documentation" OFF)
+option(ENABLE_DEBUG "Enable debug symbols" OFF)
+option(ENABLE_OPTIMIZATION "Enable optimization" ON)
+```
+
+#### **2.2 Directory Structure**
+```
+firmware_new/
+├── CMakeLists.txt              # Main build configuration
+├── src/
+│   ├── CMakeLists.txt          # Source build configuration
+│   ├── main.c                  # Main application entry
+│   ├── app/
+│   │   ├── CMakeLists.txt      # Application modules
+│   │   ├── api/                # API layer
+│   │   ├── core/               # Core functionality
+│   │   ├── managers/           # Module managers
+│   │   └── modules/            # Module handlers
+│   ├── hal/
+│   │   ├── CMakeLists.txt      # HAL layer
+│   │   ├── common/             # Common HAL functions
+│   │   ├── communication/      # Communication HAL
+│   │   ├── gpio/               # GPIO HAL
+│   │   ├── peripherals/        # Peripheral HAL
+│   │   ├── safety/             # Safety HAL
+│   │   └── storage/            # Storage HAL
+│   └── utils/
+│       └── CMakeLists.txt      # Utility functions
+├── build/                      # Build output directory
+├── tests/                      # Test suite
+├── docs/                       # Documentation
+└── scripts/                    # Build scripts
+```
+
+---
+
+## 📋 **YÊU CẦU CHỨC NĂNG**
+
+### **1. Build System Requirements**
+
+#### **1.1 Compilation Support**
+```cmake
+# Compilation Configuration
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS_DEBUG "-g -O0 -DDEBUG")
+set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+
+# Platform-specific Flags
+if(TARGET_PLATFORM STREQUAL "Orange Pi 5B")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=cortex-a76")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mtune=cortex-a76")
+endif()
+```
+
+#### **1.2 Linking Configuration**
+```cmake
+# Linking Configuration
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--strip-all")
+
+# Library Dependencies
+find_package(Threads REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+# System Libraries
+pkg_check_modules(SYSTEMD REQUIRED libsystemd)
+pkg_check_modules(JSON REQUIRED json-c)
+pkg_check_modules(UDEV REQUIRED libudev)
+```
+
+#### **Yêu cầu:**
+- ✅ **Cross-compilation:** Support ARM64 cross-compilation
+- ✅ **Optimization:** Support multiple optimization levels
+- ✅ **Debug Support:** Support debug symbols và debugging
+- ✅ **Library Linking:** Proper library linking
+- ✅ **Symbol Resolution:** Proper symbol resolution
+
+### **2. Module Build Configuration**
+
+#### **2.1 HAL Layer Build**
+```cmake
+# HAL Layer Configuration
+add_library(hal_common STATIC
+    src/hal/common/hal_common.c
+    src/hal/common/hal_common.h
+)
+
+add_library(hal_communication STATIC
+    src/hal/communication/hal_rs485.c
+    src/hal/communication/hal_network.c
+    src/hal/communication/hal_usb.c
+)
+
+add_library(hal_gpio STATIC
+    src/hal/gpio/hal_gpio.c
+    src/hal/gpio/hal_gpio.h
+)
+
+add_library(hal_peripherals STATIC
+    src/hal/peripherals/hal_led.c
+    src/hal/peripherals/hal_relay.c
+    src/hal/peripherals/hal_lidar.c
+)
+
+add_library(hal_safety STATIC
+    src/hal/safety/hal_estop.c
+    src/hal/safety/hal_estop.h
+)
+
+add_library(hal_storage STATIC
+    src/hal/storage/hal_config_persistence.c
+    src/hal/storage/hal_config_persistence.h
+)
+```
+
+#### **2.2 Application Layer Build**
+```cmake
+# Application Layer Configuration
+add_library(app_api STATIC
+    src/app/api/api_endpoints.c
+    src/app/api/api_manager.c
+    src/app/api/http_server_mock.c
+)
+
+add_library(app_core STATIC
+    src/app/core/control_loop.c
+    src/app/core/safety_monitor.c
+    src/app/core/system_controller.c
+    src/app/core/system_state_machine.c
+)
+
+add_library(app_managers STATIC
+    src/app/managers/communication_manager.c
+    src/app/managers/module_manager.c
+    src/app/managers/safety_manager.c
+    src/app/managers/telemetry_manager.c
+)
+
+add_library(app_modules STATIC
+    src/app/modules/dock_module_handler.c
+    src/app/modules/power_module_handler.c
+    src/app/modules/safety_module_handler.c
+    src/app/modules/travel_motor_module_handler.c
+    src/app/modules/module_registry.c
+)
+```
+
+#### **Yêu cầu:**
+- ✅ **Modular Build:** Support modular compilation
+- ✅ **Dependency Management:** Proper dependency resolution
+- ✅ **Static Linking:** Support static library linking
+- ✅ **Header Management:** Proper header file management
+- ✅ **Symbol Export:** Proper symbol export/import
+
+### **3. Testing Integration**
+
+#### **3.1 Test Configuration**
+```cmake
+# Testing Configuration
+if(BUILD_TESTS)
+    enable_testing()
+    
+    # Unit Tests
+    add_subdirectory(tests/unit)
+    
+    # Integration Tests
+    add_subdirectory(tests/integration)
+    
+    # System Tests
+    add_subdirectory(tests/system)
+    
+    # Mock Libraries
+    add_library(test_mocks STATIC
+        tests/mocks/mock_hal.c
+        tests/mocks/mock_communication.c
+        tests/mocks/mock_modules.c
+    )
+endif()
+```
+
+#### **3.2 Test Framework**
+```cmake
+# Test Framework Configuration
+find_package(GTest REQUIRED)
+find_package(CMocka REQUIRED)
+
+# Test Targets
+add_executable(unit_tests
+    tests/unit/test_hal.c
+    tests/unit/test_communication.c
+    tests/unit/test_modules.c
+)
+
+target_link_libraries(unit_tests
+    hal_common
+    hal_communication
+    app_managers
+    test_mocks
+    GTest::gtest
+    GTest::gtest_main
+    cmocka
+)
+```
+
+#### **Yêu cầu:**
+- ✅ **Unit Testing:** Support unit test compilation
+- ✅ **Integration Testing:** Support integration tests
+- ✅ **Mock Support:** Support mock libraries
+- ✅ **Test Execution:** Automated test execution
+- ✅ **Test Reporting:** Test result reporting
+
+### **4. Build Artifact Management**
+
+#### **4.1 Binary Generation**
+```cmake
+# Main Application Binary
+add_executable(oht50_firmware
+    src/main.c
+)
+
+target_link_libraries(oht50_firmware
+    hal_common
+    hal_communication
+    hal_gpio
+    hal_peripherals
+    hal_safety
+    hal_storage
+    app_api
+    app_core
+    app_managers
+    app_modules
+    Threads::Threads
+    ${SYSTEMD_LIBRARIES}
+    ${JSON_LIBRARIES}
+    ${UDEV_LIBRARIES}
+)
+
+# Binary Properties
+set_target_properties(oht50_firmware PROPERTIES
+    OUTPUT_NAME "oht50-firmware"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+```
+
+#### **4.2 Artifact Configuration**
+```cmake
+# Artifact Configuration
+set(ARTIFACT_NAME "oht50-firmware-${PROJECT_VERSION}")
+set(ARTIFACT_DIR "${CMAKE_BINARY_DIR}/artifacts")
+
+# Install Configuration
+install(TARGETS oht50_firmware
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+# Package Configuration
+set(CPACK_PACKAGE_NAME "OHT50-Firmware")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_DESCRIPTION "OHT-50 Master Module Firmware")
+set(CPACK_GENERATOR "DEB;RPM")
+```
+
+#### **Yêu cầu:**
+- ✅ **Binary Generation:** Generate executable binaries
+- ✅ **Library Generation:** Generate static libraries
+- ✅ **Installation:** Support installation process
+- ✅ **Packaging:** Support package generation
+- ✅ **Versioning:** Support version management
+
+---
+
+## 🔒 **YÊU CẦU AN TOÀN**
+
+### **1. Build Security**
+- ✅ **Code Signing:** Support code signing
+- ✅ **Integrity Checking:** Build integrity verification
+- ✅ **Dependency Validation:** Validate dependencies
+- ✅ **Security Scanning:** Security vulnerability scanning
+- ✅ **Audit Trail:** Build audit trail
+
+### **2. Build Reliability**
+- ✅ **Reproducible Builds:** Reproducible build process
+- ✅ **Build Validation:** Build result validation
+- ✅ **Error Handling:** Proper error handling
+- ✅ **Recovery Procedures:** Build failure recovery
+- ✅ **Backup Mechanisms:** Build artifact backup
+
+### **3. Build Consistency**
+- ✅ **Environment Consistency:** Consistent build environment
+- ✅ **Toolchain Consistency:** Consistent toolchain usage
+- ✅ **Configuration Consistency:** Consistent configuration
+- ✅ **Output Consistency:** Consistent build outputs
+- ✅ **Version Consistency:** Version consistency
+
+---
+
+## 📊 **YÊU CẦU HIỆU NĂNG**
+
+### **1. Build Performance**
+```cmake
+# Performance Configuration
+set(CMAKE_BUILD_PARALLEL_LEVEL 4)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe")
+
+# Incremental Build Support
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -MMD -MP")
+
+# Optimization Flags
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -flto")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -flto")
+```
+
+### **2. Build Time Requirements**
+- **Full Build:** < 5 minutes for clean build
+- **Incremental Build:** < 30 seconds for incremental build
+- **Test Compilation:** < 2 minutes for test compilation
+- **Linking:** < 30 seconds for linking
+- **Installation:** < 1 minute for installation
+
+### **3. Resource Requirements**
+- **Memory Usage:** < 2GB RAM during build
+- **Disk Space:** < 1GB temporary space
+- **CPU Usage:** Support parallel compilation
+- **Network Usage:** Minimal network usage
+- **Storage I/O:** Optimized I/O operations
+
+---
+
+## 🔧 **CONFIGURATION MANAGEMENT**
+
+### **1. Build Configuration**
+```cmake
+# Build Configuration Options
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option(BUILD_STATIC_LIBS "Build static libraries" ON)
+option(ENABLE_WARNINGS "Enable compiler warnings" ON)
+option(ENABLE_WERROR "Treat warnings as errors" ON)
+option(ENABLE_COVERAGE "Enable code coverage" OFF)
+option(ENABLE_SANITIZERS "Enable sanitizers" OFF)
+```
+
+### **2. Platform Configuration**
+```cmake
+# Platform Configuration
+set(SUPPORTED_PLATFORMS "Orange Pi 5B;Raspberry Pi 4;Generic ARM64")
+set(DEFAULT_PLATFORM "Orange Pi 5B")
+
+# Platform-specific Configuration
+if(TARGET_PLATFORM STREQUAL "Orange Pi 5B")
+    set(PLATFORM_DEFINES "${PLATFORM_DEFINES} -DTARGET_ORANGE_PI_5B")
+    set(PLATFORM_DEFINES "${PLATFORM_DEFINES} -DTARGET_RK3588")
+elseif(TARGET_PLATFORM STREQUAL "Raspberry Pi 4")
+    set(PLATFORM_DEFINES "${PLATFORM_DEFINES} -DTARGET_RASPBERRY_PI_4")
+    set(PLATFORM_DEFINES "${PLATFORM_DEFINES} -DTARGET_BCM2711")
+endif()
+```
+
+### **3. Toolchain Configuration**
+```cmake
+# Toolchain Configuration
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# Cross-compilation Toolchain
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+set(CMAKE_STRIP aarch64-linux-gnu-strip)
+set(CMAKE_AR aarch64-linux-gnu-ar)
+set(CMAKE_RANLIB aarch64-linux-gnu-ranlib)
+
+# Toolchain Path
+set(TOOLCHAIN_PATH "/usr/bin")
+set(CMAKE_FIND_ROOT_PATH "/usr/aarch64-linux-gnu")
+```
+
+---
+
+## 🧪 **TESTING REQUIREMENTS**
+
+### **1. Build Testing**
+- ✅ **Configuration Testing:** Test build configurations
+- ✅ **Dependency Testing:** Test dependency resolution
+- ✅ **Compilation Testing:** Test compilation process
+- ✅ **Linking Testing:** Test linking process
+- ✅ **Installation Testing:** Test installation process
+
+### **2. Integration Testing**
+- ✅ **Toolchain Integration:** Test toolchain integration
+- ✅ **Library Integration:** Test library integration
+- ✅ **Platform Integration:** Test platform integration
+- ✅ **System Integration:** Test system integration
+- ✅ **CI/CD Integration:** Test CI/CD integration
+
+### **3. Validation Testing**
+- ✅ **Binary Validation:** Validate generated binaries
+- ✅ **Symbol Validation:** Validate symbol resolution
+- ✅ **Dependency Validation:** Validate dependencies
+- ✅ **Performance Validation:** Validate build performance
+- ✅ **Security Validation:** Validate build security
+
+---
+
+## 📚 **DOCUMENTATION REQUIREMENTS**
+
+### **1. Build Documentation**
+- ✅ **Build Instructions:** Complete build instructions
+- ✅ **Configuration Guide:** Configuration guide
+- ✅ **Troubleshooting Guide:** Troubleshooting guide
+- ✅ **Platform Guide:** Platform-specific guide
+- ✅ **Toolchain Guide:** Toolchain setup guide
+
+### **2. API Documentation**
+- ✅ **Build API:** Build system API documentation
+- ✅ **Configuration API:** Configuration API documentation
+- ✅ **Target API:** Target platform API documentation
+- ✅ **Toolchain API:** Toolchain API documentation
+- ✅ **Testing API:** Testing API documentation
+
+### **3. Maintenance Documentation**
+- ✅ **Maintenance Procedures:** Maintenance procedures
+- ✅ **Update Procedures:** Update procedures
+- ✅ **Migration Guide:** Migration guide
+- ✅ **Version Guide:** Version management guide
+- ✅ **Support Guide:** Support procedures
+
+---
+
+## 🔄 **MAINTENANCE & SUPPORT**
+
+### **1. Version Management**
+- ✅ **Version Control:** Proper version control
+- ✅ **Backward Compatibility:** Maintain backward compatibility
+- ✅ **Migration Guide:** Provide migration guides
+- ✅ **Deprecation Policy:** Clear deprecation policy
+
+### **2. Support Requirements**
+- ✅ **Technical Support:** Technical support procedures
+- ✅ **Bug Reporting:** Bug reporting procedures
+- ✅ **Feature Requests:** Feature request procedures
+- ✅ **Documentation Updates:** Documentation update procedures
+
+---
+
+## 📋 **IMPLEMENTATION STATUS**
+
+### **✅ COMPLETED FEATURES:**
+- ✅ CMake build system setup
+- ✅ Basic compilation configuration
+- ✅ HAL layer build configuration
+- ✅ Application layer build configuration
+- ✅ Module build configuration
+- ✅ Basic testing integration
+- ✅ Cross-compilation support
+- ✅ Platform configuration
+- ✅ Toolchain configuration
+
+### **⚠️ PARTIALLY IMPLEMENTED:**
+- ⚠️ Advanced build optimization
+- ⚠️ Comprehensive testing
+- ⚠️ Advanced artifact management
+- ⚠️ Security features
+
+### **❌ NOT IMPLEMENTED:**
+- ❌ Advanced build analytics
+- ❌ Performance profiling
+- ❌ Advanced debugging tools
+- ❌ Comprehensive documentation
+
+---
+
+## 🚨 **CURRENT ISSUES**
+
+### **❌ LINKER ERRORS:**
+- ❌ **Symbol Resolution:** Missing symbol definitions
+- ❌ **Library Linking:** Library linking failures
+- ❌ **Dependency Resolution:** Dependency resolution issues
+- ❌ **Cross-compilation:** Cross-compilation issues
+- ❌ **Platform Compatibility:** Platform compatibility issues
+
+### **🔧 REQUIRED FIXES:**
+1. **Symbol Resolution:** Fix missing symbol definitions
+2. **Library Dependencies:** Resolve library dependencies
+3. **Cross-compilation:** Fix cross-compilation issues
+4. **Platform Support:** Fix platform compatibility
+5. **Build Configuration:** Fix build configuration issues
+
+---
+
+## 🎯 **KẾT LUẬN**
+
+### **Trạng thái hiện tại:** ❌ **FAILED (linker errors)**
+
+**Điểm mạnh:**
+- ✅ CMake build system setup
+- ✅ Basic compilation configuration
+- ✅ Modular build structure
+- ✅ Cross-compilation support
+- ✅ Platform configuration
+
+**Cần khắc phục:**
+- ❌ Linker errors
+- ❌ Symbol resolution issues
+- ❌ Library dependency issues
+- ❌ Cross-compilation issues
+- ❌ Platform compatibility issues
+
+**Khuyến nghị:**
+1. **Ưu tiên linker errors** - Fix all linker errors
+2. **Dependency resolution** - Resolve library dependencies
+3. **Cross-compilation** - Fix cross-compilation issues
+4. **Testing** - Complete build testing
+
+---
+
+**📅 Next Review:** Sau khi khắc phục linker errors  
+**👥 Responsible:** DevOps Team  
+**📊 Success Metrics:** 100% build success, 0 linker errors, < 5min build time

--- a/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_MODULE_DISCOVERY_SPECIFICATION.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_MODULE_DISCOVERY_SPECIFICATION.md
@@ -1,0 +1,459 @@
+# MODULE DISCOVERY SYSTEM SPECIFICATION - OHT-50 Master Module
+
+**Phiên bản:** v1.0.0  
+**Ngày tạo:** 2025-01-28  
+**Team:** FW Team  
+**Trạng thái:** ✅ IMPLEMENTED (cơ bản)  
+**Mục tiêu:** Định nghĩa chi tiết yêu cầu kỹ thuật và chức năng của Module Discovery system
+
+---
+
+## 🎯 **TỔNG QUAN**
+
+### **Mục tiêu:**
+- Tự động phát hiện và đăng ký các slave modules trên RS485 bus
+- Hỗ trợ hot-swap capability cho modules
+- Cung cấp real-time module status monitoring
+- Đảm bảo reliable module identification và registration
+
+### **Phạm vi:**
+- Auto-discovery protocol implementation
+- Module registry management
+- Health monitoring và status tracking
+- Event handling và notification system
+
+---
+
+## 🔧 **KIẾN TRÚC KỸ THUẬT**
+
+### **1. Discovery Architecture**
+
+#### **System Components:**
+```
+┌─────────────────────────────────────┐
+│         Module Manager              │
+│     (Discovery Coordinator)         │
+├─────────────────────────────────────┤
+│         Module Registry             │
+│     (Module Database)              │
+├─────────────────────────────────────┤
+│      Communication Manager          │
+│     (RS485/Modbus Interface)       │
+├─────────────────────────────────────┤
+│         RS485 HAL Layer             │
+│     (Hardware Interface)           │
+└─────────────────────────────────────┘
+```
+
+#### **Discovery Flow:**
+```mermaid
+sequenceDiagram
+    participant MM as Module Manager
+    participant MR as Module Registry
+    participant CM as Comm Manager
+    participant HAL as RS485 HAL
+    
+    MM->>CM: Start Discovery Scan
+    loop Address Range (0x01-0x20)
+        CM->>HAL: Read Module Type (0x00F7)
+        HAL-->>CM: Module Type Response
+        CM->>HAL: Read Version (0x00F8-0x00FF)
+        HAL-->>CM: Version Response
+        CM->>MR: Register Module
+        MR-->>CM: Registration Confirmed
+        CM-->>MM: Module Discovered
+    end
+    MM->>MR: Get Discovery Results
+    MR-->>MM: Module List
+```
+
+### **2. Module Identification Protocol**
+
+#### **2.1 Modbus Register Map (Standard)**
+```c
+// System Identification Registers (0x00F0-0x00FF)
+#define MODULE_REG_DEVICE_ID             0x00F0  // Device ID
+#define MODULE_REG_MODULE_TYPE           0x00F7  // Module Type
+#define MODULE_REG_FIRMWARE_VERSION      0x00F8  // Firmware Version
+#define MODULE_REG_HARDWARE_VERSION      0x00F9  // Hardware Version
+#define MODULE_REG_SERIAL_NUMBER         0x00FA  // Serial Number
+#define MODULE_REG_BUILD_DATE            0x00FB  // Build Date
+#define MODULE_REG_CHECKSUM              0x00FF  // Register Checksum
+```
+
+#### **2.2 Module Type Definitions**
+```c
+// Module Type Enumeration
+typedef enum {
+    MODULE_TYPE_UNKNOWN = 0x0000,
+    MODULE_TYPE_POWER = 0x0002,              // Power Management Module
+    MODULE_TYPE_SAFETY = 0x0003,             // Safety & E-Stop Module
+    MODULE_TYPE_TRAVEL_MOTOR = 0x0004,       // Travel Motor Control Module
+    MODULE_TYPE_DOCK = 0x0005,               // Docking & Location Module
+    MODULE_TYPE_LIFTER_MOTOR = 0x0006,       // Lifter Motor Module (Optional)
+    MODULE_TYPE_CARGO_DOOR = 0x0007,         // Cargo Door Module (Optional)
+    MODULE_TYPE_SAFETY_EXTENDED = 0x0008,    // Extended Safety Module (Optional)
+    MODULE_TYPE_RFID_READER = 0x0009,        // RFID Reader Module (Plug-and-Play)
+    MODULE_TYPE_CUSTOM_START = 0x000C,       // Custom Modules Start
+    MODULE_TYPE_MAX = 0x00FF
+} module_type_t;
+```
+
+---
+
+## 📋 **YÊU CẦU CHỨC NĂNG**
+
+### **1. Auto-Discovery Protocol**
+
+#### **1.1 Discovery Algorithm**
+```c
+// Discovery Configuration
+typedef struct {
+    uint8_t start_address;           // Start address (default: 0x01)
+    uint8_t end_address;             // End address (default: 0x20)
+    uint32_t timeout_ms;             // Per-module timeout (default: 1000ms)
+    uint32_t retry_count;            // Retry attempts (default: 3)
+    uint32_t discovery_interval_ms;  // Discovery interval (default: 5000ms)
+    bool auto_discovery_enabled;     // Auto-discovery enabled
+    bool hot_swap_enabled;           // Hot-swap capability
+} discovery_config_t;
+```
+
+#### **1.2 Discovery Process**
+```c
+// Discovery Process Steps
+1. Initialize discovery scan
+2. Scan address range (0x01-0x20)
+3. For each address:
+   a. Send Modbus read request (0x00F7)
+   b. Validate module type response
+   c. Read version information (0x00F8-0x00FF)
+   d. Register module in registry
+   e. Trigger discovery event
+4. Update discovery statistics
+5. Schedule next discovery cycle
+```
+
+#### **Yêu cầu:**
+- ✅ **Address Scanning:** Scan 0x01-0x20 address range
+- ✅ **Module Type Detection:** Read và validate module type
+- ✅ **Version Reading:** Read firmware version information
+- ✅ **Capability Detection:** Read module capabilities
+- ✅ **Registration:** Auto-register discovered modules
+
+### **2. Module Registry Management**
+
+#### **2.1 Registry Structure**
+```c
+// Module Information Structure
+typedef struct {
+    uint8_t address;                 // Modbus/RS485 address
+    module_type_t type;              // Module type
+    char name[32];                   // Friendly name
+    char version[16];                // Firmware version
+    char serial_number[32];          // Serial number
+    module_status_t status;          // Online/Offline status
+    uint64_t last_seen_ms;           // Last seen timestamp
+    uint32_t capabilities;           // Module capabilities bitmap
+    uint32_t config_flags;           // Configuration flags
+    uint8_t health_percentage;       // Health percentage (0-100)
+} module_info_t;
+```
+
+#### **2.2 Registry Operations**
+```c
+// Registry Management Functions
+int registry_init(void);
+int registry_add_or_update(const module_info_t *info);
+int registry_mark_online(uint8_t address, module_type_t type, const char *version);
+int registry_mark_offline(uint8_t address);
+int registry_get(uint8_t address, module_info_t *out);
+int registry_get_all(module_info_t *out_array, size_t max_items, size_t *actual_count);
+size_t registry_count_online(void);
+bool registry_all_mandatory_online(void);
+```
+
+#### **Yêu cầu:**
+- ✅ **Module Registration:** Add/update module information
+- ✅ **Status Tracking:** Track online/offline status
+- ✅ **Health Monitoring:** Monitor module health
+- ✅ **Capability Management:** Track module capabilities
+- ✅ **Event Notification:** Notify on status changes
+
+### **3. Health Monitoring System**
+
+#### **3.1 Health Check Protocol**
+```c
+// Health Check Configuration
+typedef struct {
+    uint32_t health_check_interval_ms;   // Health check interval
+    uint32_t health_check_timeout_ms;    // Health check timeout
+    uint32_t offline_timeout_ms;         // Offline timeout
+    uint8_t health_threshold;            // Health threshold percentage
+    bool auto_health_check_enabled;      // Auto health check enabled
+} health_check_config_t;
+```
+
+#### **3.2 Health Assessment**
+```c
+// Health Assessment Criteria
+typedef enum {
+    MODULE_HEALTH_UNKNOWN = 0,
+    MODULE_HEALTH_EXCELLENT,       // 100% healthy
+    MODULE_HEALTH_GOOD,            // 80-99% healthy
+    MODULE_HEALTH_FAIR,            // 60-79% healthy
+    MODULE_HEALTH_POOR,            // 40-59% healthy
+    MODULE_HEALTH_CRITICAL,        // 20-39% healthy
+    MODULE_HEALTH_FAILED           // 0-19% healthy
+} module_health_t;
+```
+
+#### **Yêu cầu:**
+- ✅ **Periodic Health Checks:** Regular health monitoring
+- ✅ **Response Time Monitoring:** Track response times
+- ✅ **Error Rate Tracking:** Monitor error rates
+- ✅ **Health Assessment:** Calculate health percentage
+- ✅ **Health Thresholds:** Configurable health thresholds
+
+### **4. Event Handling System**
+
+#### **4.1 Module Events**
+```c
+// Module Event Types
+typedef enum {
+    MODULE_EVENT_NONE = 0,
+    MODULE_EVENT_DISCOVERED,       // New module discovered
+    MODULE_EVENT_REGISTERED,       // Module registered successfully
+    MODULE_EVENT_ONLINE,           // Module came online
+    MODULE_EVENT_OFFLINE,          // Module went offline
+    MODULE_EVENT_ERROR,            // Module error detected
+    MODULE_EVENT_WARNING,          // Module warning detected
+    MODULE_EVENT_HEALTH_CHANGE,    // Module health changed
+    MODULE_EVENT_CONFIG_CHANGE,    // Module configuration changed
+    MODULE_EVENT_UPDATED,          // Module updated
+    MODULE_EVENT_TIMEOUT,          // Module timeout
+    MODULE_EVENT_MAX
+} module_event_t;
+```
+
+#### **4.2 Event Callback System**
+```c
+// Event Callback Function
+typedef void (*module_event_callback_t)(module_event_t event, uint8_t module_id, const void *data);
+
+// Event Registration
+hal_status_t module_manager_set_callback(module_event_callback_t callback);
+```
+
+#### **Yêu cầu:**
+- ✅ **Event Detection:** Detect module events
+- ✅ **Event Notification:** Notify registered callbacks
+- ✅ **Event Logging:** Log all module events
+- ✅ **Event Filtering:** Filter events by type
+- ✅ **Event History:** Maintain event history
+
+---
+
+## 🔒 **YÊU CẦU AN TOÀN**
+
+### **1. Thread Safety**
+- ✅ **Mutex Protection:** All registry operations protected
+- ✅ **Atomic Updates:** Atomic module status updates
+- ✅ **Deadlock Prevention:** Proper mutex ordering
+- ✅ **Resource Management:** Proper resource cleanup
+
+### **2. Error Recovery**
+- ✅ **Graceful Degradation:** Continue operation on errors
+- ✅ **Automatic Recovery:** Self-healing mechanisms
+- ✅ **Error Isolation:** Prevent error propagation
+- ✅ **Safe Defaults:** Safe default values
+
+### **3. Data Integrity**
+- ✅ **Data Validation:** Validate all module data
+- ✅ **Consistency Checking:** Ensure data consistency
+- ✅ **Backup Mechanisms:** Backup critical data
+- ✅ **Recovery Procedures:** Data recovery procedures
+
+---
+
+## 📊 **YÊU CẦU HIỆU NĂNG**
+
+### **1. Discovery Performance**
+```c
+// Performance Requirements
+#define DISCOVERY_MAX_ADDRESSES       32      // Maximum addresses to scan
+#define DISCOVERY_TIMEOUT_MS          1000    // Per-module timeout
+#define DISCOVERY_RETRY_COUNT         3       // Retry attempts
+#define DISCOVERY_INTERVAL_MS         5000    // Discovery interval
+#define HEALTH_CHECK_INTERVAL_MS      10000   // Health check interval
+```
+
+### **2. Response Time Requirements**
+- **Discovery Scan:** < 5 seconds for full scan
+- **Module Registration:** < 100ms per module
+- **Health Check:** < 500ms per module
+- **Event Notification:** < 10ms event delivery
+
+### **3. Reliability Requirements**
+- **Discovery Accuracy:** 99.9% accurate module detection
+- **False Positive Rate:** < 0.1% false positives
+- **False Negative Rate:** < 0.1% false negatives
+- **Uptime:** 99.9% system availability
+
+---
+
+## 🔧 **CONFIGURATION MANAGEMENT**
+
+### **1. Discovery Configuration**
+```c
+// Discovery Configuration Structure
+typedef struct {
+    uint8_t start_address;           // Start address
+    uint8_t end_address;             // End address
+    uint32_t timeout_ms;             // Timeout per module
+    uint32_t retry_count;            // Retry count
+    uint32_t discovery_interval_ms;  // Discovery interval
+    bool auto_discovery_enabled;     // Auto-discovery enabled
+    bool hot_swap_enabled;           // Hot-swap enabled
+    uint32_t health_check_interval_ms; // Health check interval
+    uint32_t offline_timeout_ms;     // Offline timeout
+} discovery_config_t;
+```
+
+### **2. Module Configuration**
+```c
+// Module Configuration Structure
+typedef struct {
+    uint8_t module_id;               // Module ID
+    uint32_t discovery_timeout_ms;   // Discovery timeout
+    uint32_t health_check_interval_ms; // Health check interval
+    uint32_t response_timeout_ms;    // Response timeout
+    uint32_t retry_count;            // Retry count
+    uint32_t config_flags;           // Configuration flags
+} module_config_t;
+```
+
+### **3. Configuration Persistence**
+- ✅ **Configuration Storage:** Persistent configuration storage
+- ✅ **Configuration Loading:** Load configuration on startup
+- ✅ **Configuration Validation:** Validate configuration data
+- ✅ **Configuration Backup:** Backup configuration data
+
+---
+
+## 🧪 **TESTING REQUIREMENTS**
+
+### **1. Unit Testing**
+- ✅ **Discovery Algorithm:** Test discovery algorithm
+- ✅ **Registry Operations:** Test registry operations
+- ✅ **Health Monitoring:** Test health monitoring
+- ✅ **Event Handling:** Test event handling
+
+### **2. Integration Testing**
+- ✅ **Hardware Integration:** Test with actual modules
+- ✅ **Protocol Testing:** Test Modbus protocol
+- ✅ **Multi-module Testing:** Test with multiple modules
+- ✅ **Stress Testing:** Test under load conditions
+
+### **3. Validation Testing**
+- ✅ **Discovery Accuracy:** Test discovery accuracy
+- ✅ **Performance Testing:** Test performance requirements
+- ✅ **Reliability Testing:** Test long-term reliability
+- ✅ **Error Handling:** Test error conditions
+
+---
+
+## 📚 **DOCUMENTATION REQUIREMENTS**
+
+### **1. API Documentation**
+- ✅ **Function Documentation:** Complete function documentation
+- ✅ **Parameter Documentation:** Parameter descriptions
+- ✅ **Return Value Documentation:** Return value descriptions
+- ✅ **Error Code Documentation:** Error code descriptions
+
+### **2. Usage Examples**
+- ✅ **Basic Usage:** Basic usage examples
+- ✅ **Advanced Usage:** Advanced usage examples
+- ✅ **Error Handling:** Error handling examples
+- ✅ **Best Practices:** Best practices documentation
+
+### **3. Troubleshooting Guide**
+- ✅ **Common Issues:** Common issues và solutions
+- ✅ **Debug Procedures:** Debug procedures
+- ✅ **Performance Tuning:** Performance tuning guide
+- ✅ **Maintenance Procedures:** Maintenance procedures
+
+---
+
+## 🔄 **MAINTENANCE & SUPPORT**
+
+### **1. Version Management**
+- ✅ **Version Control:** Proper version control
+- ✅ **Backward Compatibility:** Maintain backward compatibility
+- ✅ **Migration Guide:** Provide migration guides
+- ✅ **Deprecation Policy:** Clear deprecation policy
+
+### **2. Support Requirements**
+- ✅ **Technical Support:** Technical support procedures
+- ✅ **Bug Reporting:** Bug reporting procedures
+- ✅ **Feature Requests:** Feature request procedures
+- ✅ **Documentation Updates:** Documentation update procedures
+
+---
+
+## 📋 **IMPLEMENTATION STATUS**
+
+### **✅ COMPLETED FEATURES:**
+- ✅ Auto-discovery algorithm implementation
+- ✅ Module registry management
+- ✅ Health monitoring system
+- ✅ Event handling system
+- ✅ Thread-safe operations
+- ✅ Configuration management
+- ✅ Error handling và recovery
+- ✅ Statistics collection
+- ✅ Module type detection
+- ✅ Version reading
+
+### **⚠️ PARTIALLY IMPLEMENTED:**
+- ⚠️ Advanced health assessment
+- ⚠️ Performance optimization
+- ⚠️ Comprehensive testing
+- ⚠️ Advanced monitoring
+
+### **❌ NOT IMPLEMENTED:**
+- ❌ Advanced analytics
+- ❌ Performance profiling
+- ❌ Advanced debugging tools
+- ❌ Comprehensive documentation
+
+---
+
+## 🎯 **KẾT LUẬN**
+
+### **Trạng thái hiện tại:** ✅ **IMPLEMENTED (cơ bản)**
+
+**Điểm mạnh:**
+- ✅ Core discovery functionality hoàn thiện
+- ✅ Module registry management
+- ✅ Health monitoring system
+- ✅ Event handling system
+- ✅ Thread-safe implementation
+
+**Cần cải thiện:**
+- ⚠️ Advanced health assessment
+- ⚠️ Performance optimization
+- ⚠️ Comprehensive testing
+- ⚠️ Advanced monitoring
+
+**Khuyến nghị:**
+1. **Ưu tiên testing** - Complete comprehensive testing
+2. **Performance optimization** - Optimize discovery performance
+3. **Advanced monitoring** - Add advanced monitoring features
+4. **Documentation** - Complete API documentation
+
+---
+
+**📅 Next Review:** Sau khi hoàn thành testing phase  
+**👥 Responsible:** FW Team  
+**📊 Success Metrics:** 100% test coverage, < 5s discovery time, 99.9% accuracy

--- a/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_MODULE_MANAGEMENT_SPECIFICATION.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_MODULE_MANAGEMENT_SPECIFICATION.md
@@ -1,0 +1,484 @@
+# MODULE MANAGEMENT SYSTEM SPECIFICATION - OHT-50 Master Module
+
+**Phiên bản:** v1.0.0  
+**Ngày tạo:** 2025-01-28  
+**Team:** FW Team  
+**Trạng thái:** ✅ IMPLEMENTED (cơ bản)  
+**Mục tiêu:** Định nghĩa chi tiết yêu cầu kỹ thuật và chức năng của Module Management system
+
+---
+
+## 🎯 **TỔNG QUAN**
+
+### **Mục tiêu:**
+- Quản lý tổng thể tất cả slave modules trong hệ thống OHT-50
+- Cung cấp unified interface cho module operations
+- Đảm bảo reliable module communication và control
+- Hỗ trợ module lifecycle management
+
+### **Phạm vi:**
+- Module lifecycle management
+- Unified module interface
+- Module coordination và synchronization
+- Module state management
+- Module communication management
+
+---
+
+## 🔧 **KIẾN TRÚC KỸ THUẬT**
+
+### **1. Module Management Architecture**
+
+#### **System Components:**
+```
+┌─────────────────────────────────────┐
+│         Application Layer           │
+│     (API, UI, Control Logic)       │
+├─────────────────────────────────────┤
+│         Module Manager              │
+│     (Unified Module Interface)     │
+├─────────────────────────────────────┤
+│      Module Handlers                │
+│  ┌─────────┬─────────┬─────────┐   │
+│  │ Power   │ Safety  │ Motor   │   │
+│  │ Module  │ Module  │ Module  │   │
+│  └─────────┴─────────┴─────────┘   │
+├─────────────────────────────────────┤
+│      Communication Manager          │
+│     (RS485/Modbus Interface)       │
+├─────────────────────────────────────┤
+│         RS485 HAL Layer             │
+│     (Hardware Interface)           │
+└─────────────────────────────────────┘
+```
+
+#### **Module Management Flow:**
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant MM as Module Manager
+    participant MH as Module Handler
+    participant CM as Comm Manager
+    participant HAL as RS485 HAL
+    
+    App->>MM: Module Operation Request
+    MM->>MH: Route to Specific Handler
+    MH->>CM: Modbus Command
+    CM->>HAL: RS485 Transmission
+    HAL-->>CM: Response
+    CM-->>MH: Modbus Response
+    MH-->>MM: Operation Result
+    MM-->>App: Operation Complete
+```
+
+### **2. Module Handler Architecture**
+
+#### **2.1 Module Handler Types**
+```c
+// Module Handler Types
+typedef enum {
+    MODULE_HANDLER_POWER = 0,        // Power Module Handler
+    MODULE_HANDLER_SAFETY,           // Safety Module Handler
+    MODULE_HANDLER_TRAVEL_MOTOR,     // Travel Motor Handler
+    MODULE_HANDLER_DOCK,             // Dock Module Handler
+    MODULE_HANDLER_LIFTER_MOTOR,     // Lifter Motor Handler
+    MODULE_HANDLER_CARGO_DOOR,       // Cargo Door Handler
+    MODULE_HANDLER_SAFETY_EXTENDED,  // Extended Safety Handler
+    MODULE_HANDLER_RFID_READER,      // RFID Reader Handler
+    MODULE_HANDLER_CUSTOM,           // Custom Module Handler
+    MODULE_HANDLER_MAX
+} module_handler_type_t;
+```
+
+#### **2.2 Module Handler Interface**
+```c
+// Module Handler Interface
+typedef struct {
+    module_handler_type_t type;      // Handler type
+    uint8_t module_id;               // Module ID
+    bool initialized;                // Initialization status
+    bool enabled;                    // Enable status
+    uint64_t last_update_time;       // Last update timestamp
+    
+    // Handler functions
+    hal_status_t (*init)(void *config);
+    hal_status_t (*deinit)(void);
+    hal_status_t (*update)(void);
+    hal_status_t (*get_status)(void *status);
+    hal_status_t (*get_data)(void *data);
+    hal_status_t (*set_config)(void *config);
+    hal_status_t (*get_config)(void *config);
+    hal_status_t (*reset)(void);
+    hal_status_t (*self_test)(void);
+} module_handler_t;
+```
+
+---
+
+## 📋 **YÊU CẦU CHỨC NĂNG**
+
+### **1. Module Lifecycle Management**
+
+#### **1.1 Module Initialization**
+```c
+// Module Initialization Process
+typedef struct {
+    uint8_t module_id;               // Module ID
+    module_type_t module_type;       // Module type
+    module_config_t config;          // Module configuration
+    bool auto_initialize;            // Auto-initialize on discovery
+    uint32_t init_timeout_ms;        // Initialization timeout
+    uint32_t retry_count;            // Retry count
+} module_init_config_t;
+```
+
+#### **1.2 Module Lifecycle States**
+```c
+// Module Lifecycle States
+typedef enum {
+    MODULE_STATE_UNKNOWN = 0,
+    MODULE_STATE_DISCOVERED,         // Module discovered
+    MODULE_STATE_INITIALIZING,       // Module initializing
+    MODULE_STATE_INITIALIZED,        // Module initialized
+    MODULE_STATE_ENABLED,            // Module enabled
+    MODULE_STATE_DISABLED,           // Module disabled
+    MODULE_STATE_ERROR,              // Module in error
+    MODULE_STATE_FAULT,              // Module fault
+    MODULE_STATE_OFFLINE,            // Module offline
+    MODULE_STATE_MAINTENANCE         // Module in maintenance
+} module_state_t;
+```
+
+#### **Yêu cầu:**
+- ✅ **Auto-initialization:** Auto-initialize discovered modules
+- ✅ **State Management:** Track module lifecycle states
+- ✅ **Error Recovery:** Automatic error recovery
+- ✅ **Configuration Management:** Load/save module configurations
+- ✅ **Health Monitoring:** Monitor module health
+
+### **2. Unified Module Interface**
+
+#### **2.1 Common Module Operations**
+```c
+// Common Module Operations
+hal_status_t module_manager_init(void);
+hal_status_t module_manager_deinit(void);
+hal_status_t module_manager_start(void);
+hal_status_t module_manager_stop(void);
+
+// Module Control
+hal_status_t module_manager_enable_module(uint8_t module_id);
+hal_status_t module_manager_disable_module(uint8_t module_id);
+hal_status_t module_manager_reset_module(uint8_t module_id);
+hal_status_t module_manager_self_test_module(uint8_t module_id);
+
+// Module Information
+hal_status_t module_manager_get_module_info(uint8_t module_id, module_info_t *info);
+hal_status_t module_manager_get_module_status(uint8_t module_id, module_status_info_t *status);
+hal_status_t module_manager_get_module_data(uint8_t module_id, void *data);
+hal_status_t module_manager_set_module_config(uint8_t module_id, void *config);
+hal_status_t module_manager_get_module_config(uint8_t module_id, void *config);
+```
+
+#### **2.2 Module-specific Operations**
+```c
+// Power Module Operations
+hal_status_t power_module_get_battery_status(battery_status_t *status);
+hal_status_t power_module_set_charging_config(charging_config_t *config);
+hal_status_t power_module_control_outputs(output_control_t *control);
+
+// Safety Module Operations
+hal_status_t safety_module_get_safety_status(safety_status_t *status);
+hal_status_t safety_module_set_safety_zones(safety_zones_t *zones);
+hal_status_t safety_module_trigger_emergency_stop(void);
+
+// Motor Module Operations
+hal_status_t motor_module_set_speed(uint8_t motor_id, int16_t speed);
+hal_status_t motor_module_set_position(uint8_t motor_id, uint16_t position);
+hal_status_t motor_module_emergency_stop(uint8_t motor_id);
+
+// Dock Module Operations
+hal_status_t dock_module_start_docking(uint16_t target_position);
+hal_status_t dock_module_stop_docking(void);
+hal_status_t dock_module_get_dock_status(dock_status_t *status);
+```
+
+#### **Yêu cầu:**
+- ✅ **Unified Interface:** Common interface for all modules
+- ✅ **Type-specific Operations:** Module-specific operations
+- ✅ **Error Handling:** Consistent error handling
+- ✅ **Status Reporting:** Unified status reporting
+- ✅ **Configuration Management:** Unified configuration management
+
+### **3. Module Coordination & Synchronization**
+
+#### **3.1 Module Coordination**
+```c
+// Module Coordination Configuration
+typedef struct {
+    bool enable_coordination;        // Enable module coordination
+    uint32_t coordination_timeout_ms; // Coordination timeout
+    uint8_t priority_level;          // Module priority level
+    bool enable_synchronization;     // Enable synchronization
+    uint32_t sync_interval_ms;       // Synchronization interval
+} module_coordination_config_t;
+```
+
+#### **3.2 Module Synchronization**
+```c
+// Module Synchronization
+hal_status_t module_manager_synchronize_modules(void);
+hal_status_t module_manager_coordinate_operation(module_operation_t *operation);
+hal_status_t module_manager_wait_for_modules(uint8_t *module_ids, uint32_t count, uint32_t timeout_ms);
+hal_status_t module_manager_check_module_dependencies(uint8_t module_id, bool *dependencies_met);
+```
+
+#### **Yêu cầu:**
+- ✅ **Operation Coordination:** Coordinate multi-module operations
+- ✅ **Dependency Management:** Manage module dependencies
+- ✅ **Synchronization:** Synchronize module states
+- ✅ **Priority Management:** Manage module priorities
+- ✅ **Timeout Handling:** Handle coordination timeouts
+
+### **4. Module State Management**
+
+#### **4.1 Module State Tracking**
+```c
+// Module State Information
+typedef struct {
+    module_state_t current_state;    // Current state
+    module_state_t previous_state;   // Previous state
+    uint64_t state_entry_time;       // State entry time
+    uint32_t state_duration_ms;      // State duration
+    uint32_t state_transition_count; // State transition count
+    char state_message[256];         // State message
+} module_state_info_t;
+```
+
+#### **4.2 State Transition Management**
+```c
+// State Transition Functions
+hal_status_t module_manager_transition_state(uint8_t module_id, module_state_t new_state);
+hal_status_t module_manager_get_state_history(uint8_t module_id, module_state_info_t *history, uint32_t max_count);
+hal_status_t module_manager_validate_state_transition(uint8_t module_id, module_state_t new_state, bool *valid);
+```
+
+#### **Yêu cầu:**
+- ✅ **State Tracking:** Track module state changes
+- ✅ **State Validation:** Validate state transitions
+- ✅ **State History:** Maintain state history
+- ✅ **State Notifications:** Notify on state changes
+- ✅ **State Recovery:** Automatic state recovery
+
+---
+
+## 🔒 **YÊU CẦU AN TOÀN**
+
+### **1. Module Safety Management**
+- ✅ **Safety Coordination:** Coordinate safety across modules
+- ✅ **Emergency Procedures:** Emergency procedures for all modules
+- ✅ **Safety Validation:** Validate safety requirements
+- ✅ **Fault Isolation:** Isolate module faults
+- ✅ **Safe Defaults:** Safe default configurations
+
+### **2. Error Handling & Recovery**
+- ✅ **Error Detection:** Detect module errors
+- ✅ **Error Recovery:** Automatic error recovery
+- ✅ **Error Propagation:** Prevent error propagation
+- ✅ **Error Logging:** Log all module errors
+- ✅ **Error Reporting:** Report errors to higher layers
+
+### **3. Resource Management**
+- ✅ **Memory Management:** Proper memory management
+- ✅ **Resource Allocation:** Proper resource allocation
+- ✅ **Resource Cleanup:** Proper resource cleanup
+- ✅ **Resource Monitoring:** Monitor resource usage
+- ✅ **Resource Limits:** Enforce resource limits
+
+---
+
+## 📊 **YÊU CẦU HIỆU NĂNG**
+
+### **1. Performance Requirements**
+```c
+// Performance Requirements
+#define MODULE_OPERATION_TIMEOUT_MS  1000    // Module operation timeout
+#define MODULE_UPDATE_INTERVAL_MS    100     // Module update interval
+#define MODULE_SYNC_TIMEOUT_MS       500     // Module synchronization timeout
+#define MODULE_COORDINATION_TIMEOUT_MS 2000  // Module coordination timeout
+#define MAX_CONCURRENT_OPERATIONS    10      // Maximum concurrent operations
+```
+
+### **2. Response Time Requirements**
+- **Module Operation:** < 1000ms per operation
+- **State Transition:** < 100ms per transition
+- **Status Update:** < 100ms per update
+- **Configuration Change:** < 500ms per change
+- **Emergency Operation:** < 50ms emergency response
+
+### **3. Reliability Requirements**
+- **Module Availability:** 99.9% module availability
+- **Operation Success Rate:** 99.5% operation success rate
+- **Error Recovery Time:** < 5 seconds recovery time
+- **Data Integrity:** 100% data integrity
+- **Fault Tolerance:** Continue operation with degraded performance
+
+---
+
+## 🔧 **CONFIGURATION MANAGEMENT**
+
+### **1. Module Configuration**
+```c
+// Module Configuration Structure
+typedef struct {
+    uint8_t module_id;               // Module ID
+    module_type_t module_type;       // Module type
+    module_config_t config;          // Module-specific configuration
+    module_coordination_config_t coordination; // Coordination configuration
+    bool auto_initialize;            // Auto-initialize flag
+    bool auto_enable;                // Auto-enable flag
+    uint32_t init_timeout_ms;        // Initialization timeout
+    uint32_t operation_timeout_ms;   // Operation timeout
+    uint32_t retry_count;            // Retry count
+} module_management_config_t;
+```
+
+### **2. System Configuration**
+```c
+// System Configuration Structure
+typedef struct {
+    uint32_t max_modules;            // Maximum number of modules
+    uint32_t update_interval_ms;     // Update interval
+    uint32_t sync_interval_ms;       // Synchronization interval
+    bool enable_coordination;        // Enable coordination
+    bool enable_monitoring;          // Enable monitoring
+    bool enable_logging;             // Enable logging
+    uint32_t log_level;              // Log level
+} system_config_t;
+```
+
+### **3. Configuration Persistence**
+- ✅ **Configuration Storage:** Persistent configuration storage
+- ✅ **Configuration Loading:** Load configuration on startup
+- ✅ **Configuration Validation:** Validate configuration data
+- ✅ **Configuration Backup:** Backup configuration data
+- ✅ **Configuration Versioning:** Version configuration data
+
+---
+
+## 🧪 **TESTING REQUIREMENTS**
+
+### **1. Unit Testing**
+- ✅ **Module Handler Testing:** Test all module handlers
+- ✅ **State Management Testing:** Test state management
+- ✅ **Coordination Testing:** Test module coordination
+- ✅ **Error Handling Testing:** Test error handling
+
+### **2. Integration Testing**
+- ✅ **Multi-module Testing:** Test with multiple modules
+- ✅ **System Integration:** Test system integration
+- ✅ **Performance Testing:** Test performance requirements
+- ✅ **Stress Testing:** Test under load conditions
+
+### **3. Validation Testing**
+- ✅ **Safety Testing:** Test safety requirements
+- ✅ **Reliability Testing:** Test long-term reliability
+- ✅ **Compliance Testing:** Test compliance requirements
+- ✅ **Interoperability Testing:** Test interoperability
+
+---
+
+## 📚 **DOCUMENTATION REQUIREMENTS**
+
+### **1. API Documentation**
+- ✅ **Function Documentation:** Complete function documentation
+- ✅ **Parameter Documentation:** Parameter descriptions
+- ✅ **Return Value Documentation:** Return value descriptions
+- ✅ **Error Code Documentation:** Error code descriptions
+
+### **2. Usage Examples**
+- ✅ **Basic Usage:** Basic usage examples
+- ✅ **Advanced Usage:** Advanced usage examples
+- ✅ **Error Handling:** Error handling examples
+- ✅ **Best Practices:** Best practices documentation
+
+### **3. Troubleshooting Guide**
+- ✅ **Common Issues:** Common issues và solutions
+- ✅ **Debug Procedures:** Debug procedures
+- ✅ **Performance Tuning:** Performance tuning guide
+- ✅ **Maintenance Procedures:** Maintenance procedures
+
+---
+
+## 🔄 **MAINTENANCE & SUPPORT**
+
+### **1. Version Management**
+- ✅ **Version Control:** Proper version control
+- ✅ **Backward Compatibility:** Maintain backward compatibility
+- ✅ **Migration Guide:** Provide migration guides
+- ✅ **Deprecation Policy:** Clear deprecation policy
+
+### **2. Support Requirements**
+- ✅ **Technical Support:** Technical support procedures
+- ✅ **Bug Reporting:** Bug reporting procedures
+- ✅ **Feature Requests:** Feature request procedures
+- ✅ **Documentation Updates:** Documentation update procedures
+
+---
+
+## 📋 **IMPLEMENTATION STATUS**
+
+### **✅ COMPLETED FEATURES:**
+- ✅ Module lifecycle management
+- ✅ Unified module interface
+- ✅ Module state management
+- ✅ Basic module coordination
+- ✅ Error handling và recovery
+- ✅ Configuration management
+- ✅ Thread-safe operations
+- ✅ Event handling system
+- ✅ Statistics collection
+- ✅ Health monitoring
+
+### **⚠️ PARTIALLY IMPLEMENTED:**
+- ⚠️ Advanced module coordination
+- ⚠️ Performance optimization
+- ⚠️ Comprehensive testing
+- ⚠️ Advanced monitoring
+
+### **❌ NOT IMPLEMENTED:**
+- ❌ Advanced analytics
+- ❌ Performance profiling
+- ❌ Advanced debugging tools
+- ❌ Comprehensive documentation
+
+---
+
+## 🎯 **KẾT LUẬN**
+
+### **Trạng thái hiện tại:** ✅ **IMPLEMENTED (cơ bản)**
+
+**Điểm mạnh:**
+- ✅ Core module management functionality
+- ✅ Unified module interface
+- ✅ State management system
+- ✅ Error handling và recovery
+- ✅ Thread-safe implementation
+
+**Cần cải thiện:**
+- ⚠️ Advanced module coordination
+- ⚠️ Performance optimization
+- ⚠️ Comprehensive testing
+- ⚠️ Advanced monitoring
+
+**Khuyến nghị:**
+1. **Ưu tiên testing** - Complete comprehensive testing
+2. **Performance optimization** - Optimize module operations
+3. **Advanced coordination** - Add advanced coordination features
+4. **Documentation** - Complete API documentation
+
+---
+
+**📅 Next Review:** Sau khi hoàn thành testing phase  
+**👥 Responsible:** FW Team  
+**📊 Success Metrics:** 100% test coverage, < 1000ms operation time, 99.9% reliability

--- a/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_RS485_HAL_SPECIFICATION.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_RS485_HAL_SPECIFICATION.md
@@ -1,0 +1,414 @@
+# RS485 HAL LAYER SPECIFICATION - OHT-50 Master Module
+
+**Phiên bản:** v1.0.0  
+**Ngày tạo:** 2025-01-28  
+**Team:** EMBED + FW  
+**Trạng thái:** ✅ IMPLEMENTED (cơ bản)  
+**Mục tiêu:** Định nghĩa chi tiết yêu cầu kỹ thuật và chức năng của RS485 HAL layer
+
+---
+
+## 🎯 **TỔNG QUAN**
+
+### **Mục tiêu:**
+- Cung cấp Hardware Abstraction Layer (HAL) cho RS485/Modbus RTU communication
+- Hỗ trợ giao tiếp với tất cả slave modules qua RS485 bus
+- Đảm bảo thread-safe và reliable communication
+- Cung cấp error handling và retry mechanism
+
+### **Phạm vi:**
+- RS485 serial communication
+- Modbus RTU protocol implementation
+- Device management và configuration
+- Error handling và statistics
+
+---
+
+## 🔧 **KIẾN TRÚC KỸ THUẬT**
+
+### **1. Hardware Interface**
+
+#### **UART1 RS485 Configuration:**
+```c
+// Hardware Configuration
+#define RS485_DEVICE_PATH        "/dev/ttyOHT485"  // udev symlink
+#define RS485_BAUD_RATE          115200
+#define RS485_DATA_BITS          8
+#define RS485_STOP_BITS          1
+#define RS485_PARITY             0  // No parity
+#define RS485_BUFFER_SIZE        1024
+#define MODBUS_FRAME_SIZE        256
+```
+
+#### **Pin Assignment:**
+```c
+// UART1 Pin Configuration (Orange Pi 5B)
+UART1_TX: GPIO1_D1 (Pin 8)    // Transmit
+UART1_RX: GPIO1_D0 (Pin 10)   // Receive
+GND:      Ground              // Common ground
+```
+
+### **2. Software Architecture**
+
+#### **Layer Structure:**
+```
+┌─────────────────────────────────────┐
+│           Application Layer         │
+│     (Module Manager, API)          │
+├─────────────────────────────────────┤
+│         Communication Manager       │
+│      (Modbus RTU Protocol)         │
+├─────────────────────────────────────┤
+│           RS485 HAL Layer           │
+│      (Hardware Abstraction)         │
+├─────────────────────────────────────┤
+│         Linux Serial Driver         │
+│         (/dev/ttyS1)               │
+├─────────────────────────────────────┤
+│         Hardware (UART1)           │
+│      (Orange Pi 5B RK3588)         │
+└─────────────────────────────────────┘
+```
+
+---
+
+## 📋 **YÊU CẦU CHỨC NĂNG**
+
+### **1. Core HAL Functions**
+
+#### **1.1 Initialization & Configuration**
+```c
+// RS485 HAL Core Functions
+hal_status_t hal_rs485_init(const rs485_config_t *config);
+hal_status_t hal_rs485_deinit(void);
+hal_status_t hal_rs485_open(void);
+hal_status_t hal_rs485_close(void);
+```
+
+#### **Yêu cầu:**
+- ✅ **Configuration Validation:** Validate tất cả parameters
+- ✅ **Device Path Management:** Support udev symlink `/dev/ttyOHT485`
+- ✅ **Serial Port Configuration:** Baud rate, data bits, parity, stop bits
+- ✅ **Thread Safety:** Mutex-based synchronization
+- ✅ **State Management:** Track initialization và device status
+
+#### **1.2 Data Transmission**
+```c
+// Transmission Functions
+hal_status_t hal_rs485_transmit(const uint8_t *data, size_t length);
+hal_status_t hal_rs485_receive(uint8_t *data, size_t *length);
+hal_status_t hal_rs485_send_receive(const uint8_t *tx_data, size_t tx_length, 
+                                   uint8_t *rx_data, size_t *rx_length);
+```
+
+#### **Yêu cầu:**
+- ✅ **Reliable Transmission:** Error detection và correction
+- ✅ **Retry Mechanism:** Automatic retry với exponential backoff
+- ✅ **Timeout Handling:** Configurable timeouts
+- ✅ **Buffer Management:** Proper buffer handling
+- ✅ **Flow Control:** Prevent buffer overflow
+
+### **2. Modbus RTU Protocol**
+
+#### **2.1 Function Codes Support**
+```c
+// Modbus Function Codes
+typedef enum {
+    MODBUS_FC_READ_COILS = 0x01,                    // Read discrete outputs
+    MODBUS_FC_READ_DISCRETE_INPUTS = 0x02,          // Read discrete inputs
+    MODBUS_FC_READ_HOLDING_REGISTERS = 0x03,        // Read holding registers
+    MODBUS_FC_READ_INPUT_REGISTERS = 0x04,          // Read input registers
+    MODBUS_FC_WRITE_SINGLE_COIL = 0x05,             // Write single coil
+    MODBUS_FC_WRITE_SINGLE_REGISTER = 0x06,         // Write single register
+    MODBUS_FC_WRITE_MULTIPLE_COILS = 0x0F,          // Write multiple coils
+    MODBUS_FC_WRITE_MULTIPLE_REGISTERS = 0x10       // Write multiple registers
+} modbus_function_code_t;
+```
+
+#### **2.2 Modbus Functions**
+```c
+// Modbus RTU Functions
+hal_status_t hal_modbus_read_holding_registers(uint8_t slave_id, uint16_t start_addr, 
+                                              uint16_t quantity, uint16_t *data);
+hal_status_t hal_modbus_write_single_register(uint8_t slave_id, uint16_t address, uint16_t value);
+hal_status_t hal_modbus_read_coils(uint8_t slave_id, uint16_t start_addr, 
+                                  uint16_t quantity, bool *coils);
+hal_status_t hal_modbus_write_single_coil(uint8_t slave_id, uint16_t address, bool value);
+```
+
+#### **Yêu cầu:**
+- ✅ **CRC Calculation:** Modbus CRC16 calculation
+- ✅ **Frame Validation:** Proper frame format validation
+- ✅ **Exception Handling:** Modbus exception codes
+- ✅ **Slave ID Management:** Support 1-247 slave addresses
+- ✅ **Register Access:** 16-bit register read/write
+
+### **3. Error Handling & Recovery**
+
+#### **3.1 Error Types**
+```c
+// RS485 Error Types
+typedef enum {
+    RS485_ERROR_NONE = 0,
+    RS485_ERROR_TIMEOUT,           // Communication timeout
+    RS485_ERROR_CRC_FAILED,        // CRC validation failed
+    RS485_ERROR_FRAME_ERROR,       // Frame format error
+    RS485_ERROR_BUFFER_OVERFLOW,   // Buffer overflow
+    RS485_ERROR_DEVICE_ERROR,      // Hardware error
+    RS485_ERROR_PARAMETER_ERROR    // Invalid parameters
+} rs485_error_t;
+```
+
+#### **3.2 Retry Mechanism**
+```c
+// Retry Configuration
+typedef struct {
+    uint32_t max_retries;          // Maximum retry attempts
+    uint32_t retry_delay_ms;       // Delay between retries
+    uint32_t timeout_ms;           // Communication timeout
+    bool enable_retry;             // Enable retry mechanism
+} rs485_retry_config_t;
+```
+
+#### **Yêu cầu:**
+- ✅ **Automatic Retry:** Configurable retry count và delay
+- ✅ **Exponential Backoff:** Increasing delay between retries
+- ✅ **Error Logging:** Detailed error logging
+- ✅ **Recovery Procedures:** Automatic recovery mechanisms
+- ✅ **Statistics Tracking:** Error statistics collection
+
+### **4. Statistics & Monitoring**
+
+#### **4.1 Communication Statistics**
+```c
+// RS485 Statistics
+typedef struct {
+    uint32_t total_transmissions;      // Total transmissions
+    uint32_t successful_transmissions; // Successful transmissions
+    uint32_t failed_transmissions;     // Failed transmissions
+    uint32_t timeout_count;           // Timeout occurrences
+    uint32_t crc_error_count;         // CRC error count
+    uint32_t frame_error_count;       // Frame error count
+    uint32_t retry_count;             // Total retries
+    uint64_t total_response_time;     // Total response time
+    uint32_t average_response_time;   // Average response time
+} rs485_statistics_t;
+```
+
+#### **4.2 Device Information**
+```c
+// Device Information
+typedef struct {
+    hal_device_type_t device_type;    // Device type
+    hal_device_status_t status;       // Device status
+    rs485_status_t rs485_status;      // RS485 status
+    char device_name[64];             // Device name
+    char device_version[32];          // Device version
+    uint64_t timestamp_us;           // Last update timestamp
+    uint32_t error_count;            // Error count
+    uint32_t warning_count;          // Warning count
+} rs485_device_info_t;
+```
+
+#### **Yêu cầu:**
+- ✅ **Real-time Statistics:** Live communication statistics
+- ✅ **Performance Monitoring:** Response time tracking
+- ✅ **Error Tracking:** Detailed error statistics
+- ✅ **Health Monitoring:** Device health status
+- ✅ **Historical Data:** Statistics history
+
+---
+
+## 🔒 **YÊU CẦU AN TOÀN**
+
+### **1. Thread Safety**
+- ✅ **Mutex Protection:** All operations protected by mutex
+- ✅ **Atomic Operations:** Critical operations atomic
+- ✅ **Deadlock Prevention:** Proper mutex ordering
+- ✅ **Resource Management:** Proper resource cleanup
+
+### **2. Error Recovery**
+- ✅ **Graceful Degradation:** Continue operation on errors
+- ✅ **Automatic Recovery:** Self-healing mechanisms
+- ✅ **Error Isolation:** Prevent error propagation
+- ✅ **Safe Defaults:** Safe default values
+
+### **3. Resource Management**
+- ✅ **Memory Management:** Proper memory allocation/deallocation
+- ✅ **File Descriptor Management:** Proper FD handling
+- ✅ **Buffer Management:** Prevent buffer overflow
+- ✅ **Cleanup Procedures:** Proper cleanup on exit
+
+---
+
+## 📊 **YÊU CẦU HIỆU NĂNG**
+
+### **1. Timing Requirements**
+```c
+// Performance Requirements
+#define RS485_MIN_BAUD_RATE      9600    // Minimum baud rate
+#define RS485_MAX_BAUD_RATE      115200  // Maximum baud rate
+#define RS485_DEFAULT_TIMEOUT    1000    // Default timeout (ms)
+#define RS485_MAX_RETRIES        3       // Maximum retry attempts
+#define RS485_RETRY_DELAY        100     // Retry delay (ms)
+```
+
+### **2. Throughput Requirements**
+- **Data Rate:** Up to 115200 bps
+- **Frame Rate:** Up to 1000 frames/second
+- **Response Time:** < 100ms typical
+- **Error Rate:** < 0.1% under normal conditions
+
+### **3. Reliability Requirements**
+- **Uptime:** 99.9% availability
+- **Error Recovery:** < 1 second recovery time
+- **Data Integrity:** CRC validation on all frames
+- **Fault Tolerance:** Continue operation with degraded performance
+
+---
+
+## 🔧 **CONFIGURATION MANAGEMENT**
+
+### **1. Configuration Structure**
+```c
+// RS485 Configuration
+typedef struct {
+    char device_path[64];        // Device path
+    uint32_t baud_rate;          // Baud rate
+    uint8_t data_bits;           // Data bits
+    uint8_t stop_bits;           // Stop bits
+    uint8_t parity;              // Parity
+    uint32_t timeout_ms;         // Timeout
+    uint32_t retry_count;        // Retry count
+} rs485_config_t;
+```
+
+### **2. Configuration Validation**
+- ✅ **Parameter Validation:** Validate all configuration parameters
+- ✅ **Range Checking:** Ensure parameters within valid ranges
+- ✅ **Consistency Checking:** Ensure parameter consistency
+- ✅ **Default Values:** Provide safe default values
+
+### **3. Dynamic Configuration**
+- ✅ **Runtime Configuration:** Support runtime configuration changes
+- ✅ **Hot Reload:** Support configuration reload without restart
+- ✅ **Validation:** Validate configuration before applying
+- ✅ **Rollback:** Support configuration rollback
+
+---
+
+## 🧪 **TESTING REQUIREMENTS**
+
+### **1. Unit Testing**
+- ✅ **Function Testing:** Test all HAL functions
+- ✅ **Error Testing:** Test error conditions
+- ✅ **Boundary Testing:** Test boundary conditions
+- ✅ **Performance Testing:** Test performance requirements
+
+### **2. Integration Testing**
+- ✅ **Hardware Integration:** Test with actual hardware
+- ✅ **Protocol Testing:** Test Modbus RTU protocol
+- ✅ **Multi-module Testing:** Test with multiple modules
+- ✅ **Stress Testing:** Test under load conditions
+
+### **3. Validation Testing**
+- ✅ **Compliance Testing:** Test protocol compliance
+- ✅ **Interoperability Testing:** Test with different modules
+- ✅ **Reliability Testing:** Test long-term reliability
+- ✅ **Safety Testing:** Test safety requirements
+
+---
+
+## 📚 **DOCUMENTATION REQUIREMENTS**
+
+### **1. API Documentation**
+- ✅ **Function Documentation:** Complete function documentation
+- ✅ **Parameter Documentation:** Parameter descriptions
+- ✅ **Return Value Documentation:** Return value descriptions
+- ✅ **Error Code Documentation:** Error code descriptions
+
+### **2. Usage Examples**
+- ✅ **Basic Usage:** Basic usage examples
+- ✅ **Advanced Usage:** Advanced usage examples
+- ✅ **Error Handling:** Error handling examples
+- ✅ **Best Practices:** Best practices documentation
+
+### **3. Troubleshooting Guide**
+- ✅ **Common Issues:** Common issues và solutions
+- ✅ **Debug Procedures:** Debug procedures
+- ✅ **Performance Tuning:** Performance tuning guide
+- ✅ **Maintenance Procedures:** Maintenance procedures
+
+---
+
+## 🔄 **MAINTENANCE & SUPPORT**
+
+### **1. Version Management**
+- ✅ **Version Control:** Proper version control
+- ✅ **Backward Compatibility:** Maintain backward compatibility
+- ✅ **Migration Guide:** Provide migration guides
+- ✅ **Deprecation Policy:** Clear deprecation policy
+
+### **2. Support Requirements**
+- ✅ **Technical Support:** Technical support procedures
+- ✅ **Bug Reporting:** Bug reporting procedures
+- ✅ **Feature Requests:** Feature request procedures
+- ✅ **Documentation Updates:** Documentation update procedures
+
+---
+
+## 📋 **IMPLEMENTATION STATUS**
+
+### **✅ COMPLETED FEATURES:**
+- ✅ RS485 HAL initialization và configuration
+- ✅ Serial port management
+- ✅ Thread-safe operations
+- ✅ Basic error handling
+- ✅ Statistics collection
+- ✅ Modbus RTU protocol support
+- ✅ CRC calculation và validation
+- ✅ Retry mechanism
+- ✅ Device information tracking
+
+### **⚠️ PARTIALLY IMPLEMENTED:**
+- ⚠️ Advanced error recovery
+- ⚠️ Performance optimization
+- ⚠️ Dynamic configuration
+- ⚠️ Comprehensive testing
+
+### **❌ NOT IMPLEMENTED:**
+- ❌ Advanced monitoring features
+- ❌ Performance profiling
+- ❌ Advanced debugging tools
+- ❌ Comprehensive documentation
+
+---
+
+## 🎯 **KẾT LUẬN**
+
+### **Trạng thái hiện tại:** ✅ **IMPLEMENTED (cơ bản)**
+
+**Điểm mạnh:**
+- ✅ Core functionality hoàn thiện
+- ✅ Thread-safe implementation
+- ✅ Basic error handling
+- ✅ Modbus RTU protocol support
+- ✅ Statistics collection
+
+**Cần cải thiện:**
+- ⚠️ Advanced error recovery
+- ⚠️ Performance optimization
+- ⚠️ Comprehensive testing
+- ⚠️ Advanced monitoring
+
+**Khuyến nghị:**
+1. **Ưu tiên testing** - Complete comprehensive testing
+2. **Performance optimization** - Optimize for high throughput
+3. **Advanced monitoring** - Add advanced monitoring features
+4. **Documentation** - Complete API documentation
+
+---
+
+**📅 Next Review:** Sau khi hoàn thành testing phase  
+**👥 Responsible:** EMBED Team + FW Team  
+**📊 Success Metrics:** 100% test coverage, < 1ms response time, 99.9% reliability

--- a/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_TESTING_SYSTEM_SPECIFICATION.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_TESTING_SYSTEM_SPECIFICATION.md
@@ -1,0 +1,586 @@
+# TESTING SYSTEM SPECIFICATION - OHT-50 Master Module
+
+**Phiên bản:** v1.0.0  
+**Ngày tạo:** 2025-01-28  
+**Team:** QA Team  
+**Trạng thái:** ❌ FAILED (safety tests)  
+**Mục tiêu:** Định nghĩa chi tiết yêu cầu kỹ thuật và chức năng của Testing System
+
+---
+
+## 🎯 **TỔNG QUAN**
+
+### **Mục tiêu:**
+- Cung cấp comprehensive testing framework cho OHT-50 Master Module firmware
+- Đảm bảo software quality và reliability
+- Validate safety requirements và compliance
+- Support continuous integration và automated testing
+
+### **Phạm vi:**
+- Unit testing framework
+- Integration testing
+- System testing
+- Safety testing
+- Performance testing
+- Automated test execution
+
+---
+
+## 🔧 **KIẾN TRÚC KỸ THUẬT**
+
+### **1. Testing System Architecture**
+
+#### **Testing System Components:**
+```
+┌─────────────────────────────────────┐
+│         Test Framework              │
+│     (GTest, CMocka, Unity)         │
+├─────────────────────────────────────┤
+│         Test Runner                 │
+│     (Automated Test Execution)     │
+├─────────────────────────────────────┤
+│         Mock Framework              │
+│     (Hardware Simulation)          │
+├─────────────────────────────────────┤
+│         Test Reporting              │
+│     (Results, Coverage, Metrics)   │
+├─────────────────────────────────────┤
+│         Continuous Integration      │
+│     (CI/CD Pipeline Integration)   │
+└─────────────────────────────────────┘
+```
+
+#### **Testing Process Flow:**
+```mermaid
+graph TD
+    A[Source Code] --> B[Unit Tests]
+    A --> C[Integration Tests]
+    A --> D[System Tests]
+    A --> E[Safety Tests]
+    
+    B --> F[Test Results]
+    C --> F
+    D --> F
+    E --> F
+    
+    F --> G[Test Analysis]
+    G --> H[Coverage Report]
+    G --> I[Performance Metrics]
+    G --> J[Safety Validation]
+    
+    H --> K[Quality Gate]
+    I --> K
+    J --> K
+    
+    K --> L{Pass/Fail}
+    L -->|Pass| M[Deploy]
+    L -->|Fail| N[Fix Issues]
+    N --> A
+```
+
+### **2. Testing Framework Structure**
+
+#### **2.1 Test Categories**
+```c
+// Test Categories
+typedef enum {
+    TEST_CATEGORY_UNIT = 0,           // Unit tests
+    TEST_CATEGORY_INTEGRATION,        // Integration tests
+    TEST_CATEGORY_SYSTEM,             // System tests
+    TEST_CATEGORY_SAFETY,             // Safety tests
+    TEST_CATEGORY_PERFORMANCE,        // Performance tests
+    TEST_CATEGORY_STRESS,             // Stress tests
+    TEST_CATEGORY_REGRESSION,         // Regression tests
+    TEST_CATEGORY_COMPLIANCE,         // Compliance tests
+    TEST_CATEGORY_MAX
+} test_category_t;
+```
+
+#### **2.2 Test Framework Configuration**
+```c
+// Test Framework Configuration
+typedef struct {
+    bool enable_unit_tests;           // Enable unit tests
+    bool enable_integration_tests;    // Enable integration tests
+    bool enable_system_tests;         // Enable system tests
+    bool enable_safety_tests;         // Enable safety tests
+    bool enable_performance_tests;    // Enable performance tests
+    bool enable_coverage;             // Enable code coverage
+    bool enable_memory_checking;      // Enable memory checking
+    bool enable_static_analysis;      // Enable static analysis
+    uint32_t test_timeout_ms;         // Test timeout
+    uint32_t max_test_retries;        // Maximum test retries
+} test_framework_config_t;
+```
+
+---
+
+## 📋 **YÊU CẦU CHỨC NĂNG**
+
+### **1. Unit Testing Framework**
+
+#### **1.1 Unit Test Structure**
+```c
+// Unit Test Structure
+typedef struct {
+    const char *test_name;            // Test name
+    const char *test_description;     // Test description
+    test_category_t category;         // Test category
+    bool (*test_function)(void);      // Test function
+    uint32_t timeout_ms;              // Test timeout
+    uint32_t priority;                // Test priority
+} unit_test_t;
+
+// Unit Test Example
+static bool test_hal_rs485_init(void) {
+    // Test setup
+    rs485_config_t config = {
+        .baud_rate = 115200,
+        .data_bits = 8,
+        .stop_bits = 1,
+        .parity = 0
+    };
+    
+    // Test execution
+    hal_status_t result = hal_rs485_init(&config);
+    
+    // Test verification
+    if (result != HAL_STATUS_OK) {
+        return false;
+    }
+    
+    // Test cleanup
+    hal_rs485_deinit();
+    
+    return true;
+}
+```
+
+#### **1.2 Unit Test Framework**
+```c
+// Unit Test Framework Functions
+hal_status_t unit_test_init(const test_framework_config_t *config);
+hal_status_t unit_test_deinit(void);
+hal_status_t unit_test_register(const unit_test_t *test);
+hal_status_t unit_test_run_all(void);
+hal_status_t unit_test_run_category(test_category_t category);
+hal_status_t unit_test_run_specific(const char *test_name);
+hal_status_t unit_test_get_results(test_results_t *results);
+```
+
+#### **Yêu cầu:**
+- ✅ **Test Registration:** Register individual unit tests
+- ✅ **Test Execution:** Execute unit tests
+- ✅ **Test Isolation:** Isolate test execution
+- ✅ **Test Cleanup:** Proper test cleanup
+- ✅ **Test Reporting:** Test result reporting
+
+### **2. Integration Testing Framework**
+
+#### **2.1 Integration Test Structure**
+```c
+// Integration Test Structure
+typedef struct {
+    const char *test_name;            // Test name
+    const char *test_description;     // Test description
+    test_category_t category;         // Test category
+    bool (*setup_function)(void);     // Setup function
+    bool (*test_function)(void);      // Test function
+    bool (*teardown_function)(void);  // Teardown function
+    uint32_t timeout_ms;              // Test timeout
+    uint32_t priority;                // Test priority
+} integration_test_t;
+
+// Integration Test Example
+static bool test_module_discovery_integration(void) {
+    // Setup: Initialize communication manager
+    if (!setup_communication_manager()) {
+        return false;
+    }
+    
+    // Test: Discover modules
+    module_info_t modules[16];
+    uint32_t module_count;
+    hal_status_t result = module_manager_discover_modules();
+    
+    if (result != HAL_STATUS_OK) {
+        teardown_communication_manager();
+        return false;
+    }
+    
+    // Verify: Check discovered modules
+    result = module_manager_get_registered_modules(
+        (uint8_t*)modules, 16, &module_count);
+    
+    // Teardown: Cleanup
+    teardown_communication_manager();
+    
+    return (result == HAL_STATUS_OK && module_count > 0);
+}
+```
+
+#### **2.2 Integration Test Framework**
+```c
+// Integration Test Framework Functions
+hal_status_t integration_test_init(const test_framework_config_t *config);
+hal_status_t integration_test_deinit(void);
+hal_status_t integration_test_register(const integration_test_t *test);
+hal_status_t integration_test_run_all(void);
+hal_status_t integration_test_run_category(test_category_t category);
+hal_status_t integration_test_run_specific(const char *test_name);
+hal_status_t integration_test_get_results(test_results_t *results);
+```
+
+#### **Yêu cầu:**
+- ✅ **Component Integration:** Test component integration
+- ✅ **Interface Testing:** Test module interfaces
+- ✅ **Data Flow Testing:** Test data flow between components
+- ✅ **Error Propagation:** Test error propagation
+- ✅ **Performance Integration:** Test integration performance
+
+### **3. Safety Testing Framework**
+
+#### **3.1 Safety Test Structure**
+```c
+// Safety Test Structure
+typedef struct {
+    const char *test_name;            // Test name
+    const char *test_description;     // Test description
+    safety_requirement_t requirement; // Safety requirement
+    bool (*test_function)(void);      // Test function
+    uint32_t timeout_ms;              // Test timeout
+    uint32_t priority;                // Test priority
+    bool critical;                    // Critical test flag
+} safety_test_t;
+
+// Safety Test Example
+static bool test_emergency_stop_safety(void) {
+    // Test setup: Initialize safety system
+    safety_monitor_config_t config = {
+        .update_period_ms = 100,
+        .estop_timeout_ms = 50,
+        .enable_emergency_procedures = true
+    };
+    
+    hal_status_t result = safety_monitor_init(&config);
+    if (result != HAL_STATUS_OK) {
+        return false;
+    }
+    
+    // Test execution: Trigger emergency stop
+    result = safety_monitor_trigger_emergency_stop("Test E-Stop");
+    
+    // Test verification: Check E-Stop state
+    bool estop_active;
+    result = safety_monitor_is_estop_active(&estop_active);
+    
+    // Test cleanup
+    safety_monitor_deinit();
+    
+    return (result == HAL_STATUS_OK && estop_active);
+}
+```
+
+#### **3.2 Safety Test Framework**
+```c
+// Safety Test Framework Functions
+hal_status_t safety_test_init(const test_framework_config_t *config);
+hal_status_t safety_test_deinit(void);
+hal_status_t safety_test_register(const safety_test_t *test);
+hal_status_t safety_test_run_all(void);
+hal_status_t safety_test_run_critical(void);
+hal_status_t safety_test_run_specific(const char *test_name);
+hal_status_t safety_test_get_results(safety_test_results_t *results);
+hal_status_t safety_test_validate_compliance(compliance_report_t *report);
+```
+
+#### **Yêu cầu:**
+- ✅ **Safety Requirements:** Test safety requirements
+- ✅ **Emergency Procedures:** Test emergency procedures
+- ✅ **Fault Injection:** Test fault injection scenarios
+- ✅ **Safety Validation:** Validate safety compliance
+- ✅ **Critical Testing:** Test critical safety functions
+
+### **4. Mock Framework**
+
+#### **4.1 Mock Structure**
+```c
+// Mock Configuration
+typedef struct {
+    const char *mock_name;            // Mock name
+    void *mock_data;                  // Mock data
+    size_t mock_data_size;            // Mock data size
+    bool (*mock_function)(void *data); // Mock function
+    uint32_t call_count;              // Call count
+    uint32_t max_calls;               // Maximum calls
+} mock_config_t;
+
+// Mock Example: RS485 HAL Mock
+static bool mock_hal_rs485_transmit(const uint8_t *data, size_t length) {
+    // Mock implementation
+    mock_rs485_data_t *mock_data = get_mock_rs485_data();
+    
+    if (mock_data->call_count >= mock_data->max_calls) {
+        return false;
+    }
+    
+    // Simulate transmission
+    memcpy(mock_data->tx_buffer, data, length);
+    mock_data->tx_length = length;
+    mock_data->call_count++;
+    
+    return true;
+}
+```
+
+#### **4.2 Mock Framework Functions**
+```c
+// Mock Framework Functions
+hal_status_t mock_init(const mock_config_t *config);
+hal_status_t mock_deinit(void);
+hal_status_t mock_register(const char *name, mock_config_t *config);
+hal_status_t mock_reset(const char *name);
+hal_status_t mock_set_data(const char *name, void *data, size_t size);
+hal_status_t mock_get_data(const char *name, void *data, size_t size);
+hal_status_t mock_get_call_count(const char *name, uint32_t *count);
+```
+
+#### **Yêu cầu:**
+- ✅ **Hardware Simulation:** Simulate hardware behavior
+- ✅ **Interface Mocking:** Mock module interfaces
+- ✅ **Data Simulation:** Simulate data responses
+- ✅ **Error Simulation:** Simulate error conditions
+- ✅ **Performance Simulation:** Simulate performance characteristics
+
+---
+
+## 🔒 **YÊU CẦU AN TOÀN**
+
+### **1. Safety Testing Requirements**
+- ✅ **Safety Validation:** Validate safety requirements
+- ✅ **Emergency Testing:** Test emergency procedures
+- ✅ **Fault Tolerance:** Test fault tolerance
+- ✅ **Safety Compliance:** Ensure safety compliance
+- ✅ **Critical Path Testing:** Test critical safety paths
+
+### **2. Test Safety**
+- ✅ **Test Isolation:** Isolate test execution
+- ✅ **Test Cleanup:** Proper test cleanup
+- ✅ **Resource Management:** Proper resource management
+- ✅ **Error Handling:** Proper error handling
+- ✅ **Recovery Procedures:** Test recovery procedures
+
+### **3. Data Safety**
+- ✅ **Data Protection:** Protect test data
+- ✅ **Data Validation:** Validate test data
+- ✅ **Data Cleanup:** Clean up test data
+- ✅ **Data Integrity:** Ensure data integrity
+- ✅ **Data Privacy:** Protect sensitive data
+
+---
+
+## 📊 **YÊU CẦU HIỆU NĂNG**
+
+### **1. Test Performance**
+```c
+// Performance Requirements
+#define UNIT_TEST_TIMEOUT_MS          1000    // Unit test timeout
+#define INTEGRATION_TEST_TIMEOUT_MS   5000    // Integration test timeout
+#define SYSTEM_TEST_TIMEOUT_MS        30000   // System test timeout
+#define SAFETY_TEST_TIMEOUT_MS        10000   // Safety test timeout
+#define MAX_TEST_RETRIES              3       // Maximum test retries
+```
+
+### **2. Test Execution Requirements**
+- **Unit Test Execution:** < 1 second per test
+- **Integration Test Execution:** < 5 seconds per test
+- **System Test Execution:** < 30 seconds per test
+- **Safety Test Execution:** < 10 seconds per test
+- **Full Test Suite:** < 10 minutes total execution
+
+### **3. Coverage Requirements**
+- **Code Coverage:** > 90% code coverage
+- **Branch Coverage:** > 85% branch coverage
+- **Function Coverage:** > 95% function coverage
+- **Line Coverage:** > 90% line coverage
+- **Safety Coverage:** 100% safety requirement coverage
+
+---
+
+## 🔧 **CONFIGURATION MANAGEMENT**
+
+### **1. Test Configuration**
+```c
+// Test Configuration Structure
+typedef struct {
+    test_framework_config_t framework; // Framework configuration
+    test_category_config_t categories[TEST_CATEGORY_MAX]; // Category configs
+    mock_config_t mocks[MAX_MOCKS];     // Mock configurations
+    coverage_config_t coverage;         // Coverage configuration
+    reporting_config_t reporting;       // Reporting configuration
+} test_system_config_t;
+```
+
+### **2. Test Environment Configuration**
+```c
+// Test Environment Configuration
+typedef struct {
+    bool enable_hardware_simulation;   // Enable hardware simulation
+    bool enable_network_simulation;    // Enable network simulation
+    bool enable_time_simulation;       // Enable time simulation
+    uint32_t simulation_speed;         // Simulation speed multiplier
+    char test_data_path[256];          // Test data path
+} test_environment_config_t;
+```
+
+### **3. Test Data Management**
+- ✅ **Test Data Storage:** Store test data
+- ✅ **Test Data Loading:** Load test data
+- ✅ **Test Data Validation:** Validate test data
+- ✅ **Test Data Cleanup:** Clean up test data
+- ✅ **Test Data Versioning:** Version test data
+
+---
+
+## 🧪 **TESTING REQUIREMENTS**
+
+### **1. Test Development**
+- ✅ **Test Design:** Design comprehensive tests
+- ✅ **Test Implementation:** Implement tests
+- ✅ **Test Validation:** Validate test implementation
+- ✅ **Test Documentation:** Document tests
+- ✅ **Test Maintenance:** Maintain tests
+
+### **2. Test Execution**
+- ✅ **Automated Execution:** Automated test execution
+- ✅ **Manual Execution:** Manual test execution
+- ✅ **Scheduled Execution:** Scheduled test execution
+- ✅ **On-demand Execution:** On-demand test execution
+- ✅ **Continuous Execution:** Continuous test execution
+
+### **3. Test Analysis**
+- ✅ **Result Analysis:** Analyze test results
+- ✅ **Coverage Analysis:** Analyze coverage
+- ✅ **Performance Analysis:** Analyze performance
+- ✅ **Safety Analysis:** Analyze safety results
+- ✅ **Trend Analysis:** Analyze test trends
+
+---
+
+## 📚 **DOCUMENTATION REQUIREMENTS**
+
+### **1. Test Documentation**
+- ✅ **Test Plan:** Comprehensive test plan
+- ✅ **Test Cases:** Detailed test cases
+- ✅ **Test Procedures:** Test procedures
+- ✅ **Test Results:** Test result documentation
+- ✅ **Test Reports:** Test reports
+
+### **2. Framework Documentation**
+- ✅ **Framework API:** Framework API documentation
+- ✅ **Usage Examples:** Usage examples
+- ✅ **Best Practices:** Best practices documentation
+- ✅ **Troubleshooting:** Troubleshooting guide
+- ✅ **Maintenance:** Maintenance procedures
+
+### **3. Safety Documentation**
+- ✅ **Safety Requirements:** Safety requirements documentation
+- ✅ **Safety Procedures:** Safety procedures
+- ✅ **Safety Validation:** Safety validation documentation
+- ✅ **Compliance Reports:** Compliance reports
+- ✅ **Safety Analysis:** Safety analysis reports
+
+---
+
+## 🔄 **MAINTENANCE & SUPPORT**
+
+### **1. Test Maintenance**
+- ✅ **Test Updates:** Update tests
+- ✅ **Test Validation:** Validate test updates
+- ✅ **Test Regression:** Test regression testing
+- ✅ **Test Optimization:** Optimize tests
+- ✅ **Test Cleanup:** Clean up obsolete tests
+
+### **2. Framework Maintenance**
+- ✅ **Framework Updates:** Update framework
+- ✅ **Framework Validation:** Validate framework updates
+- ✅ **Framework Optimization:** Optimize framework
+- ✅ **Framework Documentation:** Update documentation
+- ✅ **Framework Support:** Provide framework support
+
+---
+
+## 📋 **IMPLEMENTATION STATUS**
+
+### **✅ COMPLETED FEATURES:**
+- ✅ Basic unit testing framework
+- ✅ Basic integration testing framework
+- ✅ Basic safety testing framework
+- ✅ Basic mock framework
+- ✅ Test execution engine
+- ✅ Basic test reporting
+- ✅ Test configuration management
+- ✅ Test data management
+- ✅ Basic coverage analysis
+
+### **⚠️ PARTIALLY IMPLEMENTED:**
+- ⚠️ Advanced safety testing
+- ⚠️ Performance testing
+- ⚠️ Comprehensive coverage
+- ⚠️ Advanced reporting
+
+### **❌ NOT IMPLEMENTED:**
+- ❌ Advanced analytics
+- ❌ Performance profiling
+- ❌ Advanced debugging tools
+- ❌ Comprehensive documentation
+
+---
+
+## 🚨 **CURRENT ISSUES**
+
+### **❌ SAFETY TEST FAILURES:**
+- ❌ **Emergency Stop Tests:** Emergency stop test failures
+- ❌ **Safety Validation:** Safety validation failures
+- ❌ **Compliance Tests:** Compliance test failures
+- ❌ **Critical Path Tests:** Critical path test failures
+- ❌ **Fault Injection Tests:** Fault injection test failures
+
+### **🔧 REQUIRED FIXES:**
+1. **Safety Test Implementation:** Implement missing safety tests
+2. **Safety Validation:** Fix safety validation issues
+3. **Compliance Testing:** Fix compliance testing issues
+4. **Test Coverage:** Improve test coverage
+5. **Test Reliability:** Improve test reliability
+
+---
+
+## 🎯 **KẾT LUẬN**
+
+### **Trạng thái hiện tại:** ❌ **FAILED (safety tests)**
+
+**Điểm mạnh:**
+- ✅ Basic testing framework
+- ✅ Unit testing support
+- ✅ Integration testing support
+- ✅ Mock framework
+- ✅ Test execution engine
+
+**Cần khắc phục:**
+- ❌ Safety test failures
+- ❌ Compliance issues
+- ❌ Test coverage gaps
+- ❌ Test reliability issues
+- ❌ Documentation gaps
+
+**Khuyến nghị:**
+1. **Ưu tiên safety tests** - Fix all safety test failures
+2. **Compliance validation** - Ensure compliance with safety standards
+3. **Test coverage** - Improve test coverage
+4. **Documentation** - Complete test documentation
+
+---
+
+**📅 Next Review:** Sau khi khắc phục safety test failures  
+**👥 Responsible:** QA Team  
+**📊 Success Metrics:** 100% test pass rate, >90% coverage, 100% safety compliance

--- a/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/REQ_API_INTEGRATION_SPECIFICATION.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/REQ_API_INTEGRATION_SPECIFICATION.md
@@ -1,0 +1,470 @@
+# Đặc tả Yêu cầu API Integration - OHT-50 Master Module
+
+**Phiên bản:** 1.0.0  
+**Ngày cập nhật:** 2025-01-28  
+**Team:** FW  
+**Mức độ ưu tiên:** CAO  
+**Task:** FW-07 (API Integration & BE/FE Connectivity)
+
+---
+
+## 📋 **Tổng quan**
+
+### **Mục tiêu**
+Implement hoàn chỉnh hệ thống API cho OHT-50 Master Module để kết nối với Backend và Frontend, cung cấp:
+- HTTP REST API endpoints hoạt động với dữ liệu thực
+- WebSocket real-time communication
+- Integration với core systems (system_controller, safety_manager, module_manager)
+- Authentication và authorization
+- Error handling và logging
+
+### **Phạm vi**
+- API Manager implementation hoàn chỉnh
+- Core system integration
+- HTTP/WebSocket server setup
+- Module-specific endpoints
+- Security implementation
+
+---
+
+## 🎯 **Yêu cầu chức năng**
+
+### **1. Core System Integration (BẮT BUỘC)**
+
+#### **1.1 System Controller Integration**
+```c
+// Thay thế mock data trong api_endpoints.c
+hal_status_t system_get_status(void) {
+    system_controller_status_t status;
+    hal_status_t result = system_controller_get_status(&status);
+    
+    if (result == HAL_STATUS_OK) {
+        // Convert to API format
+        api_system_status_t api_status = {
+            .system_name = "OHT-50",
+            .version = "1.0.0",
+            .status = system_controller_get_state_name(status.current_state),
+            .uptime_ms = status.uptime_ms,
+            .active_modules = status.system_ready ? 1 : 0,
+            .estop_active = !status.safety_ok,
+            .safety_ok = status.safety_ok
+        };
+        return HAL_STATUS_OK;
+    }
+    return result;
+}
+```
+
+#### **1.2 Safety Manager Integration**
+```c
+hal_status_t safety_get_status(void) {
+    safety_monitor_status_t safety_status;
+    hal_status_t result = safety_monitor_get_status(&safety_status);
+    
+    if (result == HAL_STATUS_OK) {
+        api_safety_status_t api_safety = {
+            .estop_active = safety_status.estop_active,
+            .safety_ok = safety_status.current_state == SAFETY_MONITOR_STATE_SAFE,
+            .safety_level = (uint32_t)safety_status.current_state,
+            .last_safety_check = safety_status.last_update_time
+        };
+        return HAL_STATUS_OK;
+    }
+    return result;
+}
+```
+
+#### **1.3 Module Manager Integration**
+```c
+hal_status_t module_get_list(void) {
+    uint8_t module_ids[16];
+    uint32_t actual_count;
+    hal_status_t result = module_manager_get_registered_modules(module_ids, 16, &actual_count);
+    
+    if (result == HAL_STATUS_OK) {
+        api_modules_list_t modules_list = {0};
+        modules_list.module_count = actual_count;
+        
+        for (uint32_t i = 0; i < actual_count; i++) {
+            module_info_t module_info;
+            if (module_manager_get_module_info(module_ids[i], &module_info) == HAL_STATUS_OK) {
+                modules_list.modules[i].module_id = module_ids[i];
+                strncpy(modules_list.modules[i].module_type, 
+                       module_manager_get_type_name(module_info.type), 31);
+                modules_list.modules[i].online = module_info.status == MODULE_STATUS_ONLINE;
+                modules_list.modules[i].last_seen = module_info.last_seen_ms;
+            }
+        }
+        return HAL_STATUS_OK;
+    }
+    return result;
+}
+```
+
+### **2. HTTP Server Implementation**
+
+#### **2.1 Server Configuration**
+```c
+// Trong api_manager.c - cập nhật config
+api_mgr_config_t api_config = {
+    .http_port = 8080,
+    .websocket_port = 8081,
+    .http_enabled = true,
+    .websocket_enabled = true,
+    .cors_enabled = true,
+    .cors_origin = "*",
+    .max_request_size = 4096,
+    .max_response_size = 8192,
+    .request_timeout_ms = 5000,
+    .websocket_timeout_ms = 30000,
+    .authentication_required = false, // Tạm thời disable
+    .ssl_enabled = false
+};
+```
+
+#### **2.2 Endpoint Registration**
+```c
+// Trong api_manager.c - register tất cả endpoints
+hal_status_t api_manager_register_all_endpoints(void) {
+    // System endpoints
+    api_manager_register_endpoint(&(api_mgr_endpoint_t){
+        .path = "/api/v1/system/status",
+        .method = API_MGR_HTTP_GET,
+        .handler = api_handle_system_status,
+        .authentication_required = false
+    });
+    
+    // Safety endpoints
+    api_manager_register_endpoint(&(api_mgr_endpoint_t){
+        .path = "/api/v1/safety/status",
+        .method = API_MGR_HTTP_GET,
+        .handler = api_handle_safety_status,
+        .authentication_required = false
+    });
+    
+    // Module endpoints
+    api_manager_register_endpoint(&(api_mgr_endpoint_t){
+        .path = "/api/v1/modules",
+        .method = API_MGR_HTTP_GET,
+        .handler = api_handle_modules_list,
+        .authentication_required = false
+    });
+    
+    // Configuration endpoints
+    api_manager_register_endpoint(&(api_mgr_endpoint_t){
+        .path = "/api/v1/config",
+        .method = API_MGR_HTTP_GET,
+        .handler = api_handle_config_get,
+        .authentication_required = false
+    });
+    
+    return HAL_STATUS_OK;
+}
+```
+
+### **3. WebSocket Implementation**
+
+#### **3.1 Real-time Data Broadcasting**
+```c
+// Trong telemetry_manager.c - broadcast telemetry data
+hal_status_t telemetry_broadcast_system_status(void) {
+    telemetry_data_t telemetry_data;
+    hal_status_t result = telemetry_manager_get_data(&telemetry_data);
+    
+    if (result == HAL_STATUS_OK) {
+        char json_buffer[2048];
+        int json_len = telemetry_manager_serialize_json(&telemetry_data, json_buffer, sizeof(json_buffer));
+        
+        if (json_len > 0) {
+            api_manager_broadcast_websocket_message(json_buffer, json_len);
+        }
+    }
+    return result;
+}
+```
+
+#### **3.2 WebSocket Message Handler**
+```c
+// Trong api_manager.c - handle WebSocket messages
+static hal_status_t handle_websocket_message(const api_mgr_ws_message_t *message) {
+    if (message->frame_type == API_MGR_WS_FRAME_TEXT) {
+        // Parse JSON command
+        if (strstr(message->payload, "\"command\":\"get_status\"") != NULL) {
+            // Send immediate status update
+            char response[512];
+            snprintf(response, sizeof(response), 
+                    "{\"type\":\"status_response\",\"data\":{\"timestamp\":%lu}}", 
+                    (unsigned long)time(NULL));
+            api_manager_send_websocket_message(message->client_id, response, strlen(response));
+        }
+    }
+    return HAL_STATUS_OK;
+}
+```
+
+### **4. Module-Specific Endpoints**
+
+#### **4.1 Power Module Endpoints**
+```c
+hal_status_t api_handle_power_status(const api_mgr_http_request_t *request, api_mgr_http_response_t *response) {
+    power_module_data_t power_data;
+    hal_status_t result = power_module_handler_read_data(&power_data);
+    
+    if (result == HAL_STATUS_OK) {
+        char json_buffer[1024];
+        snprintf(json_buffer, sizeof(json_buffer),
+                "{\"battery_voltage\":%.2f,\"battery_current\":%.2f,\"battery_soc\":%d,\"charge_status\":%d}",
+                power_data.battery_voltage, power_data.battery_current, 
+                power_data.battery_soc, power_data.charge_status);
+        
+        return api_create_success_response(response, json_buffer);
+    }
+    
+    return api_create_error_response(response, API_MGR_RESPONSE_INTERNAL_SERVER_ERROR, "Failed to read power data");
+}
+```
+
+#### **4.2 Safety Module Endpoints**
+```c
+hal_status_t api_handle_safety_sensors(const api_mgr_http_request_t *request, api_mgr_http_response_t *response) {
+    safety_module_data_t safety_data;
+    safety_module_handler_t handler;
+    
+    // Initialize handler with default config
+    safety_module_config_t config = {0};
+    config.address = 0x03; // Safety module address
+    safety_module_init(&handler, &config);
+    
+    hal_status_t result = safety_module_get_data(&handler, &safety_data);
+    
+    if (result == HAL_STATUS_OK) {
+        char json_buffer[512];
+        snprintf(json_buffer, sizeof(json_buffer),
+                "{\"analog_sensors\":[%d,%d,%d,%d],\"digital_sensors\":%d,\"proximity_alert\":%s}",
+                safety_data.analog_sensors[0], safety_data.analog_sensors[1],
+                safety_data.analog_sensors[2], safety_data.analog_sensors[3],
+                safety_data.digital_sensors, safety_data.proximity_alert ? "true" : "false");
+        
+        return api_create_success_response(response, json_buffer);
+    }
+    
+    return api_create_error_response(response, API_MGR_RESPONSE_INTERNAL_SERVER_ERROR, "Failed to read safety data");
+}
+```
+
+### **5. Error Handling & Logging**
+
+#### **5.1 Comprehensive Error Handling**
+```c
+// Trong api_endpoints.c - enhanced error handling
+hal_status_t api_handle_system_status(const api_mgr_http_request_t *request, api_mgr_http_response_t *response) {
+    // Validate request
+    hal_status_t validation = api_validate_request(request, API_MGR_HTTP_GET, "/api/v1/system/status");
+    if (validation != HAL_STATUS_OK) {
+        return api_create_error_response(response, API_MGR_RESPONSE_BAD_REQUEST, "Invalid request");
+    }
+    
+    // Get system status
+    api_system_status_t system_status;
+    hal_status_t result = system_get_status();
+    
+    if (result != HAL_STATUS_OK) {
+        char error_msg[256];
+        snprintf(error_msg, sizeof(error_msg), "Failed to get system status: %d", result);
+        return api_create_error_response(response, API_MGR_RESPONSE_INTERNAL_SERVER_ERROR, error_msg);
+    }
+    
+    // Create JSON response
+    char json_buffer[512];
+    hal_status_t json_result = api_create_system_status_json(&system_status, json_buffer, sizeof(json_buffer));
+    
+    if (json_result != HAL_STATUS_OK) {
+        return api_create_error_response(response, API_MGR_RESPONSE_INTERNAL_SERVER_ERROR, "JSON serialization failed");
+    }
+    
+    return api_create_success_response(response, json_buffer);
+}
+```
+
+#### **5.2 Logging Implementation**
+```c
+// Trong api_manager.c - logging functions
+static void api_log_request(const api_mgr_http_request_t *request, const api_mgr_http_response_t *response) {
+    printf("[API] %s %s -> %d (%s)\n", 
+           api_manager_get_http_method_name(request->method),
+           request->path,
+           response->status_code,
+           request->client_ip);
+}
+
+static void api_log_error(const char *context, hal_status_t error_code) {
+    printf("[API-ERROR] %s failed with code: %d\n", context, error_code);
+}
+```
+
+---
+
+## 🔧 **Yêu cầu kỹ thuật**
+
+### **1. Performance Requirements**
+- **Response time:** < 100ms cho GET requests
+- **WebSocket latency:** < 50ms cho real-time data
+- **Concurrent connections:** Hỗ trợ ít nhất 10 clients
+- **Memory usage:** < 2MB cho API manager
+
+### **2. Reliability Requirements**
+- **Uptime:** 99.9% availability
+- **Error recovery:** Auto-recovery từ communication failures
+- **Timeout handling:** Graceful timeout cho tất cả operations
+- **Data consistency:** Consistent data giữa API và core systems
+
+### **3. Security Requirements**
+- **Input validation:** Validate tất cả input parameters
+- **Buffer overflow protection:** Safe string handling
+- **Authentication:** Session-based authentication (future)
+- **Authorization:** Role-based access control (future)
+
+---
+
+## 📋 **Implementation Checklist**
+
+### **Phase 1: Core Integration (Week 1)**
+- [ ] Implement `system_get_status()` function
+- [ ] Implement `safety_get_status()` function  
+- [ ] Implement `module_get_list()` function
+- [ ] Replace mock data trong tất cả endpoints
+- [ ] Test core system integration
+
+### **Phase 2: HTTP Server (Week 2)**
+- [ ] Configure HTTP server với port 8080
+- [ ] Register tất cả endpoints
+- [ ] Implement CORS support
+- [ ] Add request/response logging
+- [ ] Test HTTP endpoints
+
+### **Phase 3: WebSocket Server (Week 3)**
+- [ ] Configure WebSocket server với port 8081
+- [ ] Implement real-time data broadcasting
+- [ ] Add message handling
+- [ ] Implement connection management
+- [ ] Test WebSocket communication
+
+### **Phase 4: Module Endpoints (Week 4)**
+- [ ] Implement power module endpoints
+- [ ] Implement safety module endpoints
+- [ ] Implement motor module endpoints
+- [ ] Implement dock module endpoints
+- [ ] Test module-specific functionality
+
+### **Phase 5: Error Handling & Testing (Week 5)**
+- [ ] Implement comprehensive error handling
+- [ ] Add logging system
+- [ ] Performance testing
+- [ ] Integration testing với BE/FE
+- [ ] Documentation update
+
+---
+
+## 🧪 **Testing Requirements**
+
+### **1. Unit Testing**
+```c
+// Test system_get_status function
+void test_system_get_status(void) {
+    api_system_status_t status;
+    hal_status_t result = system_get_status();
+    
+    TEST_ASSERT_EQUAL(HAL_STATUS_OK, result);
+    TEST_ASSERT_EQUAL_STRING("OHT-50", status.system_name);
+    TEST_ASSERT_EQUAL_STRING("1.0.0", status.version);
+}
+```
+
+### **2. Integration Testing**
+```bash
+# Test HTTP endpoints
+curl -X GET http://localhost:8080/api/v1/system/status
+curl -X GET http://localhost:8080/api/v1/safety/status
+curl -X GET http://localhost:8080/api/v1/modules
+
+# Test WebSocket connection
+wscat -c ws://localhost:8081
+```
+
+### **3. Performance Testing**
+```bash
+# Load testing với multiple clients
+ab -n 1000 -c 10 http://localhost:8080/api/v1/system/status
+```
+
+---
+
+## 📚 **Documentation Requirements**
+
+### **1. API Documentation**
+- Complete API reference với examples
+- Request/response schemas
+- Error codes và messages
+- Authentication/authorization guide
+
+### **2. Integration Guide**
+- Backend integration guide
+- Frontend integration guide
+- WebSocket protocol specification
+- Error handling guidelines
+
+### **3. Deployment Guide**
+- Server configuration
+- Environment setup
+- Monitoring và logging
+- Troubleshooting guide
+
+---
+
+## 🚨 **Risks & Mitigation**
+
+### **1. Performance Risks**
+- **Risk:** High latency với multiple clients
+- **Mitigation:** Implement connection pooling và caching
+
+### **2. Security Risks**
+- **Risk:** Unauthorized access
+- **Mitigation:** Implement authentication/authorization
+
+### **3. Reliability Risks**
+- **Risk:** System crashes due to memory issues
+- **Mitigation:** Implement memory management và error recovery
+
+---
+
+## ✅ **Acceptance Criteria**
+
+### **1. Functional Criteria**
+- [ ] Tất cả API endpoints return real data thay vì mock data
+- [ ] WebSocket server broadcast real-time updates
+- [ ] HTTP server handle concurrent requests
+- [ ] Error handling work correctly
+
+### **2. Performance Criteria**
+- [ ] Response time < 100ms cho GET requests
+- [ ] WebSocket latency < 50ms
+- [ ] Memory usage < 2MB
+- [ ] Support 10+ concurrent connections
+
+### **3. Quality Criteria**
+- [ ] Code coverage > 90%
+- [ ] No memory leaks
+- [ ] Comprehensive error handling
+- [ ] Complete documentation
+
+---
+
+**Changelog v1.0:**
+- ✅ Created API integration specification
+- ✅ Added core system integration requirements
+- ✅ Added HTTP/WebSocket implementation details
+- ✅ Added module-specific endpoints
+- ✅ Added testing và documentation requirements
+- ✅ Added implementation checklist
+
+**🚨 Lưu ý:** Team FW phải implement theo thứ tự Phase 1-5 để đảm bảo stability và functionality.

--- a/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/REQ_CONTROL_LOOP_SPEC.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/REQ_CONTROL_LOOP_SPEC.md
@@ -1,0 +1,84 @@
+# YÊU CẦU CHỨC NĂNG – CONTROL LOOP CORE
+
+Phiên bản: 1.1  
+Ngày cập nhật: 2025-09-09  
+Trạng thái: Draft (điều chỉnh theo kiến trúc mới)
+
+---
+
+## 1) Mục tiêu
+- Điều khiển vận tốc real‑time êm, an toàn cho trục Travel Motor (VELOCITY control).
+- Ước lượng vị trí 1D (x_est) từ IMU + ZUPT + neo RFID; LiDAR phục vụ vùng an toàn/docking.
+- Tuân thủ safety: WARNING → giảm tốc, CRITICAL/E‑STOP → dừng tức thời.
+- Hỗ trợ tiếp cận/dừng chính xác khi docking (LiDAR range‑gate) mà không cần encoder.
+
+## 2) Phạm vi
+- Chỉ lớp Control Loop (thuật toán điều khiển real‑time tại Firmware).
+- Trách nhiệm kiến trúc:
+  - Backend (Planner): lập kế hoạch/segment, tính khoảng cách còn lại (nếu có map), điều phối tốc độ mục tiêu (`v_target`), bật/tắt docking.
+  - Firmware (Control Loop): bám VELOCITY, ước lượng x_est, áp profile v/a/jerk, thực thi safety và docking.
+- Nguồn dữ liệu: IMU, RFID, LiDAR; không sử dụng encoder. Cấm giả lập trong runtime.
+- Loại bỏ các mode: Position, Homing, Torque tại Firmware.
+
+## 3) Yêu cầu chức năng
+- Velocity Control: đạt/giữ `v_target` êm; áp giới hạn `amax/jmax` trước PID vận tốc.
+- Segment Follow: nhận lệnh segment từ Backend (length_mm | x_target_mm, v_max, v_slow, amax, jmax, docking_enabled) và thực thi real‑time.
+- Distance‑Based Speed Policy: nếu có map và `remaining_distance ≤ 2 m` → giảm về `v_slow` theo cấu hình.
+- Safety Policies: WARNING → nhân `warning_speed_factor` với `v_target`; CRITICAL/E‑STOP → output = 0 ngay.
+- RFID Anchoring: khi đọc RFID → neo tuyệt đối cho x_est; nếu `docking_enabled=true` thì chuyển pha dock‑approach.
+- Docking Support: dùng LiDAR range‑gate/cảm biến dock để dừng chính xác (crawl speed, điều kiện ổn định).
+- Telemetry & Diagnostics: xuất trạng thái safety/docking, x_est, v, remaining, counters, thông điệp chẩn đoán.
+
+## 4) Yêu cầu phi chức năng
+- Tần số điều khiển: 200–1000 Hz; dt ổn định.
+- Độ trễ E‑Stop → zero output: < 100 ms (p95).
+- Không rung giật (giới hạn jerk), không vọt lố lớn khi chuyển pha tốc độ.
+
+## 5) Giao diện dữ liệu
+- Input (từ Backend và cảm biến):
+  - `v_target` (mm/s) từ Backend; chính sách tốc độ theo khoảng cách (nếu có map).
+  - Cảm biến: IMU (gia tốc), RFID events (id, chất lượng), LiDAR/dock range.
+  - Config: PID vận tốc, `v_max/v_slow`, `amax/jmax`, `warning_speed_factor`, tham số estimator/docking.
+- Trạng thái nội bộ (Firmware):
+  - `x_est` (mm), `v_current` (mm/s), `remaining_mm` (nếu nhận được đích từ Backend).
+- Output:
+  - `control_output` (chuẩn hóa tới cơ cấu chấp hành), `safety_state`, `docking_state`, `telemetry`/diagnostics.
+
+## 6) Ràng buộc
+- Cấm dùng dữ liệu giả lập trong runtime.
+- Mock chỉ dùng cho unit test với cờ `use_mock=true` + cảnh báo rõ ràng, không đóng gói vào firmware production.
+- Ghi chú loại bỏ mode: Position/Homing/Torque KHÔNG thuộc Firmware; nếu cần, xử lý ở Backend như Planner.
+
+## 7) Tiêu chí chấp nhận
+- Velocity: ổn định ở `v_target` (ví dụ 50 mm/s) với giới hạn jerk/accel; không giật.
+- Safety: WARNING → giảm tốc trong một chu kỳ điều khiển; CRITICAL/E‑STOP → zero output < 100 ms.
+- Distance Policy: còn ≤ 2 m thì giảm về `v_slow` theo cấu hình (nếu có map).
+- RFID: khi chạm thẻ → neo x_est; nếu `docking_enabled=true` → chuyển dock‑approach.
+- Docking: dừng trong cửa sổ sai số đặt, duy trì ổn định trong `dock_stability_time_ms` rồi kết thúc → IDLE.
+- Không sử dụng mock trong runtime; telemetry/diagnostics đầy đủ.
+
+---
+
+## 8) Data Sources & Fallback Matrix
+- Providers & Health
+  - IMU (từ `MODULE_TYPE_DOCK`): freshness_timeout_ms ≤ 100; health = ONLINE
+  - RFID (từ `MODULE_TYPE_DOCK`): event_stale_ms ≤ 2000; health = ONLINE
+  - LiDAR (từ `MODULE_TYPE_SAFETY`): freshness_timeout_ms ≤ 150; health = ONLINE
+  - MOTOR (từ `MODULE_TYPE_TRAVEL_MOTOR`): health = ONLINE
+- Fallback Rules
+  - IMU missing/stale → giảm về `v_slow`; quá timeout → STOP an toàn
+  - RFID missing lâu → tiếp tục nhưng không neo x_est; giới hạn tốc độ/quãng đường theo policy
+  - LiDAR missing → cấm docking; giới hạn tốc độ hoặc STOP theo site policy
+  - MOTOR lỗi → STOP ngay và báo FAULT
+- Policies (tham số hoá)
+  - `warning_speed_factor` ∈ [0.3, 0.7]; `slowdown_distance_m` = 2.0 (khi có map)
+  - `zupt_threshold`, `rfid_anchor_trust`, `imu_bias_update_rate`
+
+---
+
+## 9) Truy vết mã nguồn (tham chiếu)
+- `src/app/core/control_loop.c/.h`
+- `src/app/core/safety_monitor.*` (E‑Stop)
+- `src/app/modules/travel_motor_module_handler.*` (tốc độ/điều khiển)
+- `src/app/managers/communication_manager.*` (Modbus)
+ - `src/app/modules/*` (RFID/LiDAR events nếu có)

--- a/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/README.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/03-REQUIREMENTS/README.md
@@ -1,0 +1,9 @@
+# 02-REQUIREMENTS
+
+Mục tiêu: Yêu cầu hệ thống/phần mềm và giao diện (12207).
+
+- 01-system-requirements/
+- 02-software-requirements/
+- 03-interface-requirements/
+
+Ghi chú: Tham chiếu ánh xạ từ `../ISO12207_MAPPING.md`.

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/API_INTEGRATION_IMPLEMENTATION_PLAN.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/API_INTEGRATION_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,173 @@
+#️⃣ Phần dưới giữ lại (ngắn gọn, thực thi ngay)
+#
+**Phiên bản:** 2.0.0  
+**Ngày cập nhật:** 2025-01-28  
+**Team:** FW  
+**Ưu tiên:** CRITICAL
+
+## 🎯 Mục tiêu & Phạm vi (rút gọn)
+- HTTP REST API + WS theo kiến trúc dự án (FW làm gateway HTTP, không RS485 trực tiếp từ BE)
+- Wiring trực tiếp vào `system_controller`, `safety_monitor`, `control_loop`, `system_state_machine`
+- Không dùng mock trong production paths; đáp ứng p95 < 100ms
+
+## 🧭 Endpoint Matrix (P0/P1/P2)
+## 🧭 Endpoint Matrix (P0/P1/P2) – bám sát core hiện tại
+
+### P0 (ship ngay)
+- `GET /api/v1/system/status` — map `system_controller_get_status`
+- `GET /api/v1/safety/status` — map `safety_monitor_get_status`
+- `POST /api/v1/safety/estop` — map `safety_monitor_trigger_emergency_stop`
+- `GET /api/v1/modules` — map `module_manager_list`
+- `GET /api/v1/modules/{id}/status` — map `module_manager_get_status_by_id`
+- `GET /api/v1/system/state` — map `system_state_machine_get_status`
+- `GET /api/v1/control/status` — map `control_loop_get_status` + `control_loop_get_stats`
+
+### P1 (tăng giá trị vận hành)
+- `GET /api/v1/system/health` — map `system_controller_get_performance` + counters
+- `GET /api/v1/telemetry/current` — snapshot (system/safety/control)
+- `POST /api/v1/safety/reset` — map `safety_monitor_reset`
+- `GET /api/v1/safety/zones` — map `safety_monitor_get_basic_zones`
+- `POST /api/v1/control/mode` — map `control_loop_set_mode`
+- `POST /api/v1/control/target` — map `control_loop_set_target_position` / `control_loop_set_target_velocity`
+
+### P2 (module chuyên sâu + chẩn đoán + WS)
+- `GET /api/v1/modules/power/status` — điện/battery/charge (theo REQ_POWER_MODULE)
+- `GET /api/v1/modules/motor/status` — mode, pos/vel/fault
+- `GET /api/v1/modules/dock/status` — align/ready/charging
+- `GET /api/v1/diagnostics/summary` — tổng hợp lỗi/counters
+- `GET /api/v1/diagnostics/safety` — map `safety_monitor_run_diagnostics`
+- `GET /api/v1/diagnostics/state` — map `system_state_machine_get_diagnostics`
+- `GET /api/v1/diagnostics/control` — map `control_loop_get_diagnostics`
+- `WS /ws/telemetry` — broadcast `system.status` mỗi 1s
+
+Lý do: wiring trực tiếp vào `system_controller`, `safety_monitor`, `control_loop`, `system_state_machine` giúp triển khai nhanh, không chạm RS485 từ backend, đáp ứng mục tiêu Performance/Safety (<50–100ms) và mở rộng tuần 2 cho perf/WS/security nhẹ.
+
+---
+
+## 📊 Progress Tracker (FW team)
+
+| Endpoint | Priority | Owner | Status | Due | Notes |
+|---|---|---|---|---|---|
+| GET /api/v1/system/status | P0 | FW-Dev#1 | Planned | W1-D3 | Map `system_controller_get_status` |
+| GET /api/v1/safety/status | P0 | FW-Dev#2 | Planned | W1-D3 | E‑Stop, zones, watchdog |
+| POST /api/v1/safety/estop | P0 | FW-Dev#2 | Planned | W1-D2 | Guarded emergency |
+| GET /api/v1/modules | P0 | FW-Dev#3 | Planned | W1-D4 | Discovery list (real) |
+| GET /api/v1/modules/{id}/status | P0 | FW-Dev#3 | Planned | W1-D4 | ID parse + status |
+| GET /api/v1/system/state | P0 | FW-Dev#1 | Planned | W1-D3 | State machine |
+| GET /api/v1/control/status | P0 | FW-Dev#4 | Planned | W1-D5 | pos/vel/error/output |
+| GET /api/v1/system/health | P1 | FW-Dev#1 | Pending | W2-D2 | perf + counters |
+| GET /api/v1/telemetry/current | P1 | FW-Dev#5 | Pending | W2-D2 | snapshot serializer |
+| POST /api/v1/safety/reset | P1 | FW-Dev#2 | Pending | W2-D1 | require HW released |
+| GET /api/v1/safety/zones | P1 | FW-Dev#2 | Pending | W2-D1 | thresholds export |
+| POST /api/v1/control/mode | P1 | FW-Dev#4 | Pending | W2-D2 | guard transitions |
+| POST /api/v1/control/target | P1 | FW-Dev#4 | Pending | W2-D3 | limits/validation |
+| modules power/motor/dock | P2 | FW-Dev#3 | Backlog | W3-W4 | per-module handlers |
+| diagnostics/* | P2 | FW-Dev#1 | Backlog | W3-W4 | summarize + details |
+| WS /ws/telemetry | P2 | FW-Dev#5 | Backlog | W3 | 1s broadcast system.status |
+
+Ghi chú vận hành:
+- P0 phải có dữ liệu thật (no mock). P1 bổ sung health và control setting có guard. P2 mở rộng module/diag và WS cho realtime UI.
+
+---
+
+## ⚡ Minimal API v1 - 2-week execution (rút gọn)
+
+### 🎯 Goal (scope minimized, production-ready core)
+- REST (minimal):
+  - GET `/api/v1/system/status`
+  - GET `/api/v1/safety/status`, POST `/api/v1/safety/estop`
+  - GET `/api/v1/modules`, GET `/api/v1/modules/{id}/status`
+- WebSocket (optional in Week 2): `/ws/telemetry` broadcasting `system.status` only
+- Non-goals (postpone to v2): advanced config, diagnostics, module-specific deep endpoints, complex auth.
+
+### 📅 Week 1
+- Build & Tests
+  - [ ] Fix linker issues (CMake toolchain, libs) – build green
+  - [ ] Enable unit + basic integration tests to run
+  - [ ] Remove all mock usage in production paths (mocks only under tests)
+- API Surface (HTTP only)
+  - [ ] Implement 4 minimal endpoints above in `api_manager`
+  - [ ] Wire to services: `system_controller`, `safety_monitor`, `module_manager`
+  - [ ] Input validation (basic), JSON responses unified
+- Ops
+  - [ ] Health check: confirm :8080 listening, endpoints <100ms p95 (local)
+  - [ ] Logging: request line + status, errors
+
+Deliverables
+- [ ] Minimal API v1 spec (this section) locked
+- [ ] Short ADR: API Surface v1 (Minimal) + Gateway layering
+
+Acceptance (exit Week 1)
+- [ ] Build green; unit/integration smoke pass
+- [ ] 4 endpoints return real data (no mock)
+- [ ] p95 GET latency < 100ms (bench local)
+
+### 📅 Week 2
+- Reliability & Perf
+  - [ ] Error handling paths completed (timeouts, not-found, invalid)
+  - [ ] Basic rate-limit or debounce where needed (lightweight)
+  - [ ] Perf log sampling for slow requests (>100ms)
+- WebSocket (optional, if Week 1 stable)
+  - [ ] `/ws/telemetry` broadcasting `system.status` every 1s
+  - [ ] Client mgmt + backpressure-safe send
+- Security (minimal)
+  - [ ] Simple token header gate (env-config), dev default disabled
+  - [ ] Sanitize/limit request body sizes
+
+Deliverables
+- [ ] Bench doc: p95 latency HTTP, WS latency if enabled (<50ms local)
+- [ ] Update runbook: start/stop, ports, health-check curl, wscat
+
+Acceptance (exit Week 2)
+- [ ] All Week 1 criteria sustained
+- [ ] Errors well-formed JSON; no crash under 1h soak
+- [ ] Optional: WS stable with 2 clients for 30m
+
+### ⏱️ Daily tracking checklist
+- Build & tests
+  - [ ] Build green today
+  - [ ] Unit tests executed
+  - [ ] Integration smoke executed
+- API health
+  - [ ] /system/status <100ms p95
+  - [ ] /safety/status <100ms p95
+  - [ ] /modules <100ms p95
+  - [ ] /modules/{id}/status <100ms p95
+- Quality
+  - [ ] No mock in prod paths
+  - [ ] Error logs < threshold; no unhandled exceptions
+
+### 🔗 File/code touch points
+- `src/app/api/api_manager.c` – register only minimal endpoints, unify responses
+- `src/app/managers/{module_manager, safety_manager, telemetry_manager}.c` – service calls
+- `src/app/core/{system_controller, safety_monitor}.c` – read-only status hooks
+- `tests/` – enable unit/integration smoke for endpoints, safety
+- `docs/` – ADR + runbook + bench notes
+
+### 🧪 Validation commands
+```bash
+curl -s http://localhost:8080/api/v1/system/status | jq .
+curl -s http://localhost:8080/api/v1/safety/status | jq .
+curl -s http://localhost:8080/api/v1/modules | jq .
+curl -s http://localhost:8080/api/v1/modules/1/status | jq .
+# optional WS
+wscat -c ws://localhost:8081/ws/telemetry
+```
+
+### 📌 Risks & guards (for this fast-track)
+- Scope creep → hard-freeze to 4 endpoints + 1 WS topic
+- Perf regressions → track p95 daily, log >100ms
+- Hidden mocks → CI gate to disallow mock symbols in prod build
+
+---
+
+**🚨 Lưu ý:** Plan này phải được thực hiện tuần tự, không được bỏ qua phase nào. Mỗi phase phải hoàn thành 100% trước khi chuyển sang phase tiếp theo.
+
+**🔗 PROJECT INTEGRATION:** Đã align với Project SLC Planning. Scope giữ tối thiểu để ship nhanh.
+
+---
+
+**Changelog v2.0.0 (rút gọn):**
+- ✅ Thêm Endpoint Matrix P0/P1/P2 + Progress Tracker
+- ✅ Khóa Minimal API v1 (2 tuần) + checklist/commands
+- ✅ Lược bỏ mô tả phase dài, risk verbose, timeline chi tiết

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/CONTROL_LOOP_EXEC_PLAN.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/CONTROL_LOOP_EXEC_PLAN.md
@@ -1,0 +1,151 @@
+# KẾ HOẠCH THỰC THI (EXEC PLAN) – CONTROL LOOP CORE
+
+Phiên bản: 1.0  
+Ngày cập nhật: 2025-09-09  
+Trạng thái: Approved for Execution
+
+---
+
+## 1) 🎯 Mục tiêu
+- Chuyển Control Loop sang kiến trúc: VELOCITY + estimator 1D (IMU + ZUPT + RFID), LiDAR cho safety/docking.
+- Loại bỏ Position/Homing/Torque ở Firmware; Position do Backend điều phối (segment). 
+- Đảm bảo an toàn: WARNING → giảm tốc; CRITICAL/E‑STOP → dừng < 100 ms (p95).
+
+## 2) 🧭 Phạm vi & Kiến trúc (Compliance bắt buộc)
+- Firmware: real‑time control, safety monitor, estimator 1D, docking logic (LiDAR gate), không dùng mock runtime.
+- Backend: Planner/segment + map, tính remaining_distance, quyết định v_max/v_slow, bật/tắt docking (HTTP API). 
+- RS485/Modbus chỉ do Firmware giao tiếp với module (KHÔNG Backend). 
+- Tuân thủ: OHT-50 Backend Rules (HTTP/REST), Security by Design, Performance targets.
+
+## 3) 📦 Deliverables
+1) Cập nhật tài liệu (đã xong): REQ v1.1, PLAN v1.1, DEV GUIDE v1.1 + Fallback Matrix.  
+2) Thực thi trên Firmware: 
+   - VELOCITY control + amax/jmax
+   - Estimator 1D: IMU + ZUPT + neo RFID
+   - Safety policies: WARNING/CRITICAL
+   - Docking bằng LiDAR (range‑gate + ổn định thời gian)
+   - API HTTP: segment/start, segment/stop, motion/state
+3) Bộ test: Unit/Integration/Field + báo cáo latency E‑Stop.
+
+## 4) 🛠️ Công việc chi tiết theo GATE
+- Gate A – Clean up modes (0.5 ngày)
+  - Remove Position/Homing/Torque khỏi config/tài liệu runtime; giữ Emergency.
+  - Bật cờ cảnh báo nếu bản build còn đường dẫn mock (fail build).
+
+- Gate B – Estimator 1D (2 ngày)
+  - Tích hợp IMU (lọc, tích phân hạn chế), ZUPT khi v≈0. 
+  - RFID anchoring: cập nhật x_est theo `rfid_anchor_trust`; log trước/sau neo.
+  - Freshness/health checks theo Fallback Matrix.
+
+- Gate C – VELOCITY + Profile (1 ngày)
+  - Áp `amax/jmax` trước PID; xử lý chuyển pha v_max→v_slow khi `remaining ≤ 2 m` (nếu có map).
+  - WARNING → `warning_speed_factor` nhân vào v_target; CRITICAL → zero output ngay.
+
+- Gate D – Docking (1.5 ngày)
+  - Dock‑approach: crawl speed; LiDAR range‑gate; điều kiện ổn định `dock_stability_time_ms` → dừng.
+  - Block docking nếu thiếu LiDAR hoặc health≠ONLINE.
+
+- Gate E – API & Telemetry (1 ngày)
+  - HTTP: POST /api/v1/motion/segment/start|stop; GET /api/v1/motion/state.
+  - Telemetry: x_est, v, remaining, safety_state, docking_state, freshness/health.
+
+- Gate F – Test & Handover (1 ngày)
+  - Unit/Integration: safety policies, fallback paths, API. 
+  - Field test: segment dài + giảm tốc 2 m; RFID neo; docking; E‑Stop latency.
+  - Báo cáo: KPI, logs, đồ thị.
+
+## 5) ⏱️ Timeline đề xuất
+- Tổng: ~7 ngày làm việc. Có thể rút ngắn khi chạy song song B/C với D.
+
+## 6) 👥 Phân công (RACI)
+- Dev1: Estimator 1D (IMU, ZUPT, RFID), Fallback checks.  
+- Dev2: VELOCITY + amax/jmax, WARNING/CRITICAL policies.  
+- Dev3: Docking + LiDAR gate + ổn định.  
+- Dev4: HTTP API + Telemetry.  
+- QA: Test plan + đo latency, fault injection (CRC/timeout).  
+- Lead: Review kiến trúc, đảm bảo compliance, merge.
+
+## 7) ⚙️ Cấu hình chuẩn (tham chiếu)
+- v_max_mm_s, v_slow_mm_s, amax_mm_s2, jmax_mm_s3
+- slowdown_distance_m=2.0; warning_speed_factor∈[0.3,0.7]
+- zupt_threshold; rfid_anchor_trust; imu_bias_update_rate
+- docking_enabled; dock_crawl_speed_mm_s; lidar_gate_range_mm; dock_stability_time_ms
+
+## 8) 🔬 Test Plan (tóm tắt)
+- Unit: PID vận tốc, limiter v/a/jerk, chuyển pha v, policies WARNING/CRITICAL.
+- Integration: IMU freshness, RFID anchoring, LiDAR gate; API start/stop/state.
+- Field: 
+  - Segment 10 m → tự giảm tốc 2 m; dừng an toàn.
+  - WARNING stress → giảm tốc trong 1 chu kỳ; CRITICAL → zero<100 ms.
+  - RFID neo: kiểm tra sai số x_est trước/sau thẻ.
+  - Docking: dừng trong cửa sổ sai số + ổn định thời gian.
+
+## 9) 🧩 Data Sources & Fallback Matrix (thi hành)
+- Providers: IMU (DOCK), RFID (DOCK), LiDAR (SAFETY), MOTOR (TRAVEL_MOTOR)
+- Freshness: IMU≤100 ms; LiDAR≤150 ms; RFID stale≤2000 ms; Health=ONLINE
+- Fallback:
+  - IMU stale → v_slow; quá timeout → STOP
+  - RFID thiếu → chạy giới hạn, không neo x_est
+  - LiDAR lỗi → cấm docking; limit speed/STOP
+  - MOTOR lỗi → STOP ngay; báo FAULT
+
+## 10) ⚠️ Rủi ro & Rollback
+- Drift IMU khi thiếu RFID lâu → ZUPT/neo định kỳ; giới hạn v/quãng; cảnh báo Backend.
+- LiDAR nhiễu → range‑gate + trung bình trượt; block docking khi không chắc chắn.
+- Mất lệnh Backend → policy giữ tốc an toàn/fall back; watchdog kênh HTTP.
+- Rollback: giữ nhánh release trước; flag tắt docking; hạ chuẩn tốc độ toàn hệ.
+
+## 11) 📈 KPI & Chất lượng
+- E‑Stop: <100 ms (p95); WARNING: điều chỉnh v trong 1 chu kỳ.
+- Drift sau neo RFID: giảm rõ rệt so với trước neo (log/đồ thị).
+- Docking: đạt cửa sổ sai số + ổn định thời gian.
+- Không mock trong runtime; logs/telemetry đầy đủ.
+
+## 12) 🚫 Nghiêm cấm & Compliance
+- Cấm giả lập dữ liệu trong runtime. 
+- Backend không giao tiếp RS485; chỉ HTTP/REST tới Firmware.
+- Bất kỳ vi phạm → chặn merge.
+
+## 13) ✅ Checklist bàn giao
+- [ ] VELOCITY + estimator 1D chạy ổn định; không mock runtime
+- [ ] WARNING/CRITICAL đạt KPI; E‑Stop < 100 ms
+- [ ] Docking hoạt động; block khi LiDAR lỗi
+- [ ] API segment/state OK; Telemetry đủ
+- [ ] Báo cáo test + logs + đồ thị
+- [ ] Tài liệu cập nhật (REQ/PLAN/DEV GUIDE/EXEC PLAN)
+
+## 14) 📚 Truy vết tài liệu
+- REQ: `docs/03-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/REQ_CONTROL_LOOP_SPEC.md` (v1.1)
+- PLAN: `docs/04-SLC/01-planning/CONTROL_LOOP_IMPLEMENTATION_PLAN.md` (v1.1)
+- DEV GUIDE: `docs/02-HAL/CONTROL_LOOP_DEV_GUIDE.md` (v1.1)
+- EXEC PLAN: tài liệu hiện tại
+
+---
+
+## 15) 📣 Hướng dẫn vận hành (bắt buộc, khẩn)
+
+- Lệnh tạm dừng phát triển: Dừng toàn bộ feature mới cho đến khi hoàn tất toàn bộ Gate A→F theo kế hoạch này. Mọi thay đổi ngoài phạm vi phải được Lead approve.
+- Báo cáo tiến độ: Mỗi ngày 2 lần (10:00, 17:00) gửi báo cáo ngắn: Gate đang làm, kết quả/risks, kế hoạch 24h tiếp theo.
+- Chặn mock runtime: Build sẽ FAIL nếu phát hiện ký tự "mock_" trong mã nguồn runtime `src/`. Unit/integration test có thể giữ mock trong `tests/`.
+
+## 16) 🔌 API đã bật (Gate E)
+
+- POST `/api/v1/motion/segment/start` → Bật control VELOCITY, bắt đầu segment hiện tại.
+- POST `/api/v1/motion/segment/stop` → Dừng an toàn, đặt tốc độ mục tiêu 0.
+- GET `/api/v1/motion/state` → Trả về: `x_est`, `v`, `remaining`, `safety.{estop,p95}`, `docking`, `freshness`.
+
+Ghi chú: `remaining` và `map` do Backend xác định; FW cung cấp `x_est`, `v`, trạng thái an toàn và docking. Khi có LiDAR/estimator đầy đủ, FW sẽ bổ sung freshness theo Fallback Matrix.
+
+## 17) 📑 QA – Chỉ số cần đo và nộp
+
+- E‑Stop p95 < 100 ms (log + đồ thị).  
+- WARNING: điều chỉnh tốc độ trong 1 chu kỳ control.  
+- Báo cáo drift trước/sau neo RFID (bảng + đồ thị).  
+- Docking: ổn định theo cấu hình `dock_stability_time_ms` và cờ health LiDAR.
+
+## 18) 📦 Điều kiện bàn giao bổ sung
+
+- Hoàn thành toàn bộ checklist mục 13.  
+- Đính kèm log, đồ thị, và báo cáo QA theo mục 17.  
+- Xác nhận build guard mock hoạt động (screenshot lỗi khi chèn `mock_` thử nghiệm vào `src/`).
+

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/CONTROL_LOOP_IMPLEMENTATION_PLAN.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/CONTROL_LOOP_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,82 @@
+# KẾ HOẠCH TRIỂN KHAI – CONTROL LOOP CORE
+
+Phiên bản: 1.1  
+Ngày cập nhật: 2025-09-09  
+Trạng thái: Draft (điều chỉnh theo kiến trúc VELOCITY + estimator)
+
+---
+
+## 1) Mục tiêu
+- Gỡ toàn bộ giả lập; dùng dữ liệu thật từ IMU/RFID/LiDAR, tốc độ/điều khiển Motor.
+- Chỉ giữ VELOCITY control + estimator 1D; hỗ trợ docking; E‑Stop < 100 ms.
+- Loại bỏ Position/Homing/Torque ở Firmware; Position được xử lý ở Backend (Planner/segment).
+
+## 2) Phạm vi
+- Control Loop (FW): VELOCITY, estimator 1D (IMU + ZUPT + RFID anchor), chính sách tốc độ theo khoảng cách, docking bằng LiDAR.
+- Backend: gửi segment và tham số tốc độ, bật/tắt docking, tính remaining_distance khi có map.
+- Không thay đổi giao thức thiết bị; chỉ bổ sung API FW↔BE ở layer HTTP.
+
+## 3) Công việc chính (theo thứ tự)
+1. Loại bỏ mode không cần thiết
+   - Remove: Position/Homing/Torque ở tài liệu và cấu hình; giữ Emergency.
+2. Estimator 1D (IMU + RFID + ZUPT)
+   - Tích hợp IMU để ước lượng vận tốc/vị trí (tích phân có ràng buộc), ZUPT để reset drift khi đứng yên.
+   - Neo RFID: khi đọc thẻ → cập nhật x_est tuyệt đối, lọc theo `rfid_anchor_trust`.
+3. VELOCITY control + profile
+   - Áp `amax/jmax` trước PID; hỗ trợ chuyển pha v_max → v_slow khi gần đích (theo remaining_distance do Backend cung cấp).
+4. Safety & Policies
+   - Vòng kiểm tra E‑Stop/safety mỗi chu kỳ; WARNING → `warning_speed_factor`; CRITICAL → zero ngay.
+5. Docking bằng LiDAR
+   - Dock‑approach: đặt tốc crawl; dùng range‑gate và điều kiện ổn định `dock_stability_time_ms` trước khi dừng.
+6. API FW↔BE
+   - POST /api/v1/motion/segment/start { length_mm | x_target_mm, v_max_mm_s, v_slow_mm_s, amax_mm_s2, jmax_mm_s3, docking_enabled }
+   - POST /api/v1/motion/segment/stop
+   - GET /api/v1/motion/state → { x_est_mm, v_mm_s, remaining_mm, safety_state, docking_state }
+7. Telemetry/Diagnostics & Stats
+   - Xuất x_est, v, safety/docking, counters; log chẩn đoán ngắn gọn.
+8. Cấu hình an toàn khởi đầu
+   - `v_max_mm_s`, `v_slow_mm_s`, `amax_mm_s2`, `jmax_mm_s3`, `warning_speed_factor`, `zupt_threshold`, `rfid_anchor_trust`, `dock_crawl_speed_mm_s`, `lidar_gate_range_mm`, `dock_stability_time_ms`.
+
+## 4) KPI & SLO
+- Velocity: giữ `v_target` êm (vd 50 mm/s), không giật, tuân `amax/jmax`.
+- Safety: WARNING phản ứng trong 1 chu kỳ; CRITICAL/E‑STOP < 100 ms (p95).
+- Docking: dừng trong cửa sổ sai số cấu hình, ổn định trước hoàn tất.
+
+## 5) Kiểm thử
+- Unit: PID vận tốc, giới hạn v/a/jerk, safety policies, logic giảm tốc 2 m.
+- Integration: IMU/RFID event path, LiDAR docking gate, API segment/state.
+- Field test: segment dài có giảm tốc 2 m; WARNING/CRITICAL; RFID neo; docking.
+
+## 6) Rủi ro & biện pháp
+- Drift IMU khi không có RFID lâu → ZUPT/neo định kỳ, giám sát sai lệch, fail‑safe giảm tốc/dừng.
+- Mất gói API Backend → giữ tốc độ an toàn theo policy; watchdog kênh lệnh.
+- LiDAR nhiễu → range‑gate + trung bình trượt + điều kiện ổn định thời gian.
+
+## 7) Checklist bàn giao
+- [ ] Loại bỏ Position/Homing/Torque khỏi Firmware (tài liệu/cấu hình)
+- [ ] VELOCITY + estimator 1D hoạt động; không giả lập runtime
+- [ ] Safety: WARNING/CRITICAL đạt KPI; E‑Stop < 100 ms
+- [ ] Docking bằng LiDAR đạt tiêu chí ổn định
+- [ ] API segment/state hoạt động
+- [ ] Telemetry/Diagnostics đầy đủ
+- [ ] Tài liệu cập nhật
+
+---
+
+## 8) Data Sources & Fallback Matrix (kế hoạch áp dụng)
+- Mapping providers
+  - IMU: từ `MODULE_TYPE_DOCK` (DOCK & Location)
+  - RFID: từ `MODULE_TYPE_DOCK`
+  - LiDAR: từ `MODULE_TYPE_SAFETY`
+  - MOTOR: từ `MODULE_TYPE_TRAVEL_MOTOR`
+- Freshness & Health
+  - imu.freshness_timeout_ms=100; lidar.freshness_timeout_ms=150; rfid.event_stale_ms=2000
+  - health phải = ONLINE; nếu WARNING → áp `warning_speed_factor`
+- Fallback hành động
+  - IMU stale → v=v_slow; nếu quá timeout → STOP
+  - RFID thiếu → chạy giới hạn; không docking theo RFID
+  - LiDAR lỗi → cấm docking; limit speed hoặc STOP
+  - MOTOR lỗi → STOP ngay
+- QA Tasks
+  - Test latency safety p95; fault injection (CRC/timeouts)
+  - Verify policy chuyển trạng thái (SAFE→WARNING→CRITICAL)

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/FW_APP_IMPLEMENTATION_PLAN.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/FW_APP_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,652 @@
+# 🚀 **OHT-50 FIRMWARE APP IMPLEMENTATION PLAN**
+
+**Phiên bản:** 1.0  
+**Ngày tạo:** 2025-01-28  
+**Người tạo:** CTO Team  
+**Trạng thái:** ✅ APPROVED - Ready for Implementation  
+**Mục tiêu:** Kế hoạch triển khai cấu trúc firmware app an toàn và đạt chuẩn
+
+---
+
+## 🎯 **TỔNG QUAN TRIỂN KHAI**
+
+### **Nguyên tắc triển khai:**
+1. **Safety-First Implementation** - An toàn là ưu tiên tuyệt đối
+2. **Incremental Development** - Phát triển từng bước có kiểm soát
+3. **Continuous Testing** - Kiểm thử liên tục trong quá trình phát triển
+4. **Quality Gates** - Cổng kiểm soát chất lượng nghiêm ngặt
+5. **Documentation-Driven** - Tài liệu hóa đầy đủ mọi thay đổi
+
+---
+
+## 📋 **PHASE IMPLEMENTATION ROADMAP**
+
+### **Phase 1: Foundation & Safety (Weeks 1-4)**
+**Mục tiêu:** Xây dựng nền tảng an toàn và cấu trúc cơ bản
+
+#### **Week 1-2: Core Foundation**
+- [ ] **Project Structure Setup**
+  - [ ] Tạo cấu trúc thư mục theo kiến trúc 4-layer
+  - [ ] Setup CMake build system
+  - [ ] Configure development environment
+  - [ ] Setup version control và CI/CD
+
+- [ ] **Safety Layer Implementation**
+  - [ ] E-Stop system với response time < 100ms
+  - [ ] Safety interlock system
+  - [ ] Watchdog system với timeout 1s
+  - [ ] Emergency procedures
+  - [ ] Safety state machine
+
+#### **Week 3-4: HAL Layer**
+- [ ] **Hardware Abstraction Layer**
+  - [ ] RS485 HAL implementation
+  - [ ] GPIO HAL implementation
+  - [ ] Network HAL implementation
+  - [ ] LED HAL implementation
+  - [ ] Relay HAL implementation
+
+- [ ] **Driver Layer**
+  - [ ] Orange Pi 5B platform drivers
+  - [ ] RK3588 SoC drivers
+  - [ ] UART driver implementation
+  - [ ] GPIO driver implementation
+
+#### **Deliverables Phase 1:**
+- ✅ Complete project structure
+- ✅ Safety system implementation
+- ✅ HAL layer implementation
+- ✅ Driver layer implementation
+- ✅ Unit tests cho tất cả modules
+- ✅ Safety validation tests
+
+### **Phase 2: Application Layer (Weeks 5-8)**
+**Mục tiêu:** Triển khai logic ứng dụng và quản lý module
+
+#### **Week 5-6: Core Application**
+- [ ] **Application Controller**
+  - [ ] Main application controller
+  - [ ] System state machine
+  - [ ] Control loop implementation
+  - [ ] System coordination
+
+- [ ] **Module Management**
+  - [ ] Power module handler
+  - [ ] Safety module handler
+  - [ ] Motor module handler
+  - [ ] Dock module handler
+
+#### **Week 7-8: Communication & API**
+- [ ] **Communication Systems**
+  - [ ] HTTP API server implementation
+  - [ ] Modbus RTU handler
+  - [ ] Telemetry system
+  - [ ] Real-time communication
+
+- [ ] **Configuration Management**
+  - [ ] Configuration manager
+  - [ ] Configuration storage
+  - [ ] Configuration validation
+  - [ ] Dynamic configuration updates
+
+#### **Deliverables Phase 2:**
+- ✅ Application layer implementation
+- ✅ Module management system
+- ✅ Communication systems
+- ✅ API server implementation
+- ✅ Configuration management
+- ✅ Integration tests
+
+### **Phase 3: Integration & Testing (Weeks 9-12)**
+**Mục tiêu:** Tích hợp toàn bộ hệ thống và kiểm thử
+
+#### **Week 9-10: System Integration**
+- [ ] **End-to-End Integration**
+  - [ ] Application ↔ Safety layer integration
+  - [ ] Safety ↔ HAL layer integration
+  - [ ] HAL ↔ Driver layer integration
+  - [ ] Complete system integration
+
+- [ ] **Performance Optimization**
+  - [ ] Real-time performance tuning
+  - [ ] Memory optimization
+  - [ ] CPU usage optimization
+  - [ ] Network latency optimization
+
+#### **Week 11-12: Testing & Validation**
+- [ ] **Comprehensive Testing**
+  - [ ] Unit tests (90%+ coverage)
+  - [ ] Integration tests
+  - [ ] Safety tests
+  - [ ] Performance tests
+  - [ ] HIL (Hardware-in-the-Loop) tests
+
+- [ ] **Safety Validation**
+  - [ ] SIL 2 compliance validation
+  - [ ] E-Stop response time validation
+  - [ ] Safety interlock validation
+  - [ ] Emergency procedure validation
+
+#### **Deliverables Phase 3:**
+- ✅ Complete system integration
+- ✅ Performance optimization
+- ✅ Comprehensive testing
+- ✅ Safety validation
+- ✅ Production-ready firmware
+
+---
+
+## 🛡️ **SAFETY IMPLEMENTATION STRATEGY**
+
+### **1. Safety-First Development Process**
+```c
+// Safety development workflow
+1. Safety Requirements Analysis
+2. Safety Architecture Design
+3. Safety Implementation
+4. Safety Testing
+5. Safety Validation
+6. Safety Documentation
+```
+
+### **2. Safety Critical Functions**
+```c
+// E-Stop System Implementation
+int estop_system_init(void) {
+    // Initialize hardware E-Stop
+    gpio_hal_configure_estop();
+    
+    // Initialize software E-Stop
+    software_estop_init();
+    
+    // Initialize network E-Stop
+    network_estop_init();
+    
+    // Initialize safety zone E-Stop
+    safety_zone_estop_init();
+    
+    return SAFETY_OK;
+}
+
+// E-Stop Response (CRITICAL: < 100ms)
+int estop_emergency_response(void) {
+    uint32_t start_time = get_system_time_ms();
+    
+    // 1. Hardware E-Stop (highest priority)
+    if (hardware_estop_active()) {
+        gpio_hal_emergency_off_all();
+        relay_hal_emergency_off_all();
+        motor_hal_emergency_stop();
+        return SAFETY_ESTOP_HARDWARE;
+    }
+    
+    // 2. Software E-Stop
+    if (software_estop_triggered()) {
+        motor_hal_emergency_stop();
+        return SAFETY_ESTOP_SOFTWARE;
+    }
+    
+    // 3. Safety zone violation
+    if (safety_zone_violated()) {
+        motor_hal_emergency_stop();
+        return SAFETY_ESTOP_ZONE;
+    }
+    
+    // Validate response time
+    uint32_t response_time = get_system_time_ms() - start_time;
+    if (response_time > 100) {
+        log_critical_error("E-Stop response time exceeded: %dms", response_time);
+        return SAFETY_ERROR_TIMEOUT;
+    }
+    
+    return SAFETY_OK;
+}
+```
+
+### **3. Safety Testing Strategy**
+```c
+// Safety test framework
+int safety_test_estop_response_time(void) {
+    uint32_t start_time = get_system_time_ms();
+    int result = estop_emergency_response();
+    uint32_t response_time = get_system_time_ms() - start_time;
+    
+    // Assert response time < 100ms
+    assert(response_time < 100);
+    assert(result == SAFETY_OK);
+    
+    return TEST_PASS;
+}
+
+int safety_test_estop_hardware(void) {
+    // Simulate hardware E-Stop
+    gpio_hal_simulate_estop();
+    
+    // Test E-Stop response
+    int result = estop_emergency_response();
+    
+    // Assert E-Stop triggered
+    assert(result == SAFETY_ESTOP_HARDWARE);
+    
+    return TEST_PASS;
+}
+```
+
+---
+
+## ⚡ **REAL-TIME IMPLEMENTATION STRATEGY**
+
+### **1. Real-Time Constraints**
+```c
+// Real-time requirements
+#define CONTROL_LOOP_CYCLE_MS     10    // 10ms control loop
+#define SAFETY_CHECK_CYCLE_MS     5     // 5ms safety check
+#define COMMUNICATION_TIMEOUT_MS   50    // 50ms communication timeout
+#define ESTOP_RESPONSE_TIME_MS    100   // 100ms E-Stop response
+#define WATCHDOG_TIMEOUT_MS       1000  // 1s watchdog timeout
+```
+
+### **2. Real-Time Implementation**
+```c
+// Real-time control loop
+void control_loop_task(void) {
+    static uint32_t last_cycle_time = 0;
+    uint32_t current_time = get_system_time_ms();
+    
+    // Ensure 10ms cycle time
+    if (current_time - last_cycle_time < CONTROL_LOOP_CYCLE_MS) {
+        return; // Too early for next cycle
+    }
+    
+    // Update cycle time
+    last_cycle_time = current_time;
+    
+    // Execute control logic
+    control_loop_execute();
+    
+    // Update safety status
+    safety_monitor_check();
+    
+    // Send telemetry
+    telemetry_send_update();
+}
+
+// Real-time safety check
+void safety_check_task(void) {
+    static uint32_t last_safety_time = 0;
+    uint32_t current_time = get_system_time_ms();
+    
+    // Ensure 5ms safety check cycle
+    if (current_time - last_safety_time < SAFETY_CHECK_CYCLE_MS) {
+        return;
+    }
+    
+    // Update safety check time
+    last_safety_time = current_time;
+    
+    // Execute safety checks
+    safety_monitor_check();
+    estop_system_check();
+    safety_interlock_check();
+    watchdog_feed();
+}
+```
+
+---
+
+## 🔒 **SECURITY IMPLEMENTATION STRATEGY**
+
+### **1. Security Architecture**
+```c
+// Security implementation
+typedef struct {
+    char token[256];
+    uint32_t expiry_time;
+    uint8_t user_id;
+    uint8_t permissions;
+    bool valid;
+} security_context_t;
+
+// Security functions
+int security_validate_token(const char *token) {
+    // Validate Bearer token
+    if (!token || strlen(token) < 10) {
+        return SECURITY_ERROR_INVALID_TOKEN;
+    }
+    
+    // Check token format
+    if (strncmp(token, "Bearer ", 7) != 0) {
+        return SECURITY_ERROR_INVALID_FORMAT;
+    }
+    
+    // Validate token signature
+    if (!validate_token_signature(token + 7)) {
+        return SECURITY_ERROR_INVALID_SIGNATURE;
+    }
+    
+    return SECURITY_OK;
+}
+
+int security_check_permissions(uint8_t user_id, uint8_t operation) {
+    // Check user permissions
+    if (!user_has_permission(user_id, operation)) {
+        return SECURITY_ERROR_INSUFFICIENT_PERMISSIONS;
+    }
+    
+    return SECURITY_OK;
+}
+```
+
+### **2. Secure Communication**
+```c
+// Secure communication implementation
+int secure_communication_init(void) {
+    // Initialize TLS 1.3
+    tls_context_t tls_ctx;
+    if (tls_init(&tls_ctx) != TLS_OK) {
+        return SECURITY_ERROR_TLS_INIT;
+    }
+    
+    // Configure secure ciphers
+    if (tls_configure_ciphers(&tls_ctx) != TLS_OK) {
+        return SECURITY_ERROR_TLS_CONFIG;
+    }
+    
+    return SECURITY_OK;
+}
+```
+
+---
+
+## 📊 **PERFORMANCE IMPLEMENTATION STRATEGY**
+
+### **1. Performance Monitoring**
+```c
+// Performance monitoring
+typedef struct {
+    uint32_t cpu_usage_percent;
+    uint32_t memory_usage_mb;
+    uint32_t response_time_ms;
+    uint32_t throughput_rps;
+    uint32_t error_count;
+    uint32_t last_update_time;
+} performance_metrics_t;
+
+// Performance monitoring implementation
+int performance_monitor_init(void) {
+    // Initialize performance monitoring
+    performance_metrics_t *metrics = get_performance_metrics();
+    memset(metrics, 0, sizeof(performance_metrics_t));
+    
+    // Start performance monitoring thread
+    if (pthread_create(&performance_thread, NULL, performance_monitor_thread, NULL) != 0) {
+        return PERFORMANCE_ERROR_THREAD_CREATE;
+    }
+    
+    return PERFORMANCE_OK;
+}
+
+void *performance_monitor_thread(void *arg) {
+    while (running) {
+        // Update performance metrics
+        update_cpu_usage();
+        update_memory_usage();
+        update_response_time();
+        update_throughput();
+        update_error_count();
+        
+        // Check performance thresholds
+        check_performance_thresholds();
+        
+        // Sleep for monitoring interval
+        usleep(PERFORMANCE_MONITOR_INTERVAL_US);
+    }
+    
+    return NULL;
+}
+```
+
+### **2. Performance Optimization**
+```c
+// Performance optimization
+int performance_optimize_system(void) {
+    // CPU optimization
+    if (cpu_usage > CPU_THRESHOLD) {
+        optimize_cpu_usage();
+    }
+    
+    // Memory optimization
+    if (memory_usage > MEMORY_THRESHOLD) {
+        optimize_memory_usage();
+    }
+    
+    // Network optimization
+    if (network_latency > NETWORK_THRESHOLD) {
+        optimize_network_latency();
+    }
+    
+    return PERFORMANCE_OK;
+}
+```
+
+---
+
+## 🧪 **TESTING IMPLEMENTATION STRATEGY**
+
+### **1. Test Framework**
+```c
+// Test framework implementation
+typedef struct {
+    char test_name[64];
+    test_function_t test_func;
+    bool critical;
+    uint32_t timeout_ms;
+} test_case_t;
+
+// Test execution
+int test_execute_suite(test_case_t *test_suite, size_t test_count) {
+    int passed = 0;
+    int failed = 0;
+    
+    for (size_t i = 0; i < test_count; i++) {
+        printf("Running test: %s\n", test_suite[i].test_name);
+        
+        uint32_t start_time = get_system_time_ms();
+        int result = test_suite[i].test_func();
+        uint32_t execution_time = get_system_time_ms() - start_time;
+        
+        if (result == TEST_PASS) {
+            printf("✅ PASS: %s (%dms)\n", test_suite[i].test_name, execution_time);
+            passed++;
+        } else {
+            printf("❌ FAIL: %s (%dms)\n", test_suite[i].test_name, execution_time);
+            failed++;
+            
+            if (test_suite[i].critical) {
+                printf("🚨 CRITICAL TEST FAILED: %s\n", test_suite[i].test_name);
+                return TEST_ERROR_CRITICAL_FAILURE;
+            }
+        }
+    }
+    
+    printf("Test Results: %d passed, %d failed\n", passed, failed);
+    return (failed == 0) ? TEST_PASS : TEST_FAIL;
+}
+```
+
+### **2. Safety Testing**
+```c
+// Safety test suite
+test_case_t safety_test_suite[] = {
+    {"E-Stop Response Time", test_estop_response_time, true, 100},
+    {"E-Stop Hardware", test_estop_hardware, true, 50},
+    {"E-Stop Software", test_estop_software, true, 50},
+    {"Safety Interlock", test_safety_interlock, true, 100},
+    {"Watchdog System", test_watchdog_system, true, 1000},
+    {"Emergency Procedures", test_emergency_procedures, true, 200}
+};
+
+// Execute safety tests
+int safety_test_execute(void) {
+    return test_execute_suite(safety_test_suite, 
+                             sizeof(safety_test_suite) / sizeof(test_case_t));
+}
+```
+
+---
+
+## 🚀 **DEPLOYMENT IMPLEMENTATION STRATEGY**
+
+### **1. Build System**
+```cmake
+# CMakeLists.txt
+cmake_minimum_required(VERSION 3.16)
+project(OHT50_Firmware)
+
+# Safety configuration
+set(SAFETY_LEVEL SIL2)
+set(ESTOP_RESPONSE_TIME_MS 100)
+set(WATCHDOG_TIMEOUT_MS 1000)
+
+# Platform configuration
+set(PLATFORM OrangePi5B)
+set(SOC RK3588)
+
+# Compiler flags
+set(CMAKE_C_FLAGS "-Wall -Wextra -Werror -std=c99")
+set(CMAKE_C_FLAGS_DEBUG "-g -O0 -DDEBUG")
+set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+
+# Include directories
+include_directories(include)
+include_directories(src)
+
+# Source files
+set(SOURCES
+    src/main.c
+    src/app/core/app_controller.c
+    src/app/safety/safety_monitor.c
+    src/hal/rs485_hal.c
+    src/drivers/orange_pi_5b/platform_driver.c
+)
+
+# Create executable
+add_executable(firmware_app ${SOURCES})
+
+# Link libraries
+target_link_libraries(firmware_app pthread rt)
+
+# Install
+install(TARGETS firmware_app DESTINATION /usr/local/bin)
+```
+
+### **2. Deployment Script**
+```bash
+#!/bin/bash
+# deploy.sh - Deployment script
+
+set -e
+
+echo "🚀 Starting OHT-50 Firmware Deployment..."
+
+# Build firmware
+echo "📦 Building firmware..."
+./scripts/build.sh Release
+
+# Run tests
+echo "🧪 Running tests..."
+./scripts/test.sh
+
+# Run safety tests
+echo "🛡️ Running safety tests..."
+./scripts/safety_test.sh
+
+# Deploy to target
+echo "📡 Deploying to target..."
+scp firmware_app root@target:/usr/local/bin/
+
+# Start firmware
+echo "▶️ Starting firmware..."
+ssh root@target "systemctl start oht50-firmware"
+
+echo "✅ Deployment completed successfully!"
+```
+
+---
+
+## 📋 **IMPLEMENTATION CHECKLIST**
+
+### **Phase 1: Foundation & Safety**
+- [ ] Project structure setup
+- [ ] Safety layer implementation
+- [ ] HAL layer implementation
+- [ ] Driver layer implementation
+- [ ] Unit tests
+- [ ] Safety validation tests
+
+### **Phase 2: Application Layer**
+- [ ] Application controller
+- [ ] Module management
+- [ ] Communication systems
+- [ ] API server
+- [ ] Configuration management
+- [ ] Integration tests
+
+### **Phase 3: Integration & Testing**
+- [ ] End-to-end integration
+- [ ] Performance optimization
+- [ ] Comprehensive testing
+- [ ] Safety validation
+- [ ] Production readiness
+
+---
+
+## 🎯 **SUCCESS CRITERIA**
+
+### **Technical Criteria**
+- ✅ **Safety:** SIL 2 compliance, E-Stop < 100ms
+- ✅ **Performance:** Real-time constraints met
+- ✅ **Reliability:** 99.9% uptime target
+- ✅ **Security:** Authentication, encryption, secure boot
+- ✅ **Maintainability:** Modular architecture, comprehensive tests
+
+### **Quality Criteria**
+- ✅ **Code Quality:** MISRA C:2012 compliance
+- ✅ **Documentation:** Complete API and architecture docs
+- ✅ **Testing:** 90%+ code coverage
+- ✅ **Performance:** All performance targets met
+- ✅ **Safety:** All safety requirements validated
+
+---
+
+## 🔄 **MAINTENANCE & UPDATES**
+
+### **1. Update Strategy**
+- **OTA Updates:** Secure over-the-air updates
+- **Rollback Capability:** Safe rollback to previous version
+- **Version Control:** Semantic versioning
+- **Change Management:** Controlled change process
+
+### **2. Monitoring & Diagnostics**
+- **Health Monitoring:** System health checks
+- **Performance Monitoring:** Real-time performance metrics
+- **Error Logging:** Comprehensive error logging
+- **Diagnostic Tools:** Built-in diagnostic capabilities
+
+---
+
+**🚨 CTO DECISION: Kế hoạch triển khai này đảm bảo an toàn tối đa và tuân thủ các tiêu chuẩn quốc tế. Phương pháp phát triển từng bước với kiểm soát chất lượng nghiêm ngặt đáp ứng đầy đủ yêu cầu của OHT-50 Master Module.**
+
+**Changelog v1.0:**
+- ✅ Created comprehensive implementation plan
+- ✅ Added 3-phase development roadmap
+- ✅ Added safety implementation strategy
+- ✅ Added real-time implementation strategy
+- ✅ Added security implementation strategy
+- ✅ Added performance implementation strategy
+- ✅ Added testing implementation strategy
+- ✅ Added deployment implementation strategy
+- ✅ Added success criteria
+- ✅ Added maintenance strategy
+
+**🚨 Lưu ý:** Kế hoạch này đảm bảo an toàn tối đa với SIL 2 compliance và response time < 100ms cho E-Stop system.

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/FW_DAILY_PROGRESS_REPORT_TEMPLATE.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/FW_DAILY_PROGRESS_REPORT_TEMPLATE.md
@@ -1,0 +1,43 @@
+# MẪU BÁO CÁO TIẾN ĐỘ HẰNG NGÀY – FW TEAM
+
+Phiên bản: 1.0  
+Ngày cập nhật: 2025-09-09
+
+---
+
+## 1) Thông tin chung
+- Ngày: YYYY‑MM‑DD (Thứ …)
+- Sprint: Sx – Gate: A/B/C/D/E/F
+- Hạng mục chính: … (vd: Estimator 1D, VELOCITY + amax/jmax, Docking, API)
+- Owner: Dev1/Dev2/Dev3/Dev4, QA, Lead
+
+## 2) Cập nhật 10:00 (AM Update)
+- Tiến độ: …
+- Vấn đề/blockers: …
+- Hành động tức thời: …
+
+## 3) Cập nhật 17:00 (PM Update)
+- Tiến độ: …
+- Vấn đề/blockers: …
+- Hành động hôm sau: …
+
+## 4) KPI & Kết quả đo (nếu có)
+- E‑Stop p95 (ms): …  | WARNING reaction (chu kỳ): …
+- Soak: thời lượng, trạng thái, ghi chú: …
+- Discovery p95/p99 (nếu bật RS485): … | Timeout %: … | CRC %: …
+
+## 5) Artifacts đính kèm (đường dẫn)
+- Logs: …
+- Reports: …
+- CTest: …
+
+## 6) Checklist ngắn (tick những mục hoàn tất)
+- [ ] Gate hiện tại hoàn tất tiêu chí
+- [ ] Không dùng mock runtime
+- [ ] Safety đạt KPI
+- [ ] Telemetry/Diagnostics đầy đủ
+
+## 7) Ghi chú khác
+- …
+
+

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/MODULE_MANAGER_IMPLEMENTATION_PLAN.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/MODULE_MANAGER_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,291 @@
+# KẾ HOẠCH TRIỂN KHAI MODULE MANAGER (Production‑grade)
+
+Phiên bản: 1.0  
+Ngày cập nhật: 2025-09-09  
+Trạng thái: Draft (đề xuất thực thi ngay)  
+Phạm vi: Firmware Module Manager (quét, quản lý, theo dõi sức khỏe các module RS485; API/WS phục vụ Backend)
+
+---
+
+## 1) Bối cảnh và mục tiêu
+- Module Manager hiện đã có: auto‑discovery, registry, health‑check định kỳ, sự kiện, thống kê cơ bản, polling tối thiểu.
+- Mục tiêu bản kế hoạch: nâng cấp lên mức production‑grade (resilience + observability) để vận hành dài hạn, dễ mở rộng.
+
+### Mục tiêu cụ thể
+- Ổn định dưới điều kiện lỗi/độ nhiễu cao; tránh flapping ONLINE/OFFLINE.
+- Đo lường được hiệu năng (p95/p99), tỷ lệ lỗi, timeout; có SLO rõ ràng.
+- Cấu hình linh hoạt (dải địa chỉ, chu kỳ health, ngưỡng OFFLINE, retry/backoff) qua file + API.
+- Telemetry chi tiết theo loại module, phát sự kiện realtime qua WebSocket cho Backend/UI.
+- Registry bền vững (persist), tự phục hồi sau reboot.
+
+---
+
+## 2) Phạm vi & nguyên tắc
+- Chỉ trong phạm vi Firmware.
+- Giao tiếp với Backend qua HTTP/REST + WebSocket (tuân thủ kiến trúc).
+- Không thay đổi giao thức thiết bị RS485 (Firmware là Protocol Gateway). 
+- Ưu tiên không phá vỡ API nội bộ hiện có; nếu mở rộng, thêm endpoint mới.
+
+---
+
+## 3) Yêu cầu chức năng (Functional)
+- Quét tự động RS485: dải địa chỉ cấu hình được; retry + exponential backoff.
+- Đăng ký/huỷ đăng ký/cập nhật module vào registry, lưu và khôi phục từ YAML.
+- Theo dõi sức khỏe định kỳ: tính %health từ thời gian đáp ứng + lỗi; debounce offline.
+- Polling dữ liệu theo loại module (POWER/SAFETY/MOTOR/DOCK) → telemetry chi tiết.
+- Phát sự kiện realtime: Discovered/Online/Offline/HealthChange/Updated.
+- API HTTP để: xem danh sách, xem thống kê, kích hoạt scan, chỉnh cấu hình.
+
+## 4) Yêu cầu phi chức năng (Non‑functional)
+- Hiệu năng: p95 thời gian quét/địa chỉ < 300 ms; timeout rate < 1%.
+- Ổn định: không flapping trạng thái khi mạng/bus nhiễu nhẹ.
+- Tài nguyên: CPU < 10% (trung bình), RAM < 64 MB cho tiến trình FW (tham chiếu).
+- Bảo mật API: rate‑limit, validate input; (auth do Backend/Center quản lý tầng trên).
+- Quan sát được: log có cấu trúc, metrics p95/p99, counters, error budget.
+
+---
+
+## 5) Thiết kế kỹ thuật (đề xuất)
+- Lập lịch nền: health‑check theo interval có jitter (±10%) để tránh trùng xung; scan theo batch, sleep giữa địa chỉ (20–50 ms).
+- Backoff & circuit‑breaker per‑address: nếu 3 lần liên tiếp timeout → tạm ngưng thăm dò địa chỉ trong T giây (cooldown), giảm tải bus.
+- Debounce OFFLINE: chỉ đánh dấu OFFLINE sau ≥2 lần miss liên tiếp và quá offline_threshold_ms.
+- Polling theo loại module: ánh xạ thanh ghi → trường dữ liệu (vd POWER: điện áp/dòng/nhiệt; MOTOR: vị trí/vận tốc/fault…).
+- Registry bền vững: YAML versioned (v1, v2…), lưu last_seen, type, version, capabilities; migration nếu schema đổi.
+- Metrics nội bộ: discovery_total_ms, discovery_p95_ms, discovery_p99_ms, health_checks, health_timeouts, crc_error_count, avg_response_time_ms…
+- Sự kiện nội bộ → WebSocket: gom nhóm (batch) để giảm spam; tối đa N sự kiện/giây.
+
+### Sơ đồ luồng quét (Mermaid)
+```mermaid
+sequenceDiagram
+  autonumber
+  participant M as Module Manager
+  participant RS as RS485 Bus
+  participant R as Registry
+  participant WS as WebSocket API
+
+  M->>RS: Đọc DeviceID (0x00F0) địa chỉ A
+  RS-->>M: Phản hồi/Timeout
+  alt Có phản hồi
+    M->>RS: Đọc ModuleType (0x00F7)
+    M->>R: Cập nhật/đăng ký module (ONLINE)
+    M->>WS: Emit event: Discovered/Online
+  else Timeout
+    M->>R: Debounce + không đánh dấu OFFLINE ngay
+  end
+  M->>M: Lặp địa chỉ (backoff + jitter)
+```
+
+### Cấu trúc thành phần (Mermaid)
+```mermaid
+flowchart LR
+  subgraph FW
+    MM[Module Manager]
+    REG[Registry (YAML Persist)]
+    HL[Health Checker]
+    PL[Type-based Poller]
+    MET[Metrics Collector]
+    API[HTTP/WS API]
+  end
+  RS[RS485 Bus] --- MM
+  MM --- REG
+  MM --- HL
+  MM --- PL
+  MM --- MET
+  MM --- API
+```
+
+---
+
+## 6) API đề xuất (phục vụ Backend)
+- HTTP
+  - GET `/api/v1/modules` → danh sách + trạng thái + health%.
+  - GET `/api/v1/modules/{id}` → chi tiết + dữ liệu gần nhất.
+  - POST `/api/v1/modules/scan` body: `{start,end,retry,timeout_ms}` → kích hoạt quét.
+  - PATCH `/api/v1/modules/config` → `{health_interval_ms, offline_threshold_ms, backoff}`.
+  - GET `/api/v1/modules/stats` → KPI/metrics.
+- WebSocket
+  - Kênh sự kiện: discovered, online, offline, health_change, updated (kèm payload tối thiểu).
+
+---
+
+## 7) Kế hoạch triển khai theo giai đoạn
+### Sprint 0 (0.5–1 ngày) – Ổn định nhanh
+- Sửa test pipeline (ctest), bật lại unit/integration test cốt lõi.
+- Cấu hình qua YAML: scan_start, scan_end, health_interval_ms, offline_threshold_ms.
+- Hiện metric cơ bản (total_ms, p95/p99, timeouts) vào log/diagnostics.
+
+### Sprint 1 (2–3 ngày) – Hoàn chỉnh API/WS
+- Thêm endpoint HTTP như mục (6); validate input, rate‑limit nhẹ.
+- WS phát sự kiện (debounced); định dạng payload ổn định.
+- Mở rộng polling theo loại module (POWER/SAFETY/MOTOR/DOCK) → telemetry phong phú.
+- Persist registry có version; auto‑reload khi FW khởi động.
+
+### Sprint 2–3 (1–2 tuần) – Resilience + Observability
+- Circuit‑breaker per‑address, exponential backoff, jitter lập lịch.
+- Bộ metrics chuẩn (p95/p99, error budget, SLO) + soak test 60–120 phút.
+- Playbook sự cố (timeout hàng loạt, CRC tăng, nhiễu bus) + cảnh báo mức sự kiện.
+
+---
+
+## 8) KPI & SLO (đo hằng ngày)
+| Nhóm | Chỉ số | Mục tiêu |
+|---|---|---|
+| Discovery | p95 thời gian/địa chỉ | < 300 ms |
+| Discovery | Tỷ lệ thất bại (per scan) | < 5% |
+| Health | Timeout rate | < 1% |
+| Health | Flapping rate (online↔offline) | < 0.5% |
+| Comm | CRC error rate | < 0.5% |
+| System | Soak test 120′ | Không flapping, không memory leak |
+
+---
+
+## 9) Kiểm thử
+- Unit: discover_module_at_address, tính %health, debounce offline, parsing version regs.
+- Integration: scan_range với mock RS485 (timeout/CRC), registry persist/load.
+- API/WS: kiểm tra endpoint, tham số, rate limit, payload sự kiện.
+- Performance: đo p95/p99, tổng thời gian scan; benchmark với N địa chỉ.
+- Soak test: chạy liên tục 60–120 phút; theo dõi timeouts, CRC, flapping, RAM.
+
+---
+
+## 10) Rủi ro & biện pháp
+- Nhiễu bus/thiết bị chập chờn → debounce + backoff + circuit‑breaker.
+- Khác biệt thiết bị (không hỗ trợ version regs) → fallback hợp lý.
+- Tài nguyên hạn chế → giới hạn batch size, sleep giữa địa chỉ, giãn polling.
+- Đổi schema registry → version + migration.
+
+---
+
+## 11) Phân công & tiến độ (khuyến nghị)
+- FW Lead: kiến trúc, circuit‑breaker, metrics p95/p99.
+- Dev 1: API/WS + validation + rate‑limit.
+- Dev 2: Polling theo loại module + telemetry mapping.
+- QA: test pipeline, soak test, báo cáo KPI.
+
+---
+
+## 12) Tiêu chí chấp nhận (DoD)
+- KPI đạt mục tiêu mục (8) trong 2 lần đo liên tiếp.
+- API/WS hoạt động, tài liệu endpoint đầy đủ.
+- Registry persist + tự phục hồi sau reboot.
+- Test xanh (unit/integration/perf/soak).
+
+---
+
+## 13) Kế hoạch rollback
+- Cho phép tắt circuit‑breaker/backoff qua cấu hình (feature flags).
+- Lưu bản registry trước khi migration; có đường quay lại.
+- Tắt WS sự kiện nếu gây tải quá mức (config).
+
+---
+
+## 14) Checklist thực thi (Action Checklist)
+- Trước triển khai:
+  - [ ] Xác nhận dải địa chỉ quét RS485 (scan_start, scan_end)
+  - [ ] Chốt health_interval_ms, offline_threshold_ms, retry_count, retry_delay_ms
+  - [ ] Xác nhận file cấu hình YAML và vị trí lưu registry (modules.yaml)
+  - [ ] Bật log mức INFO cho Module Manager + Communication Manager
+  - [ ] Rà soát tài nguyên: CPU/RAM còn trống cho lịch nền, WS
+- Trong triển khai:
+  - [ ] Thêm jitter vào lập lịch health‑check
+  - [ ] Thêm exponential backoff + circuit‑breaker theo địa chỉ
+  - [ ] Mở rộng polling theo loại module (POWER/SAFETY/MOTOR/DOCK)
+  - [ ] Gộp/batch sự kiện WS để tránh spam
+  - [ ] Ghi metrics: discovery_total_ms, p95/p99, timeout/CRC, avg_response_time_ms
+- Kiểm thử:
+  - [ ] Unit: discover_module_at_address, debounce OFFLINE, %health
+  - [ ] Integration: scan_range (mock timeout/CRC), registry persist/load
+  - [ ] API/WS: endpoint, rate‑limit, payload sự kiện
+  - [ ] Performance: p95/p99, tổng thời gian scan; benchmark theo N địa chỉ
+  - [ ] Soak test 60–120 phút: theo dõi flapping, memory leak, CRC/timeout
+- Sau triển khai:
+  - [ ] Tổng hợp KPI thực đo, so sánh mục tiêu
+  - [ ] Báo cáo lỗi/chướng ngại, đề xuất tối ưu lần 2
+  - [ ] Cập nhật tài liệu và playbook sự cố
+
+---
+
+## 15) Bảng tiến độ (Progress Tracker)
+| Hạng mục | Owner | Bắt đầu | Kết thúc | Trạng thái | Ghi chú |
+|---|---|---|---|---|---|
+| Sửa test pipeline (ctest) | QA | 2025-09-09 10:00 | 2025-09-09 18:48 | Done | PASS sau khi bật headless mode cho LED/Relay |
+| YAML config (scan/health/offline) | Dev 1 | 2025-09-09 10:00 | 2025-09-09 18:20 | Done | Nạp lúc khởi động; hỗ trợ /etc/oht50/modules.yaml |
+| Log metrics cơ bản | Dev 1 | 2025-09-09 10:00 | 2025-09-09 18:30 | Done | total_ms, p95/p99, timeouts |
+| HTTP endpoints modules/stats/scan/config | Dev 1 | 2025-09-09 10:00 | 2025-09-09 18:35 | Done | Theo mục 6; trả dữ liệu thật |
+| WebSocket sự kiện (debounced) | Dev 1 | 2025-09-09 14:00 | 2025-09-09 18:40 | Done | Batch + debounce sự kiện |
+| Polling theo loại module | Dev 2 | 2025-09-09 10:00 | 2025-09-09 18:25 | Done | POWER/SAFETY/MOTOR/DOCK |
+| Registry persist (versioned) | Dev 2 | 2025-09-09 10:00 | 2025-09-09 18:20 | Done | YAML + schema_version + migrate stub |
+| Circuit‑breaker + backoff + jitter | FW Lead | 2025-09-09 10:00 | 2025-09-09 18:30 | Done | Per‑address cooldown + exponential backoff + jitter |
+| Bộ metrics chuẩn + export | FW Lead | 2025-09-09 10:00 | 2025-09-09 18:35 | Done | p95/p99, discovery_total_ms, CRC/timeout |
+| Soak test 60–120 phút | QA |  |  | Deferred | PM chấp thuận tạm hoãn (sẽ lên lịch) |
+| Playbook sự cố | QA | 2025-09-09 18:35 | 2025-09-09 18:45 | Done | profiling_results/PLAYBOOK_SU_CO.md |
+| Soak 3–5 phút (đo nhanh) | QA | 2025-09-09 18:30 | 2025-09-09 18:48 | Done | Artifacts: soak_report_20250909_184811_3m.md, console log |
+| RS485 quick validation (10s) | QA | 2025-09-09 19:00 | 2025-09-09 19:10 | Done | profiling_results/soak_console_probe10s.log |
+| CTest verbose full run | QA | 2025-09-09 18:50 | 2025-09-09 19:20 | Done | profiling_results/ctest_output_verbose_full.txt |
+
+Ghi chú mã trạng thái: Planned / In‑Progress / Blocked / Done.
+
+---
+
+## 16) Phân tích mô tả chi tiết sau khi hoàn thành (Post‑implementation Report)
+- Tổng quan thực thi
+  - Phạm vi đã triển khai, phạm vi hoãn, thay đổi ngoài kế hoạch (nếu có)
+- Kết quả KPI (so với mục tiêu)
+  - Discovery p95, p99, tổng thời gian scan mỗi chu kỳ
+  - Timeout rate, CRC error rate, flapping rate
+  - Soak test: thời lượng, kết quả, quan sát
+- Phân tích lỗi/chướng ngại & cách xử lý
+  - Lỗi giao tiếp (timeout/CRC), xử lý backoff/circuit‑breaker
+  - Flapping và biện pháp debounce
+  - Memory/CPU footprint và tối ưu đã áp dụng
+- Hiệu năng & độ ổn định
+  - Đồ thị p95/p99 theo thời gian, điểm bất thường
+  - Ảnh hưởng cấu hình (interval/backoff) đến độ trễ trung bình
+- Quan sát & Telemetry
+  - Sự kiện WS/HTTP: tần suất, batch size, độ trễ end‑to‑end
+  - Tính hữu ích của metrics, đề xuất bổ sung
+- Rủi ro còn lại & khuyến nghị Sprint kế tiếp
+  - Hạng mục nên productize thêm (alerting, tự healing nâng cao…)
+- Tài liệu đính kèm
+  - Liên kết logs, metrics snapshots, modules.yaml, cấu hình YAML
+
+Mẫu báo cáo ngắn:
+```
+[Ngày]: YYYY‑MM‑DD
+Discovery p95/p99: XXX/YYY ms | Timeout: A% | CRC: B% | Flapping: C%
+Soak test: PASS/FAIL, thời lượng, ghi chú
+Vấn đề chính & fix: ...
+Đề xuất tiếp theo: ...
+```
+
+### Cập nhật nhanh 2025-09-09
+- Discovery: ~140 ms/địa chỉ (8 địa chỉ → total ~1120 ms). Đạt mục tiêu p95 < 300 ms.
+- Timeouts: thấp trong đo nhanh; CRC: lác đác (đặc biệt 0x06), đã retry OK.
+- Flapping: 0; Health-check latency: ~30–33 ms/module.
+- Soak: 3′ PASS (headless), RS485 probe 10s PASS; 60′/120′ Deferred theo PM.
+
+---
+
+## 17) Sprint 0–1 – Báo cáo nhanh (Module Manager & QA)
+- Artifacts:
+  - Soak report 3 phút: `firmware_new/profiling_results/soak_report_20250909_184811_3m.md`
+  - Soak console: `firmware_new/profiling_results/soak_console_20250909_184811_3m.log`
+  - Playbook sự cố: `firmware_new/profiling_results/PLAYBOOK_SU_CO.md`
+  - CTest (verbose phần an toàn): `firmware_new/profiling_results/ctest_safety_latency_verbose.txt`
+  - CTest full (hoàn tất): `firmware_new/profiling_results/ctest_output_verbose_full.txt`
+  - RS485 probe 10s: `firmware_new/profiling_results/soak_console_probe10s.log`
+- Kết quả chính:
+  - Soak 3′: Timeouts 0; CRC 0; Flapping 0; RSS ~580 kB (headless, chưa bật RS485 thật)
+  - CTest: trước 95% PASS, fail latency do GPIO; sau sửa headless LED/Relay → ✅ PASS
+- Rủi ro/ghi chú:
+  - KPI bus cần RS485 thật (discovery/timeout/CRC); số đo hiện tại = 0 là bình thường ở headless
+- Bước tiếp theo:
+  - (PM chấp thuận) Tạm hoãn Soak 60′/120′; sẽ lên lịch khi có cửa sổ phù hợp
+  - Đã chạy `ctest -V` full; lưu `ctest_output_verbose_full.txt`
+
+---
+
+## Changelog
+- v1.2 (2025-09-09): Thêm Sprint 0–1 report, cập nhật Progress Tracker, liên kết artifacts.
+- v1.1 (2025-09-09): Bổ sung Checklist, Bảng tiến độ, và mẫu Báo cáo sau triển khai.
+- v1.0 (2025-09-09): Khởi tạo kế hoạch production‑grade cho Module Manager.

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/archive/issues/ISSUE_TESTING_SYSTEM_IMPROVEMENT.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/archive/issues/ISSUE_TESTING_SYSTEM_IMPROVEMENT.md
@@ -1,0 +1,165 @@
+# ISSUE: Testing System Improvement - Medium Priority
+
+**Issue ID:** TESTING-001  
+**Priority:** 🟡 MEDIUM  
+**Status:** ✅ IMPLEMENTED  
+**Assigned:** QA Team  
+**Created:** 2025-01-28  
+**Due Date:** 2025-02-15  
+
+---
+
+## 📋 **ISSUE DESCRIPTION**
+
+Testing system cần được cải thiện để đảm bảo comprehensive test coverage và reliable test execution cho tất cả firmware components.
+
+### **🚨 Current Status:**
+- ✅ **Basic Framework:** COMPLETED
+- ✅ **Test Framework:** COMPLETE IMPLEMENTATION
+- ✅ **Unit Tests:** COMPREHENSIVE COVERAGE
+- ✅ **Integration Tests:** WORKING PROPERLY
+- ⚠️ **Safety Tests:** MINOR ISSUES (NON-CRITICAL)
+- ⚠️ **Advanced Testing:** PARTIALLY IMPLEMENTED
+
+---
+
+## 🔍 **ROOT CAUSE ANALYSIS**
+
+### **1. Coverage Issues:**
+```c
+// Coverage problems:
+- Unit test coverage < 90%
+- Integration test gaps
+- Safety test failures
+- Missing edge case tests
+```
+
+### **2. Test Reliability Issues:**
+```c
+// Reliability problems:
+- Flaky tests
+- Inconsistent results
+- Missing test data
+- Incomplete mock implementations
+```
+
+### **3. Advanced Testing Missing:**
+- Performance testing incomplete
+- Stress testing missing
+- Security testing not implemented
+- Compliance testing incomplete
+
+---
+
+## 🎯 **REQUIRED FIXES**
+
+### **1. Improve Test Coverage**
+```c
+// Coverage improvements:
+- Add missing unit tests
+- Implement integration tests
+- Add edge case testing
+- Complete safety test suite
+- Add performance tests
+```
+
+### **2. Fix Test Reliability**
+```c
+// Reliability fixes:
+- Fix flaky tests
+- Add proper test data
+- Improve mock implementations
+- Add test isolation
+- Implement test cleanup
+```
+
+### **3. Add Advanced Testing**
+```c
+// Advanced testing:
+- Performance benchmarking
+- Stress testing
+- Security testing
+- Compliance validation
+- Load testing
+```
+
+---
+
+## 📋 **IMPLEMENTATION PLAN**
+
+### **Phase 1: Coverage Improvement (Days 1-7)**
+1. ✅ **Add missing unit tests**
+2. ✅ **Implement integration tests**
+3. ✅ **Add edge case tests**
+4. ✅ **Complete safety tests**
+
+### **Phase 2: Reliability Fixes (Days 8-14)**
+1. ✅ **Fix flaky tests**
+2. ✅ **Add test data management**
+3. ✅ **Improve mock framework**
+4. ✅ **Add test isolation**
+
+### **Phase 3: Advanced Testing (Days 15-21)**
+1. ✅ **Add performance tests**
+2. ✅ **Implement stress tests**
+3. ✅ **Add security tests**
+4. ✅ **Add compliance tests**
+
+---
+
+## 🧪 **TESTING REQUIREMENTS**
+
+### **Test Execution:**
+```bash
+# Test commands:
+make test_all
+make test_coverage
+make test_performance
+make test_security
+make test_compliance
+```
+
+### **Validation Criteria:**
+- ✅ Test coverage > 90%
+- ✅ All tests pass consistently
+- ✅ Performance benchmarks met
+- ✅ Security tests pass
+- ✅ Compliance validation successful
+
+---
+
+## 📊 **SUCCESS METRICS**
+
+### **Coverage Metrics:**
+- **Unit Test Coverage:** > 90%
+- **Integration Test Coverage:** > 85%
+- **Safety Test Coverage:** 100%
+- **Performance Test Coverage:** > 80%
+
+### **Reliability Metrics:**
+- **Test Pass Rate:** > 99%
+- **Test Execution Time:** < 10 minutes
+- **Flaky Test Rate:** < 1%
+- **Test Maintenance:** Low
+
+---
+
+## 🔗 **RELATED DOCUMENTS**
+
+- [REQ_TESTING_SYSTEM_SPECIFICATION.md](../02-REQUIREMENTS/03-FIRMWARE-REQUIREMENTS/04-IMPLEMENTED-MODULES/REQ_TESTING_SYSTEM_SPECIFICATION.md)
+- [QA_QC_FIRMWARE_REPORT.md](../05-QUALITY/01-qa-reports/QA_QC_FIRMWARE_REPORT.md)
+
+---
+
+## 📝 **NOTES**
+
+- **Priority:** Medium - affects code quality
+- **Impact:** Medium - affects development workflow
+- **Risk:** Low - standard testing improvements
+- **Dependencies:** Build system fixes (BUILD-001), Safety fixes (SAFETY-001)
+
+---
+
+**📅 Next Review:** 2025-02-15  
+**👥 Responsible:** QA Team  
+**📊 Success Metrics:** >90% test coverage, >99% test pass rate

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/implementation/retrospective/MANAGERS_REMEDIATION_PLAN.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/01-planning/implementation/retrospective/MANAGERS_REMEDIATION_PLAN.md
@@ -1,0 +1,157 @@
+# Kế hoạch Khắc phục Managers - OHT-50 Master Module
+
+**Phiên bản:** 1.0.0  
+**Ngày cập nhật:** 2025-01-28  
+**Team:** FW  
+**Mức độ ưu tiên:** CAO  
+**Trạng thái:** PLANNING
+
+---
+
+## 🎯 Mục tiêu
+Sửa toàn bộ lỗi nghiêm trọng đã phát hiện trong `src/app/managers/` (Communication, Module, Safety, Telemetry), đảm bảo ổn định, an toàn, và sẵn sàng tích hợp API.
+
+---
+
+## 📅 Lộ trình 2 Tuần (10 ngày làm việc)
+
+### Week 1: Ổn định nền tảng (HAL, Memory, Thread)
+1. HAL Integration Guard (ngày 1)
+2. Thread Safety & Mutex (ngày 2)
+3. Memory Cleanup & Error Paths (ngày 3)
+4. Input/Return Validation & Bounds (ngày 4)
+5. JSON Serialization Hardening (ngày 5)
+
+### Week 2: Dữ liệu thực & Kiểm thử
+6. Replace Simulated Data with HAL (ngày 6-7)
+7. Real Health Checks (ngày 8)
+8. Integration Tests (ngày 9)
+9. Docs & Diagnostics (ngày 10)
+
+---
+
+## 🔧 Checklist chi tiết theo Manager
+
+### 1) Communication Manager
+- [x] Thêm `pthread_mutex_t` cho `g_comm_manager`
+- [x] Guard state: `waiting_for_response`, `response_timeout`
+- [x] Sửa leak khi `comm_manager_modbus_send_request` fail
+- [x] Reset state khi lỗi build/send/recv/parse
+- [x] Kiểm tra kết quả `hal_rs485_init/open/receive/transmit/health_check`
+- [ ] Thêm backoff cấu hình được cho retry
+- [ ] Thêm thống kê lỗi chi tiết (per-fc, per-slave)
+
+### 2) Module Manager
+ - [x] Kiểm tra `comm_manager` đã init trước khi discover
+- [x] Sửa mapping `module_type` (đồng bộ enum ↔ register value)
+- [x] Implement health check thực (đo thời gian phản hồi, CRC/timeout)
+- [ ] Không tăng/giảm online/error count sai logic
+- [ ] Debounce offline theo thời gian cấu hình
+- [ ] Bảo vệ registry calls (kiểm tra trả về, fallback)
+
+### 3) Safety Manager
+- [ ] Kiểm tra kết quả `hal_estop_set_callback`, `hal_led_*`
+- [ ] Implement check thực cho `safety_circuit` và `sensors`
+- [ ] Xử lý đầy đủ `SAFETY_EVENT_EMERGENCY_STOP` (gọi shutdown hooks)
+- [ ] Đồng bộ với `safety_monitor` khi có (nếu có integration)
+- [ ] Bổ sung diagnostics chi tiết (lý do, timestamp, đếm sự kiện)
+
+### 4) Telemetry Manager
+- [x] Cleanup khi init fail (free ring buffer, reset state)
+- [x] Thu thập metrics thực (CPU/mem/temp) qua HAL/OS khi có
+- [ ] Cứng hoá `serialize_json` (kiểm soát `written`, cắt chuỗi an toàn)
+- [ ] Giới hạn tần suất broadcast, chống flood
+- [ ] Thêm schema version trong JSON
+
+---
+
+## 🧪 Kiểm thử & Chấp nhận
+
+### Unit/Integration Tests (thêm vào `tests/`)
+- [ ] RS485 happy-path + timeout + CRC error (mock HAL)
+- [ ] Modbus read/write với retry/backoff
+- [ ] Module discovery: online/offline/debounce
+- [ ] Safety: estop press/release, circuit/sensor fault
+- [ ] Telemetry: JSON size limits, frequency control
+
+### Tiêu chí chấp nhận
+- [ ] Không crash sau 24h chạy liên tục
+- [ ] Không leak bộ nhớ (valgrind clean trên dev)
+- [ ] Timeout/CRC handled đúng, có thống kê
+- [ ] Health check phản ánh đúng trạng thái
+- [ ] JSON không tràn buffer, hợp lệ format
+
+---
+
+## 📋 Phân rã công việc theo hạng mục (Tasks)
+
+### A. HAL Integration Guards
+- [x] Thêm macro guard/adapter cho HAL missing
+- [x] Log cảnh báo khi HAL không có; fallback an toàn
+
+### B. Thread Safety
+- [x] Mutex cho `g_comm_manager`, cấu trúc tương tự cho managers khác nếu cần
+- [x] Vùng critical: send/receive, update state, statistics
+
+### C. Memory & Error Paths
+- [x] Quy trình cleanup thống nhất `goto cleanup:`
+- [x] Đảm bảo free mọi allocation khi lỗi
+
+### D. Validation & Bounds
+- [x] Kiểm tra `NULL`, `quantity`, kích thước buffer
+- [x] Kiểm tra return code từ tất cả HAL/manager calls
+- [x] Thêm bounds checks cho Modbus requests (slave_id, quantity, start_address)
+- [x] Validate address ranges trong module discovery
+- [x] Guard max_count==0 trong get_registered_modules
+
+### E. Real Data & Health
+- [x] Thay simulated → HAL (CPU/mem/temp, RS485 link, module response)
+- [x] Tính health = hàm của timeout/CRC/error rate
+
+### F. JSON Hardening
+- [x] Helper `snprintf_s` trả về -1 nếu không đủ chỗ
+- [x] Cắt chuỗi an toàn, validate độ dài
+
+### G. Tests & Docs
+- [x] Bổ sung tests vào `tests/integration/`
+- [ ] Cập nhật diagnostics strings + README
+
+### H. Integration Tests
+- [x] RS485/Modbus read/write với bounds checking
+- [x] Module discovery với comm manager dependency
+- [x] Safety E-Stop/LED integration
+- [x] Telemetry JSON serialization với buffer limits
+- [x] Cross-manager end-to-end flow
+- [x] Thread safety và concurrent access
+- [x] Error recovery và resilience testing
+
+---
+
+## 📊 Theo dõi tiến độ (liên kết TODO)
+
+### Completed TODOs ✅
+- [x] `mgr-hal-integration-fixes` - HAL integration fixes (completed)
+- [x] `mgr-thread-safety` - Thread safety implementation (completed)
+- [x] `mgr-memory-cleanup` - Memory leak fixes (completed)
+- [x] `mgr-real-data` - Replace simulated data (completed)
+- [x] `mgr-json-serialization` - JSON serialization hardening (completed)
+- [x] `mgr-validate-io` - Validate inputs/returns and add bounds checks (completed)
+- [x] `mgr-integration-tests` - Integration tests (completed)
+- [x] `mgr-docs` - Update documentation and diagnostics for managers (completed)
+
+### Status Summary
+- **Total TODOs:** 8
+- **Completed:** 8 ✅
+- **Remaining:** 0
+- **Overall Progress:** 100% Complete
+
+---
+
+## 🛡️ Rủi ro & Giảm thiểu
+- R1: Thiếu HAL thực → dùng adapter/mocks, degrade graceful
+- R2: Deadlock do mutex → phạm vi khóa nhỏ, review kỹ
+- R3: Thay đổi nhiều ảnh hưởng build → chạy CI local, chia nhỏ commits
+
+---
+
+**Ghi chú:** Kế hoạch này là tiền đề trước khi nối API layer mới. Sau khi hoàn tất, tiến hành Phase 2: tích hợp API endpoints với các managers đã ổn định.

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/CHANGELOG.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/CHANGELOG.md
@@ -1,0 +1,384 @@
+# Changelog - OHT-50 Firmware Development
+
+**Phiên bản:** 3.1.0  
+**Ngày cập nhật:** 2025-01-28  
+**Trạng thái:** ✅ **DOCUMENTATION CLEANUP COMPLETED - INTEGRATION READY**
+
+---
+
+## 📋 **CHANGELOG OVERVIEW**
+
+### **Current Version:** 3.1.0
+### **Release Date:** 2025-01-28
+### **Status:** Documentation Cleanup Completed Successfully
+### **Next Phase:** Integration & Testing
+
+---
+
+## 🚀 **VERSION 3.1.0 - DOCUMENTATION CLEANUP & INTEGRATION (2025-01-28)**
+
+### **✅ MAJOR ACHIEVEMENTS:**
+- **Documentation Structure Cleanup:** 100% completed
+- **README Files Update:** All README files updated with clean structure
+- **CHANGELOG Update:** Comprehensive changelog with documentation improvements
+- **Integration:** Firmware documentation integrated with project structure
+- **Navigation:** Comprehensive navigation and cross-references added
+
+### **🔧 DOCUMENTATION IMPROVEMENTS:**
+1. **Main Documentation**
+   - Updated main docs README with comprehensive navigation
+   - Added project integration guidelines
+   - Added team access guidelines
+   - Added documentation standards
+
+2. **Firmware Documentation**
+   - Updated firmware README with clean structure
+   - Added comprehensive navigation
+   - Added integration with project SLC planning
+   - Added team access guidelines
+
+3. **QMS Documentation**
+   - Updated QMS README with quality objectives
+   - Added quality management principles
+   - Added quality assurance processes
+   - Added quality control checkpoints
+
+4. **HAL Documentation**
+   - Updated HAL README with comprehensive architecture
+   - Added HAL implementation details
+   - Added HAL requirements and status
+   - Added HAL testing procedures
+
+5. **Requirements Documentation**
+   - Updated Requirements README with comprehensive overview
+   - Added requirements status tracking
+   - Added requirements implementation details
+   - Added requirements validation procedures
+
+6. **Risk Documentation**
+   - Updated Risk README with comprehensive risk categories
+   - Added risk analysis and matrix
+   - Added risk mitigation strategies
+   - Added risk monitoring procedures
+
+7. **SLC Documentation**
+   - Updated SLC README with comprehensive SLC overview
+   - Added SLC implementation status
+   - Added SLC implementation roadmap
+   - Added SLC metrics and KPIs
+
+8. **Safety Documentation**
+   - Updated Safety README with comprehensive safety architecture
+   - Added safety implementation details
+   - Added safety requirements and standards
+   - Added safety testing procedures
+
+9. **Quality Documentation**
+   - Updated Quality README with comprehensive quality overview
+   - Added quality objectives and metrics
+   - Added quality assurance processes
+   - Added quality testing procedures
+
+### **📊 DOCUMENTATION METRICS:**
+- **Total README Files:** 9 updated
+- **Total CHANGELOG Files:** 1 updated
+- **Navigation Links:** 100+ cross-references added
+- **Documentation Coverage:** 100% coverage
+- **Integration:** Complete integration with project structure
+
+### **🧹 QA/QC Documentation Cleanup (2025-09-08)**
+- Removed obsolete/archived/paused drafts under `03-SLC/01-planning/archive/**` (14 files)
+- Removed off-scope docs from `firmware_new/docs/` (2 files: HOMEPAGE_*)
+- Removed empty placeholder `05-QUALITY/02-testing/TEST_VALIDATION_REPORT.md`
+- Verified no temp files (*.tmp, *.bak, *.orig, *~) remain in `firmware_new/docs`
+
+Impact:
+- Reduced noise, ensured only compliant, in-scope documents remain
+- No changes to active specifications or READMEs
+
+### **📌 Planning Update (2025-09-08)**
+- Added Endpoint Matrix (P0/P1/P2) vào `01-planning/API_INTEGRATION_IMPLEMENTATION_PLAN.md`
+- Added Progress Tracker (FW team) để theo dõi tiến độ endpoint
+- Aligned with Minimal API v1 two-week plan; không dùng mock trong production path
+ - Slimmed `API_INTEGRATION_IMPLEMENTATION_PLAN.md`: giữ mục tiêu rút gọn, Endpoint Matrix, Tracker, Minimal API v1; loại bỏ phase dài/risk verbose/timeline chi tiết
+
+---
+
+## 🚀 **VERSION 3.0.0 - PHASE 2 COMPLETION (03/09/2025)**
+
+### **✅ MAJOR ACHIEVEMENTS:**
+- **Core Systems Implementation:** 100% completed
+- **Safety Framework:** E-Stop latency <50ms achieved
+- **Control Systems:** Response time <100ms validated
+- **Testing Framework:** Unit tests 100% passing
+- **Telemetry Integration:** Core systems telemetry operational
+
+### **🔧 CORE SYSTEMS IMPLEMENTED:**
+1. **System Controller**
+   - Ring-buffer event queue (32 events)
+   - HAL-based timing và performance monitoring
+   - Event dispatch trong update() cycle
+   - CPU usage <5% target achieved
+
+2. **Safety Monitor**
+   - E-Stop latency measurement (<50ms)
+   - Emergency stop callback hooks
+   - Fault code enum và reporting
+   - Safety zone và interlock monitoring
+
+3. **Control Loop**
+   - PID position/velocity control
+   - Motion profile generation
+   - Safety limits và acceleration limiting
+   - Response time <100ms validated
+
+4. **System State Machine**
+   - State transition logic và validation
+   - LED pattern mapping theo state
+   - Safety-state integration via Safety Monitor
+   - Emergency state handling
+
+5. **Telemetry Integration**
+   - Core systems telemetry wiring
+   - Standardized telemetry schema
+   - JSON publishing: system/safety/control status
+   - Error propagation từ core systems
+
+6. **Testing Framework**
+   - Unit tests cho E-Stop latency
+   - Control loop timing validation
+   - Telemetry JSON field verification
+   - Performance benchmarks và metrics
+
+### **📊 QUALITY IMPROVEMENTS:**
+- **Code Quality:** Excellent (0 linter errors)
+- **Safety Compliance:** E-Stop latency <50ms achieved
+- **Test Coverage:** 100% (all unit tests passing)
+- **Performance:** Control loop <100ms, CPU <5%
+- **Architecture:** Event-driven design, clean interfaces
+
+---
+
+## 📋 **VERSION 2.2.0 - PHASE 4 COMPLETION (01/09/2025)**
+
+### **✅ PHASE 4 DELIVERABLES:**
+1. **Complete API Documentation**
+   - API endpoint documentation với request/response examples
+   - Error code documentation với troubleshooting guides
+   - Integration examples cho common use cases
+   - API_ENDPOINTS_SPECIFICATION.md updated với v2.0 architecture
+
+2. **Safety Documentation Update**
+   - Safety system architecture documentation
+   - Zone configuration guides
+   - Emergency procedures documentation
+   - SAFETY_ARCHITECTURE.md created với SIL2 compliance
+
+3. **Final System Validation (Partial)**
+   - Basic integration tests: All passing
+   - Performance tests: Enhanced logging validated
+   - API documentation: Complete và comprehensive
+   - Safety validation tests: Minor issues identified (non-critical)
+
+### **🔧 CRITICAL ISSUE RESOLUTION:**
+- **BUILD-001:** ✅ **RESOLVED** - Build System Fixes
+- **RS485-001:** ✅ **IMPLEMENTED** - RS485 HAL Implementation
+- **DISCOVERY-001:** ✅ **IMPLEMENTED** - Module Discovery Enhancement
+- **TESTING-001:** ✅ **IMPLEMENTED** - Testing System Improvement
+
+---
+
+## 📋 **VERSION 2.1.0 - PHASE 3 COMPLETION (30/08/2025)**
+
+### **✅ PHASE 3 DELIVERABLES:**
+1. **Performance Optimization**
+   - Safety Monitor Update: Batch checking với early exit (3% improvement)
+   - Zone Checking: Single-pass algorithm với static buffers
+   - API Manager: Cached endpoint pointers và optimized error handling
+   - Find Endpoint: Early exit và optimized iteration
+
+2. **Enhanced Error Handling & Logging**
+   - Structured Logging: Component, function, line number context
+   - Color-coded Log Levels: Visual distinction cho different log levels
+   - Error Tracking: Automatic error counting và statistics
+   - Performance Logging: 28,571 msgs/sec (28x faster than requirement)
+   - Logging Statistics: Total messages, errors, uptime tracking
+
+### **📊 PERFORMANCE METRICS:**
+- **Response Time:** 171μs (improved from 176μs - 3% faster)
+- **Memory Usage:** 0 KB growth (stable memory usage)
+- **Logging Performance:** 28,571 msgs/sec (28x faster than requirement)
+- **Build Success Rate:** 100% (no critical errors)
+- **Test Success Rate:** 100% (all core tests passing)
+
+---
+
+## 📋 **VERSION 2.0.0 - PHASE 2 COMPLETION (29/08/2025)**
+
+### **✅ PHASE 2 DELIVERABLES:**
+1. **Integration Testing**
+   - Basic Integration Tests: 6/6 tests passed (100%)
+   - Module Discovery Tests: 12/14 tests passed (85.7%)
+   - Performance Tests: 2/3 tests passed (66.7%)
+   - API Endpoint Registration: System endpoints working
+   - System State Machine Integration: Proper initialization
+
+2. **Performance Optimization**
+   - Safety Check Cycles: Optimized với early exit và batch processing
+   - Memory Usage: Reduced với static buffers và single-pass algorithms
+   - API Manager: Optimized endpoint lookup và request processing
+
+---
+
+## 📋 **VERSION 1.1.0 - PHASE 1 COMPLETION (28/08/2025)**
+
+### **✅ PHASE 1 DELIVERABLES:**
+1. **Complete TODO Implementation (BE-009)**
+   - Timestamp Function - High-precision implementation
+   - Zone Checking Logic - Multi-zone support  
+   - Interlock Checking - Door/light curtain/emergency
+   - Sensor Checking - Fault detection system
+   - Watchdog Checking - Timeout monitoring
+   - Logging System - Event logging với telemetry
+
+2. **Safety Integration Testing**
+   - Safety system validation
+   - Emergency procedures testing
+   - Safety compliance validation
+
+---
+
+## 📋 **VERSION 1.0.0 - PHASE 0 COMPLETION (27/08/2025)**
+
+### **✅ PHASE 0 DELIVERABLES:**
+1. **Emergency Build Fixes**
+   - Fixed linker errors (duplicate relay functions)
+   - Fixed build warnings và include errors
+   - Build Status: SUCCESS - All targets compile successfully
+   - Critical Issues: RESOLVED - No more build blockers
+
+---
+
+## 🚀 **UPCOMING VERSIONS - PHASE 2 DEVELOPMENT**
+
+### **VERSION 4.0.0 - PHASE 2 COMPLETION (11/10/2025)**
+- **Module Manager Enhancement** - Auto-discovery và health monitoring
+- **Communication Manager Enhancement** - Advanced protocols và redundancy
+- **Safety Manager Enhancement** - Advanced safety features
+- **Configuration Manager** - Dynamic configuration management
+- **Diagnostics Manager** - Comprehensive system diagnostics
+
+### **VERSION 5.0.0 - PRODUCTION RELEASE (TBD)**
+- Production-ready firmware package
+- Security & compliance validation
+- Deployment & monitoring setup
+- User acceptance testing
+- Production deployment
+
+---
+
+## 📊 **VERSION COMPARISON MATRIX**
+
+| Version | Phase | Status | Test Coverage | Quality Gates | Safety Compliance |
+|---------|-------|--------|---------------|---------------|-------------------|
+| 1.0.0   | 0     | ✅     | 85%           | 3/5          | Basic            |
+| 1.1.0   | 1     | ✅     | 90%           | 4/5          | Enhanced         |
+| 2.0.0   | 2     | ✅     | 92%           | 4/5          | Enhanced         |
+| 2.1.0   | 3     | ✅     | 95%           | 5/5          | Enhanced         |
+| 2.2.0   | 4     | ✅     | 95%           | 5/5          | Enhanced         |
+| **3.0.0** | **1** | **✅** | **100%**      | **5/5**      | **SIL2**         |
+| 4.0.0   | 2     | 🔄     | TBD           | TBD          | TBD              |
+
+---
+
+## 📋 **BREAKING CHANGES**
+
+### **VERSION 3.0.0:**
+- **Error Handling:** All error cases now return HAL_STATUS_ERROR (-1)
+- **API Consistency:** Standardized error response patterns
+- **Safety Validation:** Enhanced parameter validation requirements
+
+### **VERSION 2.1.0:**
+- **Logging System:** Structured logging với new format
+- **Performance:** Optimized algorithms với different behavior
+- **API Manager:** Cached lookups với performance improvements
+
+---
+
+## 📋 **DEPRECATED FEATURES**
+
+### **VERSION 3.0.0:**
+- **Old Error Codes:** Inconsistent error handling patterns
+- **Unsafe Parameter Validation:** Missing input validation
+- **Test Framework Issues:** Inconsistent test results
+
+---
+
+## 📋 **KNOWN ISSUES**
+
+### **VERSION 3.0.0:**
+- **None:** All critical issues resolved
+- **Minor:** Performance optimization opportunities identified
+- **Future:** Advanced features planned for Phase 2
+
+---
+
+## 📋 **CONTRIBUTORS**
+
+### **Development Team:**
+- **FW Team Lead:** Core development và architecture
+- **Core Developers:** Implementation và testing
+- **Test Engineers:** Quality assurance và validation
+- **Documentation:** Technical writing và user guides
+
+### **QA/QC Team:**
+- **Safety Validation:** E-Stop system testing
+- **Quality Gates:** Code quality assessment
+- **Test Coverage:** Comprehensive testing validation
+- **Compliance:** SIL2 standards validation
+
+---
+
+## 📋 **LICENSE & COMPLIANCE**
+
+### **License:**
+- **Project:** OHT-50 Firmware Development
+- **License Type:** Proprietary
+- **Compliance:** ISO 12207:2017 Software Life Cycle Processes
+
+### **Safety Standards:**
+- **SIL Level:** SIL2 compliance achieved
+- **Safety Validation:** 100% safety systems validated
+- **Emergency Procedures:** All emergency procedures tested
+- **Fail-Safe Design:** No safety bypass possible
+
+---
+
+**🎯 CHANGELOG STATUS: COMPLETE VERSION 3.0.0**
+
+**🚀 NEXT VERSION: 4.0.0 - PHASE 2 COMPLETION (11/10/2025)**
+
+**📋 MAINTAINED BY: PM & FW Team Lead**
+
+---
+
+**Changelog v3.1.0:**
+- ✅ Added Version 3.1.0 - Documentation Cleanup & Integration
+- ✅ Updated all README files with clean structure
+- ✅ Integrated firmware documentation with project structure
+- ✅ Added comprehensive navigation and cross-references
+- ✅ Updated changelog with documentation improvements
+- ✅ Added Version 3.0.0 - Phase 1 Completion
+- ✅ Added Version 2.2.0 - Phase 4 Completion
+- ✅ Added Version 2.1.0 - Phase 3 Completion
+- ✅ Added Version 2.0.0 - Phase 2 Completion
+- ✅ Added Version 1.1.0 - Phase 1 Completion
+- ✅ Added Version 1.0.0 - Phase 0 Completion
+- ✅ Added upcoming versions planning
+- ✅ Added version comparison matrix
+- ✅ Added breaking changes documentation
+- ✅ Added deprecated features
+- ✅ Added known issues
+- ✅ Added contributors section
+- ✅ Added license & compliance
+- ✅ Added overall project status

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/OHT50_FIRMWARE_IMPLEMENTATION_PLAN.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/OHT50_FIRMWARE_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,721 @@
+# OHT-50 Firmware Implementation Plan
+
+**Version:** 1.0  
+**Date:** 2025-01-28  
+**Status:** Active  
+**Project:** OHT-50 Master Module Firmware  
+
+## 📋 Table of Contents
+
+1. [Project Overview](#project-overview)
+2. [Implementation Phases](#implementation-phases)
+3. [Phase 1: Foundation & HAL](#phase-1-foundation--hal)
+4. [Phase 2: Core Systems](#phase-2-core-systems)
+5. [Phase 3: Managers & Communication](#phase-3-managers--communication)
+6. [Phase 4: Module Handlers](#phase-4-module-handlers)
+7. [Phase 5: API & Integration](#phase-5-api--integration)
+8. [Phase 6: Testing & Validation](#phase-6-testing--validation)
+9. [Phase 7: Documentation & Deployment](#phase-7-documentation--deployment)
+10. [Risk Management](#risk-management)
+11. [Success Criteria](#success-criteria)
+
+---
+
+## 🎯 Project Overview
+
+### **Objective**
+Implement a complete, production-ready firmware system for the OHT-50 Master Module with:
+- **Hardware Integration:** RS485, Ethernet, WiFi, GPIO, LED, E-Stop, Relay
+- **Module Management:** Power, Safety, Motor, Dock modules
+- **Safety Systems:** E-Stop, safety monitoring, emergency procedures
+- **Communication:** Modbus RTU, HTTP API, WebSocket telemetry
+- **Control Systems:** Motion control, navigation, docking
+- **Monitoring:** Real-time telemetry, diagnostics, logging
+
+### **Architecture Overview**
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OHT-50 Master Module                     │
+├─────────────────────────────────────────────────────────────┤
+│  Application Layer (API, Managers, Modules)                │
+├─────────────────────────────────────────────────────────────┤
+│  Core Systems (Control, Safety, State Machine)             │
+├─────────────────────────────────────────────────────────────┤
+│  Hardware Abstraction Layer (HAL)                          │
+├─────────────────────────────────────────────────────────────┤
+│  Hardware (Orange Pi 5B + Peripherals)                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 🚀 Implementation Phases
+
+### **Timeline Overview**
+- **Total Duration:** 12 weeks
+- **Phase Duration:** 1-3 weeks each
+- **Parallel Development:** Multiple teams working simultaneously
+- **Integration Points:** End of each phase
+
+### **Phase Dependencies**
+```
+Phase 1 (HAL) → Phase 2 (Core) → Phase 3 (Managers) → Phase 4 (Modules)
+     ↓              ↓                ↓                   ↓
+Phase 5 (API) ← Phase 6 (Testing) ← Phase 7 (Deploy)
+```
+
+---
+
+## 🔧 Phase 1: Foundation & HAL (Week 1-2)
+
+### **Objective**
+Establish hardware abstraction layer and basic system foundation.
+
+### **Deliverables**
+- [ ] HAL implementation for all hardware interfaces
+- [ ] Basic system initialization and configuration
+- [ ] Hardware validation and testing framework
+- [ ] Error handling and logging system
+
+### **Detailed Tasks**
+
+#### **1.1 HAL Common (Days 1-2)**
+- [ ] Implement `hal_common.c/h` with status codes and utilities
+- [ ] Add timestamp functions (`hal_get_timestamp_us/ms`)
+- [ ] Implement error handling system
+- [ ] Add configuration management
+- [ ] Create logging system with levels
+- [ ] Add statistics tracking
+
+#### **1.2 HAL Communication (Days 3-5)**
+- [ ] **RS485 HAL (`hal_rs485.c/h`)**
+  - [ ] UART1 configuration (`/dev/ttyS1`)
+  - [ ] Modbus RTU protocol implementation
+  - [ ] CRC calculation and verification
+  - [ ] Frame transmission/reception
+  - [ ] Error handling and retry logic
+  - [ ] Statistics tracking
+
+- [ ] **Network HAL (`hal_network.c/h`)**
+  - [ ] Ethernet interface management
+  - [ ] WiFi interface management
+  - [ ] Network status monitoring
+  - [ ] Failover mechanism (Ethernet → WiFi)
+  - [ ] Connectivity testing
+
+- [ ] **USB HAL (`hal_usb.c/h`)**
+  - [ ] USB device enumeration
+  - [ ] Serial communication
+  - [ ] Packet handling
+
+#### **1.3 HAL Peripherals (Days 6-8)**
+- [ ] **GPIO HAL (`hal_gpio.c/h`)**
+  - [ ] Pin configuration and management
+  - [ ] Input/output operations
+  - [ ] Interrupt handling
+  - [ ] Pin validation (GPIO1_D2, GPIO1_D3)
+
+- [ ] **LED HAL (`hal_led.c/h`)**
+  - [ ] 5 LED control (Power, System, Communication, Network, Error)
+  - [ ] LED patterns and states
+  - [ ] Brightness control
+
+- [ ] **Relay HAL (`hal_relay.c/h`)**
+  - [ ] Relay control (2 channels)
+  - [ ] Safety interlocks
+  - [ ] Status monitoring
+
+- [ ] **LiDAR HAL (`hal_lidar.c/h`)**
+  - [ ] LiDAR device initialization
+  - [ ] Scan data acquisition
+  - [ ] Data processing
+
+#### **1.4 HAL Safety (Days 9-10)**
+- [ ] **E-Stop HAL (`hal_estop.c/h`)**
+  - [ ] E-Stop button monitoring
+  - [ ] Safety circuit validation
+  - [ ] Emergency procedures
+  - [ ] Callback system
+
+#### **1.5 HAL Storage (Days 11-12)**
+- [ ] **Configuration Persistence (`hal_config_persistence.c/h`)**
+  - [ ] Configuration file management
+  - [ ] JSON/YAML parsing
+  - [ ] Default configuration
+  - [ ] Configuration validation
+
+### **Testing & Validation**
+- [ ] Hardware validation tests
+- [ ] HAL unit tests
+- [ ] Integration tests with real hardware
+- [ ] Performance benchmarks
+
+### **Exit Criteria**
+- [ ] All HAL modules compile without errors
+- [ ] Hardware validation tests pass
+- [ ] Basic communication established
+- [ ] Error handling working correctly
+
+---
+
+## 🏗️ Phase 2: Core Systems (Week 3-4)
+
+### **Objective**
+Implement core system components for control, safety, and state management.
+
+### **Deliverables**
+- [ ] System controller with state management
+- [ ] Safety monitoring system
+- [ ] Control loop implementation
+- [ ] System state machine
+
+### **Detailed Tasks**
+
+#### **2.1 System Controller (Days 1-3)**
+- [ ] **System Controller (`system_controller.c/h`)**
+  - [ ] System initialization and shutdown
+  - [ ] State management (Init, Idle, Active, Fault, Emergency, Shutdown)
+  - [ ] Event processing system
+  - [ ] Performance monitoring
+  - [ ] Error handling and recovery
+  - [ ] Configuration management
+
+#### **2.2 Safety Monitor (Days 4-6)**
+- [ ] **Safety Monitor (`safety_monitor.c/h`)**
+  - [ ] E-Stop monitoring and handling
+  - [ ] Safety zone management
+  - [ ] Interlock monitoring
+  - [ ] Sensor validation
+  - [ ] Emergency procedures
+  - [ ] Safety compliance validation
+  - [ ] LiDAR safety integration
+
+#### **2.3 Control Loop (Days 7-9)**
+- [ ] **Control Loop (`control_loop.c/h`)**
+  - [ ] PID controller implementation
+  - [ ] Motion profile generation
+  - [ ] Position and velocity control
+  - [ ] Safety limit checking
+  - [ ] Emergency stop handling
+  - [ ] Control mode management (Position, Velocity, Torque)
+
+#### **2.4 System State Machine (Days 10-12)**
+- [ ] **State Machine (`system_state_machine.c/h`)**
+  - [ ] State transition logic
+  - [ ] Event-driven state changes
+  - [ ] State validation
+  - [ ] LED pattern management
+  - [ ] Safety state integration
+
+### **Testing & Validation**
+- [ ] Unit tests for all core components
+- [ ] State machine validation
+- [ ] Safety system testing
+- [ ] Control loop performance testing
+
+### **Exit Criteria**
+- [ ] All core systems compile and run
+- [ ] State transitions work correctly
+- [ ] Safety systems respond properly
+- [ ] Control loop meets performance requirements
+
+---
+
+## 📡 Phase 3: Managers & Communication (Week 5-6)
+
+### **Objective**
+Implement manager layer for communication, module management, and telemetry.
+
+### **Deliverables**
+- [ ] Communication manager with Modbus support
+- [ ] Module manager with discovery and health monitoring
+- [ ] Safety manager integration
+- [ ] Telemetry manager with real-time data
+
+### **Detailed Tasks**
+
+#### **3.1 Communication Manager (Days 1-4)**
+- [ ] **Communication Manager (`communication_manager.c/h`)**
+  - [ ] Modbus RTU protocol implementation
+  - [ ] Thread-safe request/response handling
+  - [ ] Automatic retry and timeout management
+  - [ ] Statistics tracking and monitoring
+  - [ ] Event callback system
+  - [ ] Error handling and recovery
+  - [ ] Buffer management
+
+#### **3.2 Module Manager (Days 5-8)**
+- [ ] **Module Manager (`module_manager.c/h`)**
+  - [ ] Automatic module discovery (addresses 0x01-0x08)
+  - [ ] Module registration and tracking
+  - [ ] Health monitoring with response time tracking
+  - [ ] Module type detection (Power, Safety, Motor, Dock)
+  - [ ] Bounds checking and validation
+  - [ ] Event system for module status changes
+  - [ ] Statistics and diagnostics
+
+#### **3.3 Safety Manager (Days 9-10)**
+- [ ] **Safety Manager (`safety_manager.c/h`)**
+  - [ ] Safety system integration
+  - [ ] E-Stop handling
+  - [ ] Safety circuit monitoring
+  - [ ] Fault detection and reporting
+  - [ ] Safety compliance validation
+
+#### **3.4 Telemetry Manager (Days 11-12)**
+- [ ] **Telemetry Manager (`telemetry_manager.c/h`)**
+  - [ ] Real-time data collection
+  - [ ] JSON serialization
+  - [ ] Event broadcasting
+  - [ ] Data buffering and management
+  - [ ] Performance optimization
+
+### **Testing & Validation**
+- [ ] Manager integration tests
+- [ ] Communication reliability testing
+- [ ] Module discovery validation
+- [ ] Telemetry performance testing
+
+### **Exit Criteria**
+- [ ] All managers compile and integrate
+- [ ] Module discovery works correctly
+- [ ] Communication is reliable
+- [ ] Telemetry data is accurate
+
+---
+
+## 🔌 Phase 4: Module Handlers (Week 7-8)
+
+### **Objective**
+Implement specific handlers for each module type with full functionality.
+
+### **Deliverables**
+- [ ] Power module handler with battery management
+- [ ] Safety module handler with sensor monitoring
+- [ ] Motor module handler with motion control
+- [ ] Dock module handler with docking procedures
+
+### **Detailed Tasks**
+
+#### **4.1 Power Module Handler (Days 1-4)**
+- [ ] **Power Module Handler (`power_module_handler.c/h`)**
+  - [ ] DalyBMS battery management
+  - [ ] SK60X charging control
+  - [ ] INA219 power distribution monitoring
+  - [ ] Relay control (12V, 5V, 3.3V)
+  - [ ] Battery health monitoring
+  - [ ] Charging status management
+  - [ ] Fault detection and handling
+  - [ ] Auto-detection functionality
+
+#### **4.2 Safety Module Handler (Days 5-6)**
+- [ ] **Safety Module Handler (`safety_module_handler.c/h`)**
+  - [ ] Analog sensor monitoring (4 sensors)
+  - [ ] Digital sensor monitoring
+  - [ ] Safety zone management
+  - [ ] Relay output control
+  - [ ] Proximity alert system
+  - [ ] Emergency stop integration
+  - [ ] Fault detection and reporting
+
+#### **4.3 Motor Module Handler (Days 7-8)**
+- [ ] **Motor Module Handler (`travel_motor_module_handler.c/h`)**
+  - [ ] Position control
+  - [ ] Velocity control
+  - [ ] Acceleration control
+  - [ ] Homing procedure
+  - [ ] Emergency stop handling
+  - [ ] Fault detection and recovery
+  - [ ] Motion profile management
+  - [ ] Safety limit enforcement
+
+#### **4.4 Dock Module Handler (Days 9-10)**
+- [ ] **Dock Module Handler (`dock_module_handler.c/h`)**
+  - [ ] Docking procedure management
+  - [ ] Position alignment
+  - [ ] Distance monitoring
+  - [ ] Charging connection management
+  - [ ] RFID tag reading
+  - [ ] Safety monitoring during docking
+  - [ ] Calibration procedures
+
+#### **4.5 Module Registry (Days 11-12)**
+- [ ] **Module Registry (`module_registry.c/h`)**
+  - [ ] Module registration system
+  - [ ] Module metadata management
+  - [ ] Online/offline tracking
+  - [ ] Configuration persistence
+  - [ ] Event system integration
+
+### **Testing & Validation**
+- [ ] Module handler unit tests
+- [ ] Integration tests with real modules
+- [ ] Performance testing
+- [ ] Error handling validation
+
+### **Exit Criteria**
+- [ ] All module handlers compile and work
+- [ ] Module communication is reliable
+- [ ] Error handling is robust
+- [ ] Performance meets requirements
+
+---
+
+## 🌐 Phase 5: API & Integration (Week 9-10)
+
+### **Objective**
+Implement HTTP API and WebSocket interfaces for external communication.
+
+### **Deliverables**
+- [ ] HTTP REST API with full CRUD operations
+- [ ] WebSocket telemetry streaming
+- [ ] API documentation and examples
+- [ ] Integration with all managers and modules
+
+### **Detailed Tasks**
+
+#### **5.1 HTTP API Implementation (Days 1-5)**
+- [ ] **API Framework Setup**
+  - [ ] HTTP server implementation
+  - [ ] REST API routing
+  - [ ] JSON request/response handling
+  - [ ] Authentication and authorization
+  - [ ] Error handling and status codes
+
+- [ ] **System API Endpoints**
+  - [ ] `GET /api/v1/system/status` - System status
+  - [ ] `GET /api/v1/system/config` - Configuration
+  - [ ] `POST /api/v1/system/config` - Update configuration
+  - [ ] `POST /api/v1/system/restart` - System restart
+  - [ ] `POST /api/v1/system/shutdown` - System shutdown
+
+- [ ] **Module API Endpoints**
+  - [ ] `GET /api/v1/modules` - List all modules
+  - [ ] `GET /api/v1/modules/{id}` - Module details
+  - [ ] `POST /api/v1/modules/discover` - Start discovery
+  - [ ] `GET /api/v1/modules/{id}/status` - Module status
+  - [ ] `POST /api/v1/modules/{id}/command` - Send command
+
+- [ ] **Control API Endpoints**
+  - [ ] `POST /api/v1/control/move` - Move command
+  - [ ] `POST /api/v1/control/stop` - Stop command
+  - [ ] `POST /api/v1/control/emergency-stop` - Emergency stop
+  - [ ] `GET /api/v1/control/status` - Control status
+
+- [ ] **Safety API Endpoints**
+  - [ ] `GET /api/v1/safety/status` - Safety status
+  - [ ] `POST /api/v1/safety/reset` - Reset safety
+  - [ ] `GET /api/v1/safety/zones` - Safety zones
+
+#### **5.2 WebSocket Implementation (Days 6-8)**
+- [ ] **WebSocket Server**
+  - [ ] WebSocket connection management
+  - [ ] Real-time data streaming
+  - [ ] Connection authentication
+  - [ ] Heartbeat mechanism
+
+- [ ] **Telemetry Streaming**
+  - [ ] Real-time system status
+  - [ ] Module data streaming
+  - [ ] Event notifications
+  - [ ] Performance metrics
+
+#### **5.3 API Integration (Days 9-10)**
+- [ ] **Manager Integration**
+  - [ ] Connect API to all managers
+  - [ ] Data validation and sanitization
+  - [ ] Error handling and logging
+  - [ ] Performance optimization
+
+- [ ] **Security Implementation**
+  - [ ] API authentication
+  - [ ] Request validation
+  - [ ] Rate limiting
+  - [ ] CORS handling
+
+### **Testing & Validation**
+- [ ] API unit tests
+- [ ] Integration tests
+- [ ] Performance testing
+- [ ] Security testing
+
+### **Exit Criteria**
+- [ ] All API endpoints work correctly
+- [ ] WebSocket streaming is reliable
+- [ ] Performance meets requirements
+- [ ] Security is properly implemented
+
+---
+
+## 🧪 Phase 6: Testing & Validation (Week 11)
+
+### **Objective**
+Comprehensive testing of the entire system with validation against requirements.
+
+### **Deliverables**
+- [ ] Complete test suite
+- [ ] Performance validation
+- [ ] Safety validation
+- [ ] Integration test results
+
+### **Detailed Tasks**
+
+#### **6.1 Unit Testing (Days 1-3)**
+- [ ] **HAL Unit Tests**
+  - [ ] Communication HAL tests
+  - [ ] Peripheral HAL tests
+  - [ ] Safety HAL tests
+  - [ ] Error handling tests
+
+- [ ] **Core System Tests**
+  - [ ] System controller tests
+  - [ ] Safety monitor tests
+  - [ ] Control loop tests
+  - [ ] State machine tests
+
+- [ ] **Manager Tests**
+  - [ ] Communication manager tests
+  - [ ] Module manager tests
+  - [ ] Safety manager tests
+  - [ ] Telemetry manager tests
+
+- [ ] **Module Handler Tests**
+  - [ ] Power module tests
+  - [ ] Safety module tests
+  - [ ] Motor module tests
+  - [ ] Dock module tests
+
+#### **6.2 Integration Testing (Days 4-6)**
+- [ ] **System Integration Tests**
+  - [ ] End-to-end system tests
+  - [ ] Manager integration tests
+  - [ ] Module integration tests
+  - [ ] API integration tests
+
+- [ ] **Hardware Integration Tests**
+  - [ ] Real hardware validation
+  - [ ] Communication reliability tests
+  - [ ] Performance benchmarks
+  - [ ] Stress testing
+
+#### **6.3 Safety Validation (Days 7-8)**
+- [ ] **Safety System Tests**
+  - [ ] E-Stop functionality
+  - [ ] Safety zone validation
+  - [ ] Emergency procedures
+  - [ ] Fault handling
+
+- [ ] **Compliance Testing**
+  - [ ] Safety standards compliance
+  - [ ] Performance requirements
+  - [ ] Reliability requirements
+
+#### **6.4 Performance Testing (Days 9-10)**
+- [ ] **Performance Benchmarks**
+  - [ ] Response time testing
+  - [ ] Throughput testing
+  - [ ] Memory usage testing
+  - [ ] CPU usage testing
+
+- [ ] **Stress Testing**
+  - [ ] High load testing
+  - [ ] Long duration testing
+  - [ ] Error condition testing
+
+### **Testing & Validation**
+- [ ] All tests pass
+- [ ] Performance meets requirements
+- [ ] Safety validation complete
+- [ ] Documentation updated
+
+### **Exit Criteria**
+- [ ] All unit tests pass
+- [ ] Integration tests successful
+- [ ] Safety validation complete
+- [ ] Performance requirements met
+
+---
+
+## 📚 Phase 7: Documentation & Deployment (Week 12)
+
+### **Objective**
+Complete documentation and prepare for production deployment.
+
+### **Deliverables**
+- [ ] Complete system documentation
+- [ ] User and developer guides
+- [ ] Deployment procedures
+- [ ] Production-ready firmware
+
+### **Detailed Tasks**
+
+#### **7.1 Documentation (Days 1-4)**
+- [ ] **System Documentation**
+  - [ ] Architecture documentation
+  - [ ] API documentation
+  - [ ] Configuration guide
+  - [ ] Troubleshooting guide
+
+- [ ] **User Documentation**
+  - [ ] Installation guide
+  - [ ] User manual
+  - [ ] Operation procedures
+  - [ ] Maintenance guide
+
+- [ ] **Developer Documentation**
+  - [ ] Development setup guide
+  - [ ] Code documentation
+  - [ ] Testing guide
+  - [ ] Contribution guidelines
+
+#### **7.2 Deployment Preparation (Days 5-8)**
+- [ ] **Build System**
+  - [ ] Automated build process
+  - [ ] Version management
+  - [ ] Release packaging
+  - [ ] Deployment scripts
+
+- [ ] **Configuration Management**
+  - [ ] Default configurations
+  - [ ] Configuration validation
+  - [ ] Migration procedures
+  - [ ] Backup procedures
+
+#### **7.3 Production Readiness (Days 9-10)**
+- [ ] **Quality Assurance**
+  - [ ] Final testing
+  - [ ] Performance validation
+  - [ ] Security review
+  - [ ] Code review
+
+- [ ] **Deployment Procedures**
+  - [ ] Installation procedures
+  - [ ] Configuration procedures
+  - [ ] Testing procedures
+  - [ ] Rollback procedures
+
+### **Testing & Validation**
+- [ ] Documentation review
+- [ ] Deployment testing
+- [ ] User acceptance testing
+- [ ] Production validation
+
+### **Exit Criteria**
+- [ ] Documentation is complete and accurate
+- [ ] Deployment procedures work correctly
+- [ ] System is production-ready
+- [ ] All stakeholders approve
+
+---
+
+## ⚠️ Risk Management
+
+### **Technical Risks**
+- **Hardware Compatibility Issues**
+  - **Risk:** Hardware not working as expected
+  - **Mitigation:** Early hardware validation, fallback options
+  - **Contingency:** Hardware replacement or modification
+
+- **Performance Issues**
+  - **Risk:** System not meeting performance requirements
+  - **Mitigation:** Early performance testing, optimization
+  - **Contingency:** Hardware upgrade or code optimization
+
+- **Safety Compliance Issues**
+  - **Risk:** Not meeting safety standards
+  - **Mitigation:** Early safety validation, expert review
+  - **Contingency:** Design modifications or additional safety features
+
+### **Schedule Risks**
+- **Development Delays**
+  - **Risk:** Tasks taking longer than expected
+  - **Mitigation:** Buffer time, parallel development
+  - **Contingency:** Scope reduction or schedule extension
+
+- **Integration Issues**
+  - **Risk:** Components not integrating properly
+  - **Mitigation:** Early integration testing, clear interfaces
+  - **Contingency:** Interface redesign or additional testing
+
+### **Resource Risks**
+- **Team Availability**
+  - **Risk:** Team members unavailable
+  - **Mitigation:** Cross-training, documentation
+  - **Contingency:** External resources or schedule adjustment
+
+- **Hardware Availability**
+  - **Risk:** Hardware not available when needed
+  - **Mitigation:** Early procurement, simulation
+  - **Contingency:** Hardware alternatives or simulation
+
+---
+
+## ✅ Success Criteria
+
+### **Functional Requirements**
+- [ ] All hardware interfaces work correctly
+- [ ] Module discovery and communication reliable
+- [ ] Safety systems meet requirements
+- [ ] API provides all required functionality
+- [ ] Performance meets specifications
+
+### **Quality Requirements**
+- [ ] Code coverage > 90%
+- [ ] All tests pass
+- [ ] No critical bugs
+- [ ] Documentation complete
+- [ ] Performance benchmarks met
+
+### **Safety Requirements**
+- [ ] E-Stop functionality works correctly
+- [ ] Safety zones properly implemented
+- [ ] Emergency procedures validated
+- [ ] Compliance with safety standards
+- [ ] Fault handling robust
+
+### **Performance Requirements**
+- [ ] Response time < 100ms for critical operations
+- [ ] Communication reliability > 99.9%
+- [ ] System uptime > 99.5%
+- [ ] Memory usage within limits
+- [ ] CPU usage within limits
+
+---
+
+## 📊 Progress Tracking
+
+### **Weekly Reviews**
+- **Week 1-2:** HAL implementation review
+- **Week 3-4:** Core systems review
+- **Week 5-6:** Managers review
+- **Week 7-8:** Module handlers review
+- **Week 9-10:** API implementation review
+- **Week 11:** Testing review
+- **Week 12:** Final review and deployment
+
+### **Milestones**
+- **Milestone 1:** HAL Complete (Week 2)
+- **Milestone 2:** Core Systems Complete (Week 4)
+- **Milestone 3:** Managers Complete (Week 6)
+- **Milestone 4:** Module Handlers Complete (Week 8)
+- **Milestone 5:** API Complete (Week 10)
+- **Milestone 6:** Testing Complete (Week 11)
+- **Milestone 7:** Production Ready (Week 12)
+
+### **Success Metrics**
+- **Code Quality:** Linting errors = 0, test coverage > 90%
+- **Performance:** All benchmarks met
+- **Safety:** All safety tests pass
+- **Documentation:** 100% complete and reviewed
+- **Deployment:** Successful production deployment
+
+---
+
+**Changelog v1.0:**
+- ✅ Created comprehensive implementation plan
+- ✅ Defined 7 phases with detailed tasks
+- ✅ Added risk management section
+- ✅ Included success criteria and metrics
+- ✅ Added progress tracking framework
+
+**🚨 Note:** This plan should be reviewed and updated weekly based on progress and any changes in requirements or constraints.

--- a/firmware_new/docs/02-IMPLEMENTATION/04-SLC/README.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/04-SLC/README.md
@@ -1,0 +1,307 @@
+# System Life Cycle (SLC) - OHT-50 Firmware
+
+**Phiên bản:** 2.0  
+**Ngày cập nhật:** 2025-01-28  
+**Mục tiêu:** System Life Cycle documentation cho OHT-50 firmware
+
+---
+
+## 📋 **SLC Overview**
+
+### **System Life Cycle Phases:**
+- **Phase 1:** Planning & Requirements (Completed)
+- **Phase 2:** Design & Architecture (Completed)
+- **Phase 3:** Implementation (In Progress)
+- **Phase 4:** Integration & Testing (Planned)
+- **Phase 5:** Deployment & Operations (Planned)
+- **Phase 6:** Maintenance & Evolution (Planned)
+
+### **Current Status:**
+- **Phase 1-2:** ✅ Completed
+- **Phase 3:** 🔄 In Progress (Module Data API Implementation)
+- **Phase 4:** 📋 Planned (Integration & Testing)
+- **Phase 5:** 📋 Planned (Deployment)
+- **Phase 6:** 📋 Planned (Maintenance)
+
+---
+
+## 📚 **SLC Documentation**
+
+### **Planning:**
+- [API Integration Implementation Plan](01-planning/API_INTEGRATION_IMPLEMENTATION_PLAN.md) - API integration planning
+- [Firmware Development Plan Phase 3](01-planning/FW_DEVELOPMENT_PLAN_PHASE3.md) - Phase 3 development plan
+- [Module Manager Implementation Plan](01-planning/MODULE_MANAGER_IMPLEMENTATION_PLAN.md) - Module manager planning
+- [Phase 2 Core Systems Completion Report](01-planning/PHASE2_CORE_SYSTEMS_COMPLETION_REPORT.md) - Phase 2 completion report
+
+### **Design:**
+- [System Architecture Design](02-design/) - System architecture design
+- [Module Design Specifications](02-design/module-design/) - Module design specifications
+- [API Design Specifications](02-design/api-design/) - API design specifications
+
+### **Implementation:**
+- [Implementation Guidelines](03-implementation/) - Implementation guidelines
+- [Module Implementation Guide](03-implementation/module-implementation/) - Module implementation guide
+- [API Implementation Guide](03-implementation/api-implementation/) - API implementation guide
+
+### **Testing:**
+- [Testing Procedures](04-testing/) - Testing procedures
+- [Unit Testing Guide](04-testing/unit-testing/) - Unit testing guide
+- [Integration Testing Guide](04-testing/integration-testing/) - Integration testing guide
+
+---
+
+## 🎯 **SLC Implementation Status**
+
+### **✅ COMPLETED PHASES:**
+
+#### **Phase 1: Planning & Requirements**
+- **Requirements Analysis:** Complete system requirements analysis
+- **Architecture Planning:** System architecture planning
+- **Resource Planning:** Resource allocation and planning
+- **Timeline Planning:** Project timeline and milestones
+
+#### **Phase 2: Design & Architecture**
+- **System Design:** Complete system design
+- **Module Design:** Module architecture design
+- **API Design:** API architecture design
+- **Safety Design:** Safety system design
+
+### **🔄 IN PROGRESS:**
+
+#### **Phase 3: Implementation**
+- **Core Systems:** Core system implementation
+- **Module Systems:** Module system implementation
+- **API Systems:** API system implementation
+- **Safety Systems:** Safety system implementation
+
+### **📋 PLANNED PHASES:**
+
+#### **Phase 4: Integration & Testing**
+- **System Integration:** System integration testing
+- **Module Integration:** Module integration testing
+- **API Integration:** API integration testing
+- **Safety Integration:** Safety system integration
+
+#### **Phase 5: Deployment & Operations**
+- **System Deployment:** System deployment procedures
+- **Operations Setup:** Operations and monitoring setup
+- **User Training:** User training and documentation
+- **Go-Live:** System go-live procedures
+
+#### **Phase 6: Maintenance & Evolution**
+- **System Maintenance:** Ongoing system maintenance
+- **Performance Monitoring:** Performance monitoring and optimization
+- **Feature Evolution:** Feature enhancement and evolution
+- **Lifecycle Management:** System lifecycle management
+
+---
+
+## 🔧 **SLC Implementation Roadmap**
+
+### **Sprint 1: Firmware HTTP Server (Week 1-2)**
+- **HTTP Server Setup:** Basic HTTP server implementation
+- **API Endpoints:** Core API endpoints implementation
+- **Error Handling:** Basic error handling implementation
+- **Testing:** Basic testing implementation
+
+### **Sprint 2: WebSocket & Real-time (Week 3-4)**
+- **WebSocket Server:** WebSocket server implementation
+- **Real-time Communication:** Real-time data streaming
+- **Message Handling:** WebSocket message handling
+- **Connection Management:** Connection management
+
+### **Sprint 3: Security & Performance (Week 5-6)**
+- **Security Implementation:** Security features implementation
+- **Performance Optimization:** Performance optimization
+- **Monitoring:** System monitoring implementation
+- **Logging:** Comprehensive logging system
+
+### **Sprint 4: Backend Integration (Week 7-8)**
+- **Backend API Integration:** Backend API integration
+- **Data Synchronization:** Data synchronization
+- **Error Recovery:** Error recovery mechanisms
+- **Testing:** Integration testing
+
+### **Sprint 5: Frontend Integration (Week 9-10)**
+- **Frontend API Integration:** Frontend API integration
+- **UI Integration:** User interface integration
+- **Real-time Updates:** Real-time UI updates
+- **Testing:** End-to-end testing
+
+### **Sprint 6: Integration & Validation (Week 11-12)**
+- **System Integration:** Complete system integration
+- **Performance Validation:** Performance validation
+- **Safety Validation:** Safety system validation
+- **User Acceptance Testing:** User acceptance testing
+
+---
+
+## 📊 **SLC Metrics & KPIs**
+
+### **Implementation Metrics:**
+- **Code Coverage:** > 90% test coverage
+- **Build Success Rate:** > 95% build success
+- **API Response Time:** < 100ms average response
+- **System Uptime:** > 99.9% uptime
+- **Error Rate:** < 0.1% error rate
+
+### **Quality Metrics:**
+- **Defect Density:** < 1 defect per KLOC
+- **Code Review Coverage:** 100% code review
+- **Documentation Coverage:** 100% documentation
+- **Safety Compliance:** 100% safety compliance
+- **Performance Compliance:** 100% performance compliance
+
+### **Project Metrics:**
+- **Schedule Adherence:** > 95% on-time delivery
+- **Budget Adherence:** > 95% budget adherence
+- **Scope Adherence:** > 95% scope adherence
+- **Quality Adherence:** > 95% quality adherence
+- **Risk Management:** < 5% risk impact
+
+---
+
+## 🔒 **SLC Quality Gates**
+
+### **Phase 1 Gate: Planning Complete**
+- [ ] Requirements analysis complete
+- [ ] Architecture design complete
+- [ ] Resource allocation complete
+- [ ] Timeline planning complete
+
+### **Phase 2 Gate: Design Complete**
+- [ ] System design complete
+- [ ] Module design complete
+- [ ] API design complete
+- [ ] Safety design complete
+
+### **Phase 3 Gate: Implementation Complete**
+- [ ] Core systems implemented
+- [ ] Module systems implemented
+- [ ] API systems implemented
+- [ ] Safety systems implemented
+
+### **Phase 4 Gate: Integration Complete**
+- [ ] System integration complete
+- [ ] Module integration complete
+- [ ] API integration complete
+- [ ] Safety integration complete
+
+### **Phase 5 Gate: Deployment Complete**
+- [ ] System deployment complete
+- [ ] Operations setup complete
+- [ ] User training complete
+- [ ] Go-live complete
+
+### **Phase 6 Gate: Maintenance Complete**
+- [ ] System maintenance complete
+- [ ] Performance monitoring complete
+- [ ] Feature evolution complete
+- [ ] Lifecycle management complete
+
+---
+
+## 🧪 **SLC Testing Strategy**
+
+### **Unit Testing:**
+- **Function Testing:** Test all functions
+- **Interface Testing:** Test all interfaces
+- **Error Testing:** Test error conditions
+- **Performance Testing:** Test performance requirements
+
+### **Integration Testing:**
+- **System Integration:** Test system integration
+- **Module Integration:** Test module integration
+- **API Integration:** Test API integration
+- **Safety Integration:** Test safety integration
+
+### **System Testing:**
+- **End-to-End Testing:** Test complete system
+- **Performance Testing:** Test system performance
+- **Stress Testing:** Test system under stress
+- **Safety Testing:** Test safety requirements
+
+### **Acceptance Testing:**
+- **User Acceptance:** User acceptance testing
+- **System Acceptance:** System acceptance testing
+- **Performance Acceptance:** Performance acceptance testing
+- **Safety Acceptance:** Safety acceptance testing
+
+---
+
+## 📚 **SLC Documentation**
+
+### **Planning Documentation:**
+- **Project Plans:** Project planning documents
+- **Implementation Plans:** Implementation planning documents
+- **Testing Plans:** Testing planning documents
+- **Deployment Plans:** Deployment planning documents
+
+### **Design Documentation:**
+- **System Design:** System design documents
+- **Module Design:** Module design documents
+- **API Design:** API design documents
+- **Safety Design:** Safety design documents
+
+### **Implementation Documentation:**
+- **Implementation Guides:** Implementation guide documents
+- **Code Documentation:** Code documentation
+- **API Documentation:** API documentation
+- **User Documentation:** User documentation
+
+### **Testing Documentation:**
+- **Test Plans:** Test planning documents
+- **Test Cases:** Test case documents
+- **Test Results:** Test result documents
+- **Test Reports:** Test report documents
+
+---
+
+## 🔄 **SLC Management**
+
+### **SLC Governance:**
+- **SLC Board:** SLC governance board
+- **SLC Processes:** SLC management processes
+- **SLC Standards:** SLC standards and guidelines
+- **SLC Metrics:** SLC metrics and KPIs
+
+### **SLC Monitoring:**
+- **Progress Monitoring:** SLC progress monitoring
+- **Quality Monitoring:** SLC quality monitoring
+- **Risk Monitoring:** SLC risk monitoring
+- **Performance Monitoring:** SLC performance monitoring
+
+### **SLC Improvement:**
+- **Process Improvement:** SLC process improvement
+- **Quality Improvement:** SLC quality improvement
+- **Performance Improvement:** SLC performance improvement
+- **Risk Improvement:** SLC risk improvement
+
+---
+
+## 📚 **Related Documents**
+
+### **Firmware Documentation:**
+- [Firmware README](../README.md) - Main firmware documentation
+- [Requirements Documentation](../02-REQUIREMENTS/) - Firmware requirements
+- [Safety Documentation](../04-SAFETY/) - Safety systems
+- [Quality Documentation](../05-QUALITY/) - Quality assurance
+
+### **Project Documentation:**
+- [Project SLC Planning](../../../03-ARCHITECTURE/architecture/SLC_PLANNING_OHT-50.md) - Project SLC planning
+- [System Architecture](../../../03-ARCHITECTURE/) - System architecture
+- [Requirements](../../../02-REQUIREMENTS/) - Project requirements
+
+---
+
+**Changelog v2.0:**
+- ✅ Updated SLC documentation structure
+- ✅ Added comprehensive SLC overview
+- ✅ Added SLC implementation status
+- ✅ Added SLC implementation roadmap
+- ✅ Added SLC metrics and KPIs
+- ✅ Added SLC quality gates
+- ✅ Added SLC testing strategy
+- ✅ Integrated with firmware documentation cleanup
+
+**🚨 Lưu ý:** SLC documentation đã được updated để reflect current implementation status và integration với project structure.

--- a/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/02-safety-integration/LIDAR_SAFETY_INTEGRATION_FINAL_REPORT.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/02-safety-integration/LIDAR_SAFETY_INTEGRATION_FINAL_REPORT.md
@@ -1,0 +1,477 @@
+# LiDAR Safety Integration - Final Report
+
+**Phiên bản:** 1.0.0  
+**Ngày hoàn thành:** 2025-01-28  
+**Dự án:** OHT-50 Master Module  
+**Module:** LiDAR Safety Integration  
+**Team:** FIRMWARE  
+**Tổng thời gian:** 24.5 giờ
+
+---
+
+## 📋 **TỔNG QUAN DỰ ÁN**
+
+### **Mục tiêu dự án**
+Tích hợp LiDAR sensor với safety system của OHT-50 Master Module để cung cấp real-time proximity detection và safety zone monitoring, đảm bảo an toàn cho hệ thống robot tự động.
+
+### **Phạm vi dự án**
+- LiDAR driver integration
+- Safety zones monitoring (3 zones: Emergency, Warning, Safe)
+- E-Stop integration (hardware & software)
+- LED status indication
+- Configuration management
+- API integration
+- Testing & validation framework
+- Comprehensive documentation
+
+---
+
+## ✅ **KẾT QUẢ HOÀN THÀNH**
+
+### **Tổng quan tiến độ**
+- **Tổng số tasks:** 8/8 (100% hoàn thành)
+- **Critical Tasks:** 2/2 (100% hoàn thành)
+- **High Priority Tasks:** 3/3 (100% hoàn thành)
+- **Medium Priority Tasks:** 1/1 (100% hoàn thành)
+- **Low Priority Tasks:** 2/2 (100% hoàn thành)
+
+### **Chi tiết từng task**
+
+#### **Task 1: LiDAR Driver Integration** ✅
+- **Thời gian:** 2.5 giờ
+- **Trạng thái:** Hoàn thành
+- **Mô tả:** Tích hợp LiDAR driver với safety monitor
+- **Deliverables:** LiDAR scan data processing, distance calculation
+
+#### **Task 2: Basic Safety Zones (3 zones)** ✅
+- **Thời gian:** 4 giờ
+- **Trạng thái:** Hoàn thành
+- **Mô tả:** Implement 3-zone safety system
+- **Deliverables:** Emergency (500mm), Warning (1000mm), Safe (2000mm) zones
+
+#### **Task 4: Safety Zone Violation Handling** ✅
+- **Thời gian:** 2.5 giờ
+- **Trạng thái:** Hoàn thành
+- **Mô tả:** Xử lý vi phạm safety zones
+- **Deliverables:** Zone violation detection, automatic E-Stop trigger
+
+#### **Task 5: API Integration cho Safety Data** ✅
+- **Thời gian:** 3 giờ
+- **Trạng thái:** Hoàn thành
+- **Mô tả:** REST API cho safety data
+- **Deliverables:** Safety status, zones, E-Stop API endpoints
+
+#### **Task 6: E-Stop Integration với LiDAR** ✅
+- **Thời gian:** 2.5 giờ
+- **Trạng thái:** Hoàn thành
+- **Mô tả:** Tích hợp E-Stop với LiDAR data
+- **Deliverables:** LiDAR-triggered E-Stop, response time < 100ms
+
+#### **Task 7: Safety Status LED Integration** ✅
+- **Thời gian:** 2 giờ
+- **Trạng thái:** Hoàn thành
+- **Mô tả:** LED patterns cho safety states
+- **Deliverables:** Visual feedback cho tất cả safety states
+
+#### **Task 8: Configuration Management** ✅
+- **Thời gian:** 3 giờ
+- **Trạng thái:** Hoàn thành
+- **Mô tả:** Quản lý cấu hình safety system
+- **Deliverables:** JSON import/export, persistence, validation
+
+#### **Task 9: Testing & Validation** ✅
+- **Thời gian:** 3 giờ
+- **Trạng thái:** Hoàn thành
+- **Mô tả:** Test framework và validation
+- **Deliverables:** Unit, integration, safety, performance tests
+
+#### **Task 10: Documentation Update** ✅
+- **Thời gian:** 2 giờ
+- **Trạng thái:** Hoàn thành
+- **Mô tả:** Cập nhật tài liệu
+- **Deliverables:** API reference, integration guide, configuration guide
+
+---
+
+## 🔧 **TECHNICAL IMPLEMENTATION**
+
+### **Core Components**
+
+#### **1. Safety Monitor Module**
+```c
+// Core safety monitoring system
+safety_monitor.c/h
+├── Initialization & management
+├── Safety zones monitoring
+├── E-Stop handling
+├── State transitions
+├── LED status management
+└── Configuration management
+```
+
+#### **2. LiDAR Integration**
+```c
+// LiDAR data processing
+lidar_driver.c/h
+├── Real-time scan data processing
+├── Distance calculation
+├── Zone violation detection
+└── E-Stop triggering
+```
+
+#### **3. API Interface**
+```c
+// REST API endpoints
+api_endpoints.c/h
+├── Safety status API
+├── Safety zones API
+├── E-Stop control API
+└── Configuration management API
+```
+
+#### **4. Configuration System**
+```c
+// Configuration management
+hal_config_persistence.c/h
+├── JSON import/export
+├── Persistent storage
+├── Factory defaults
+└── Validation
+```
+
+#### **5. Test Framework**
+```c
+// Comprehensive testing
+safety_monitor_test.c/h
+├── Unit tests
+├── Integration tests
+├── Safety tests
+├── Performance tests
+└── Test runner
+```
+
+### **Safety Features**
+
+#### **3-Zone Safety System**
+- **Emergency Zone:** < 500mm - Immediate E-Stop
+- **Warning Zone:** < 1000mm - Reduce speed, warning indication
+- **Safe Zone:** < 2000mm - Normal operation, monitoring
+
+#### **E-Stop Integration**
+- **Hardware E-Stop:** Physical button integration
+- **Software E-Stop:** LiDAR-triggered emergency stop
+- **Response Time:** < 100ms cho E-Stop trigger
+- **Reliability:** 99.9% uptime cho safety monitoring
+
+#### **LED Status Indication**
+- **Safe State:** All LEDs solid (normal operation)
+- **Warning State:** System LED fast blink, Comm LED slow blink
+- **E-Stop State:** Error LED fast blink red, others off
+- **Fault State:** Error LED slow blink red, others off
+
+---
+
+## 📊 **PERFORMANCE METRICS**
+
+### **Safety Performance**
+- **E-Stop Response Time:** < 100ms (target achieved)
+- **Zone Detection Accuracy:** ±10mm
+- **False Positive Rate:** < 0.1%
+- **False Negative Rate:** 0% (critical safety)
+
+### **System Performance**
+- **Update Frequency:** 20Hz (target achieved)
+- **Memory Usage:** < 1MB cho safety monitor
+- **CPU Usage:** < 5% cho safety monitoring
+- **API Response Time:** < 50ms
+
+### **Reliability Metrics**
+- **System Uptime:** 99.9% target
+- **Safety System Reliability:** 99.99%
+- **Configuration Persistence:** 100%
+- **Test Coverage:** > 90%
+
+---
+
+## 🔌 **API ENDPOINTS**
+
+### **Safety Status API**
+```
+GET /api/v1/safety/status
+Response: Current safety status và zone information
+```
+
+### **Safety Zones API**
+```
+GET /api/v1/safety/zones
+PUT /api/v1/safety/zones
+Request/Response: Safety zones configuration
+```
+
+### **E-Stop Control API**
+```
+POST /api/v1/safety/estop
+Request/Response: E-Stop control và status
+```
+
+### **Configuration Management API**
+```
+GET /api/v1/safety/config
+PUT /api/v1/safety/config
+GET /api/v1/safety/config/export
+POST /api/v1/safety/config/import
+POST /api/v1/safety/config/reset
+```
+
+---
+
+## 🧪 **TESTING & VALIDATION**
+
+### **Test Categories**
+- **Unit Tests:** Core functionality testing
+- **Integration Tests:** Component integration testing
+- **Safety Tests:** Critical safety validation
+- **Performance Tests:** Performance benchmarking
+- **Stress Tests:** System stress testing
+
+### **Test Results**
+- **Total Tests:** 12 tests implemented
+- **Unit Tests:** 5 tests (Safety monitor, zones, E-Stop, states, LED)
+- **Integration Tests:** 3 tests (LiDAR, API, config persistence)
+- **Safety Tests:** 3 tests (Emergency violation, warning violation, response time)
+- **Performance Tests:** 1 test (Update frequency)
+
+### **Test Framework Features**
+- **Automated Test Execution:** Command-line test runner
+- **Test Reporting:** Detailed test reports
+- **Mock Data Generation:** LiDAR và safety zones mock data
+- **Performance Benchmarking:** Response time measurement
+- **Safety Validation:** Critical safety checks
+
+---
+
+## 📁 **DELIVERABLES**
+
+### **Source Code**
+```
+firmware_new/src/app/core/
+├── safety_monitor.c/h          # Core safety monitor
+├── safety_monitor_test.c/h     # Test framework
+└── test/
+    └── safety_monitor_test_runner.c  # Test runner
+
+firmware_new/src/app/api/
+├── api_endpoints.c/h           # API implementation
+└── api_manager.c               # API routing
+
+firmware_new/src/hal/
+├── peripherals/hal_led.c/h     # LED control
+├── safety/hal_estop.c/h        # E-Stop control
+└── storage/hal_config_persistence.c/h  # Configuration
+```
+
+### **Documentation**
+```
+firmware_new/docs/
+├── LIDAR_SAFETY_INTEGRATION_PLAN.md      # Project plan
+├── SAFETY_MONITOR_API_REFERENCE.md       # API reference
+├── LIDAR_SAFETY_INTEGRATION_GUIDE.md     # Integration guide
+├── SAFETY_CONFIGURATION_GUIDE.md         # Configuration guide
+├── QA_QC_FIRMWARE_REPORT.md              # QA/QC report
+└── LIDAR_SAFETY_INTEGRATION_FINAL_REPORT.md  # Final report
+```
+
+### **Test Framework**
+- **Test Header:** `safety_monitor_test.h`
+- **Test Implementation:** `safety_monitor_test.c`
+- **Test Runner:** `safety_monitor_test_runner.c`
+- **Test Configuration:** Configurable test categories
+- **Test Reporting:** Automated report generation
+
+---
+
+## 🎯 **ACHIEVEMENTS**
+
+### **Technical Achievements**
+- ✅ **Real-time Safety Monitoring:** LiDAR-based proximity detection
+- ✅ **3-Zone Safety System:** Emergency, Warning, Safe zones
+- ✅ **E-Stop Integration:** Hardware & software E-Stop
+- ✅ **LED Status Feedback:** Visual indication cho safety states
+- ✅ **Configuration Management:** JSON import/export, persistence
+- ✅ **API Integration:** Complete REST API interface
+- ✅ **Test Framework:** Comprehensive testing suite
+- ✅ **Documentation:** Complete technical documentation
+
+### **Safety Achievements**
+- ✅ **Response Time:** < 100ms E-Stop response (target achieved)
+- ✅ **Reliability:** 99.9% uptime target
+- ✅ **Accuracy:** ±10mm distance measurement
+- ✅ **False Positives:** < 0.1% target
+- ✅ **False Negatives:** 0% (critical safety)
+
+### **Quality Achievements**
+- ✅ **Test Coverage:** > 90% code coverage
+- ✅ **Documentation:** 100% API documented
+- ✅ **Code Quality:** Clean, maintainable code
+- ✅ **Error Handling:** Comprehensive error handling
+- ✅ **Validation:** Input validation và safety checks
+
+---
+
+## 🔒 **SAFETY COMPLIANCE**
+
+### **Safety Standards**
+- **Functional Safety:** SIL2 compliance target
+- **Emergency Stop:** IEC 60204-1 compliance
+- **Safety Zones:** ISO 13482 compliance
+- **Response Time:** < 100ms cho critical safety functions
+
+### **Safety Features**
+- **Hardware E-Stop:** Physical emergency stop button
+- **Software E-Stop:** LiDAR-triggered emergency stop
+- **Zone Monitoring:** Real-time proximity detection
+- **Visual Feedback:** LED status indication
+- **Configuration Validation:** Safety parameter validation
+- **Error Handling:** Comprehensive error recovery
+
+### **Safety Validation**
+- **Zone Violation Tests:** Emergency, warning, safe zone testing
+- **E-Stop Response Tests:** Response time validation
+- **Integration Tests:** End-to-end safety validation
+- **Performance Tests:** Safety system performance validation
+
+---
+
+## 📈 **PERFORMANCE BENCHMARKS**
+
+### **Safety Performance**
+| Metric | Target | Achieved | Status |
+|--------|--------|----------|--------|
+| E-Stop Response Time | < 100ms | < 100ms | ✅ |
+| Zone Detection Accuracy | ±10mm | ±10mm | ✅ |
+| False Positive Rate | < 0.1% | < 0.1% | ✅ |
+| False Negative Rate | 0% | 0% | ✅ |
+
+### **System Performance**
+| Metric | Target | Achieved | Status |
+|--------|--------|----------|--------|
+| Update Frequency | 20Hz | 20Hz | ✅ |
+| Memory Usage | < 1MB | < 1MB | ✅ |
+| CPU Usage | < 5% | < 5% | ✅ |
+| API Response Time | < 50ms | < 50ms | ✅ |
+
+### **Reliability Metrics**
+| Metric | Target | Achieved | Status |
+|--------|--------|----------|--------|
+| System Uptime | 99.9% | 99.9% | ✅ |
+| Safety Reliability | 99.99% | 99.99% | ✅ |
+| Test Coverage | > 90% | > 90% | ✅ |
+| Documentation | 100% | 100% | ✅ |
+
+---
+
+## 🚀 **DEPLOYMENT READINESS**
+
+### **Production Readiness**
+- ✅ **Code Complete:** All features implemented
+- ✅ **Tested:** Comprehensive test coverage
+- ✅ **Documented:** Complete documentation
+- ✅ **Validated:** Safety validation completed
+- ✅ **Performance:** Performance targets met
+- ✅ **Reliability:** Reliability targets met
+
+### **Deployment Checklist**
+- [x] **Safety System:** Validated và tested
+- [x] **API Interface:** Complete và documented
+- [x] **Configuration:** Management system ready
+- [x] **Testing:** Framework implemented
+- [x] **Documentation:** Complete technical docs
+- [x] **Performance:** Benchmarks achieved
+- [x] **Reliability:** Targets met
+- [x] **Compliance:** Safety standards met
+
+---
+
+## 🔮 **FUTURE ENHANCEMENTS**
+
+### **Potential Improvements**
+- **Advanced Zone Shapes:** Custom zone geometries
+- **Machine Learning:** Predictive safety analysis
+- **Multi-Sensor Fusion:** Integration với other sensors
+- **Cloud Integration:** Remote monitoring capabilities
+- **Advanced Analytics:** Safety performance analytics
+
+### **Scalability Considerations**
+- **Multi-Robot Support:** Support for multiple robots
+- **Distributed Safety:** Distributed safety monitoring
+- **Real-time Analytics:** Real-time safety analytics
+- **Mobile Integration:** Mobile app integration
+
+---
+
+## 📋 **LESSONS LEARNED**
+
+### **Technical Lessons**
+- **Safety First:** Safety requirements must be prioritized
+- **Real-time Performance:** Response time is critical for safety
+- **Comprehensive Testing:** Safety systems require extensive testing
+- **Documentation:** Good documentation is essential for safety systems
+- **Configuration Management:** Flexible configuration is important
+
+### **Process Lessons**
+- **Incremental Development:** Step-by-step development works well
+- **Continuous Testing:** Regular testing throughout development
+- **Documentation Updates:** Keep documentation updated
+- **Safety Validation:** Regular safety validation is crucial
+- **Performance Monitoring:** Monitor performance continuously
+
+---
+
+## 🎉 **CONCLUSION**
+
+### **Project Success**
+LiDAR Safety Integration project đã hoàn thành thành công với tất cả objectives đạt được:
+
+- ✅ **100% Tasks Completed:** Tất cả 8 tasks đã hoàn thành
+- ✅ **All Targets Met:** Tất cả performance targets đạt được
+- ✅ **Safety Compliance:** Safety standards compliance
+- ✅ **Production Ready:** System ready for production deployment
+- ✅ **Comprehensive Documentation:** Complete technical documentation
+- ✅ **Test Framework:** Comprehensive testing suite
+
+### **Key Achievements**
+1. **Real-time Safety Monitoring:** LiDAR-based proximity detection
+2. **3-Zone Safety System:** Emergency, Warning, Safe zones
+3. **E-Stop Integration:** Hardware & software E-Stop
+4. **LED Status Feedback:** Visual indication cho safety states
+5. **Configuration Management:** JSON import/export, persistence
+6. **API Integration:** Complete REST API interface
+7. **Test Framework:** Comprehensive testing suite
+8. **Documentation:** Complete technical documentation
+
+### **Impact**
+- **Safety Enhancement:** Significant improvement in system safety
+- **Real-time Monitoring:** Real-time proximity detection
+- **Automated Response:** Automatic safety responses
+- **Visual Feedback:** Clear visual safety indication
+- **Configuration Flexibility:** Flexible safety configuration
+- **API Integration:** Easy integration với external systems
+- **Comprehensive Testing:** Thorough testing và validation
+
+**LiDAR Safety Integration project đã hoàn thành thành công và sẵn sàng cho production deployment!**
+
+---
+
+**Changelog v1.0:**
+- ✅ Created comprehensive final report
+- ✅ Added project overview và objectives
+- ✅ Added detailed task completion status
+- ✅ Added technical implementation details
+- ✅ Added performance metrics và benchmarks
+- ✅ Added safety compliance information
+- ✅ Added deployment readiness assessment
+- ✅ Added future enhancement suggestions
+- ✅ Added lessons learned
+- ✅ Added project conclusion
+
+**🚨 Lưu ý:** Dự án đã hoàn thành thành công với tất cả requirements đạt được.

--- a/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/02-safety-integration/LIDAR_SAFETY_INTEGRATION_GUIDE.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/02-safety-integration/LIDAR_SAFETY_INTEGRATION_GUIDE.md
@@ -1,0 +1,479 @@
+# LiDAR Safety Integration Guide
+
+**Phiên bản:** 1.0.0  
+**Ngày cập nhật:** 2025-01-28  
+**Module:** LiDAR Safety Integration  
+**Team:** FIRMWARE  
+**Task:** LIDAR Safety Integration
+
+---
+
+## 📋 **TỔNG QUAN**
+
+LiDAR Safety Integration Guide mô tả cách tích hợp LiDAR sensor với safety system của OHT-50 Master Module để cung cấp real-time proximity detection và safety zone monitoring.
+
+---
+
+## 🎯 **MỤC TIÊU**
+
+### **Primary Objectives**
+- ✅ **Real-time Safety Monitoring:** LiDAR-based proximity detection
+- ✅ **3-Zone Safety System:** Emergency, Warning, Safe zones
+- ✅ **E-Stop Integration:** Automatic E-Stop khi emergency zone violated
+- ✅ **LED Status Feedback:** Visual indication cho safety states
+- ✅ **Configuration Management:** Flexible zone configuration
+
+### **Safety Requirements**
+- **Emergency Zone:** < 500mm - Immediate E-Stop
+- **Warning Zone:** < 1000mm - Reduce speed, warning indication
+- **Safe Zone:** < 2000mm - Normal operation, monitoring
+- **Response Time:** < 100ms cho E-Stop trigger
+- **Reliability:** 99.9% uptime cho safety monitoring
+
+---
+
+## 🔧 **ARCHITECTURE OVERVIEW**
+
+### **System Architecture**
+```mermaid
+graph TD
+    A[LiDAR Sensor] --> B[LiDAR Driver]
+    B --> C[Safety Monitor]
+    C --> D[E-Stop System]
+    C --> E[LED Status]
+    C --> F[API Interface]
+    C --> G[Configuration]
+    
+    H[Hardware E-Stop] --> D
+    I[API Commands] --> F
+    J[Config Files] --> G
+```
+
+### **Data Flow**
+```mermaid
+sequenceDiagram
+    participant LIDAR as LiDAR Sensor
+    participant DRIVER as LiDAR Driver
+    participant SAFETY as Safety Monitor
+    participant ESTOP as E-Stop System
+    participant LED as LED Status
+    participant API as API Interface
+    
+    LIDAR->>DRIVER: Scan Data
+    DRIVER->>SAFETY: Processed Data
+    SAFETY->>SAFETY: Zone Check
+    alt Emergency Zone Violated
+        SAFETY->>ESTOP: Trigger E-Stop
+        SAFETY->>LED: Error Pattern
+    else Warning Zone Violated
+        SAFETY->>LED: Warning Pattern
+    else Safe Zone Violated
+        SAFETY->>LED: Normal Pattern
+    end
+    SAFETY->>API: Status Update
+```
+
+---
+
+## 📁 **FILE STRUCTURE**
+
+### **Core Files**
+```
+firmware_new/src/app/core/
+├── safety_monitor.h          # Safety monitor header
+├── safety_monitor.c          # Safety monitor implementation
+└── lidar_driver.h           # LiDAR driver interface
+
+firmware_new/src/hal/
+├── peripherals/
+│   ├── hal_led.h            # LED control
+│   └── hal_led.c
+├── safety/
+│   ├── hal_estop.h          # E-Stop control
+│   └── hal_estop.c
+└── storage/
+    ├── hal_config_persistence.h  # Configuration storage
+    └── hal_config_persistence.c
+
+firmware_new/src/app/api/
+├── api_endpoints.h          # API endpoints
+├── api_endpoints.c          # API implementation
+└── api_manager.c            # API routing
+
+firmware_new/docs/
+├── LIDAR_SAFETY_INTEGRATION_PLAN.md
+├── SAFETY_MONITOR_API_REFERENCE.md
+├── LIDAR_SAFETY_INTEGRATION_GUIDE.md
+└── SAFETY_CONFIGURATION_GUIDE.md
+```
+
+---
+
+## 🔌 **INTEGRATION STEPS**
+
+### **Step 1: LiDAR Driver Integration**
+```c
+// Initialize LiDAR driver
+hal_status_t status = lidar_driver_init();
+if (status != HAL_STATUS_OK) {
+    printf("Failed to initialize LiDAR driver\n");
+    return status;
+}
+
+// Configure LiDAR parameters
+lidar_config_t config = {
+    .baud_rate = 460800,
+    .scan_frequency = 10,  // 10Hz
+    .angle_resolution = 1, // 1 degree
+    .range_min = 50,       // 50mm
+    .range_max = 5000      // 5000mm
+};
+lidar_driver_set_config(&config);
+```
+
+### **Step 2: Safety Monitor Initialization**
+```c
+// Initialize safety monitor
+status = safety_monitor_init();
+if (status != HAL_STATUS_OK) {
+    printf("Failed to initialize safety monitor\n");
+    return status;
+}
+
+// Set safety zones
+basic_safety_zones_t zones = {
+    .enabled = true,
+    .emergency_zone_mm = 500,  // 500mm
+    .warning_zone_mm = 1000,   // 1000mm
+    .safe_zone_mm = 2000       // 2000mm
+};
+safety_monitor_set_basic_zones(&zones);
+```
+
+### **Step 3: Main Loop Integration**
+```c
+// Main safety monitoring loop
+while (running) {
+    // Get LiDAR scan data
+    lidar_scan_data_t scan_data;
+    status = lidar_driver_get_scan_data(&scan_data);
+    
+    if (status == HAL_STATUS_OK) {
+        // Update safety monitor with LiDAR data
+        safety_monitor_update_with_lidar(&scan_data);
+    } else {
+        // Fallback to basic safety monitoring
+        safety_monitor_update();
+    }
+    
+    // Update LED status
+    hal_led_update();
+    
+    // Sleep for 50ms (20Hz update rate)
+    usleep(50000);
+}
+```
+
+---
+
+## 🚨 **SAFETY ZONES CONFIGURATION**
+
+### **Zone Definitions**
+```c
+typedef struct {
+    bool enabled;                    // Enable/disable zones
+    uint16_t emergency_zone_mm;      // Emergency zone (500mm)
+    uint16_t warning_zone_mm;        // Warning zone (1000mm)
+    uint16_t safe_zone_mm;           // Safe zone (2000mm)
+    uint16_t min_distance_mm;        // Current min distance
+    uint16_t min_distance_angle;     // Angle of min distance
+    bool emergency_violated;         // Emergency zone violated
+    bool warning_violated;           // Warning zone violated
+    bool safe_violated;              // Safe zone violated
+    uint64_t last_violation_time;    // Last violation timestamp
+} basic_safety_zones_t;
+```
+
+### **Zone Behavior**
+| Zone | Distance | Action | LED Pattern |
+|------|----------|--------|-------------|
+| **Emergency** | < 500mm | E-Stop | Error LED fast blink |
+| **Warning** | < 1000mm | Reduce speed | System LED fast blink |
+| **Safe** | < 2000mm | Monitor | Normal operation |
+| **Clear** | > 2000mm | Normal | All LEDs solid |
+
+---
+
+## 🔧 **CONFIGURATION MANAGEMENT**
+
+### **JSON Configuration Format**
+```json
+{
+  "safety_config": {
+    "version": "1.0.0",
+    "timestamp": 1234567890,
+    "safety_zones": {
+      "enabled": true,
+      "emergency_zone_mm": 500,
+      "warning_zone_mm": 1000,
+      "safe_zone_mm": 2000
+    },
+    "monitor_config": {
+      "estop_timeout_ms": 100,
+      "zone_check_period_ms": 50,
+      "interlock_check_period_ms": 100,
+      "sensor_check_period_ms": 200,
+      "watchdog_timeout_ms": 1000,
+      "enable_zone_monitoring": true,
+      "enable_interlock_monitoring": true,
+      "enable_sensor_monitoring": true,
+      "enable_watchdog_monitoring": true
+    }
+  }
+}
+```
+
+### **Configuration API Endpoints**
+```
+GET  /api/v1/safety/config          # Get current config
+PUT  /api/v1/safety/config          # Update config
+GET  /api/v1/safety/config/export   # Export config file
+POST /api/v1/safety/config/import   # Import config file
+POST /api/v1/safety/config/reset    # Reset to factory defaults
+```
+
+---
+
+## 🎨 **LED STATUS INDICATION**
+
+### **LED Pattern Mapping**
+```c
+// Safe State
+hal_led_power_set(LED_STATE_ON);      // Green solid
+hal_led_system_set(LED_STATE_ON);     // Blue solid
+hal_led_comm_set(LED_STATE_ON);       // Yellow solid
+hal_led_network_set(LED_STATE_ON);    // Green solid
+hal_led_error_set(LED_STATE_OFF);     // Red off
+
+// Warning State
+hal_led_power_set(LED_STATE_ON);      // Green solid
+hal_led_system_set(LED_STATE_BLINK_FAST); // Blue fast blink
+hal_led_comm_set(LED_STATE_BLINK_SLOW);   // Yellow slow blink
+hal_led_network_set(LED_STATE_ON);    // Green solid
+hal_led_error_set(LED_STATE_OFF);     // Red off
+
+// E-Stop State
+hal_led_power_set(LED_STATE_ON);      // Green solid
+hal_led_system_set(LED_STATE_OFF);    // Blue off
+hal_led_comm_set(LED_STATE_OFF);      // Yellow off
+hal_led_network_set(LED_STATE_OFF);   // Green off
+hal_led_error_set(LED_STATE_BLINK_FAST); // Red fast blink
+```
+
+---
+
+## 🔌 **API INTEGRATION**
+
+### **Safety Status API**
+```bash
+# Get safety status
+curl -X GET "http://localhost:8000/api/v1/safety/status"
+
+# Response
+{
+  "estop_active": false,
+  "safety_ok": true,
+  "safety_level": 0,
+  "safety_message": "System safe",
+  "last_safety_check": 1234567890,
+  "current_state": "SAFE",
+  "safety_zones": {
+    "enabled": true,
+    "emergency_zone_mm": 500,
+    "warning_zone_mm": 1000,
+    "safe_zone_mm": 2000,
+    "min_distance_mm": 1500,
+    "emergency_violated": false,
+    "warning_violated": false,
+    "safe_violated": false
+  },
+  "violation_count": 0,
+  "fault_count": 0
+}
+```
+
+### **Safety Zones API**
+```bash
+# Get zones configuration
+curl -X GET "http://localhost:8000/api/v1/safety/zones"
+
+# Update zones configuration
+curl -X PUT "http://localhost:8000/api/v1/safety/zones" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "emergency_zone_mm": 400,
+    "warning_zone_mm": 800,
+    "safe_zone_mm": 1500
+  }'
+```
+
+---
+
+## ⚠️ **TROUBLESHOOTING**
+
+### **Common Issues**
+
+#### **1. LiDAR Connection Issues**
+```bash
+# Check LiDAR device
+ls -la /dev/ttyUSB0
+
+# Check permissions
+sudo chmod 666 /dev/ttyUSB0
+
+# Test LiDAR communication
+lidar_test_communication
+```
+
+#### **2. Safety Monitor Not Initializing**
+```bash
+# Check HAL components
+hal_led_init
+hal_estop_init
+hal_config_init
+
+# Check safety monitor status
+safety_monitor_get_status
+```
+
+#### **3. Zone Violations Not Detected**
+```bash
+# Check LiDAR data
+lidar_get_scan_data
+
+# Check zone configuration
+safety_monitor_get_basic_zones
+
+# Test zone calculation
+safety_monitor_test_zones
+```
+
+#### **4. E-Stop Not Triggering**
+```bash
+# Check E-Stop hardware
+hal_estop_get_status
+
+# Check software E-Stop
+safety_monitor_is_estop_active
+
+# Test E-Stop trigger
+safety_monitor_trigger_emergency_stop "Test"
+```
+
+### **Debug Commands**
+```bash
+# Enable debug mode
+export SAFETY_DEBUG=1
+
+# Check safety monitor logs
+tail -f /var/log/safety_monitor.log
+
+# Monitor safety status
+watch -n 1 'curl -s http://localhost:8000/api/v1/safety/status | jq'
+```
+
+---
+
+## 🔒 **SAFETY VALIDATION**
+
+### **Safety Checklist**
+- [ ] **LiDAR Sensor:** Connected và calibrated
+- [ ] **Safety Zones:** Properly configured
+- [ ] **E-Stop System:** Hardware và software working
+- [ ] **LED Indicators:** All LEDs functional
+- [ ] **API Interface:** All endpoints responding
+- [ ] **Configuration:** Valid và saved
+- [ ] **Response Time:** < 100ms cho E-Stop
+- [ ] **Error Handling:** Proper fallback mechanisms
+
+### **Validation Tests**
+```bash
+# Test 1: Zone Violation Detection
+# Move object vào emergency zone
+# Verify E-Stop triggered
+
+# Test 2: LED Pattern Changes
+# Trigger different safety states
+# Verify LED patterns correct
+
+# Test 3: API Response
+# Call all safety APIs
+# Verify responses correct
+
+# Test 4: Configuration Persistence
+# Change configuration
+# Restart system
+# Verify configuration preserved
+```
+
+---
+
+## 📊 **PERFORMANCE METRICS**
+
+### **Key Performance Indicators**
+- **Response Time:** < 100ms cho E-Stop trigger
+- **Update Rate:** 20Hz safety monitoring
+- **Accuracy:** ±10mm distance measurement
+- **Reliability:** 99.9% uptime
+- **False Positives:** < 0.1%
+- **False Negatives:** 0% (critical safety)
+
+### **Monitoring Commands**
+```bash
+# Monitor performance
+safety_monitor_get_statistics
+
+# Check response times
+safety_monitor_benchmark
+
+# Monitor resource usage
+top -p $(pgrep safety_monitor)
+```
+
+---
+
+## 🔄 **MAINTENANCE**
+
+### **Regular Maintenance**
+- **Daily:** Check LED indicators
+- **Weekly:** Validate zone configuration
+- **Monthly:** Test E-Stop functionality
+- **Quarterly:** Calibrate LiDAR sensor
+- **Annually:** Full safety system validation
+
+### **Backup Procedures**
+```bash
+# Backup configuration
+safety_monitor_export_config_json > backup_config.json
+
+# Restore configuration
+safety_monitor_import_config_json < backup_config.json
+
+# Factory reset
+safety_monitor_reset_config_to_factory
+```
+
+---
+
+**Changelog v1.0:**
+- ✅ Created comprehensive integration guide
+- ✅ Added architecture overview
+- ✅ Added step-by-step integration instructions
+- ✅ Added configuration management guide
+- ✅ Added troubleshooting section
+- ✅ Added safety validation checklist
+- ✅ Added performance metrics
+- ✅ Added maintenance procedures
+
+**🚨 Lưu ý:** Luôn tuân thủ safety procedures và validation checklist trước khi deploy.

--- a/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/02-safety-integration/LIDAR_SAFETY_INTEGRATION_PLAN.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/02-safety-integration/LIDAR_SAFETY_INTEGRATION_PLAN.md
@@ -1,0 +1,354 @@
+# 🔧 **LIDAR & SAFETY INTEGRATION PLAN - OHT-50**
+
+**Phiên bản:** v1.0.0  
+**Ngày tạo:** 2025-01-28  
+**Team:** FW + EMBED  
+**Mục tiêu:** Tích hợp LiDAR vào safety system với basic safety zones
+
+---
+
+## 📋 **PHÂN TÍCH TÌNH TRẠNG HIỆN TẠI**
+
+### **✅ ĐÃ CÓ SẴN:**
+- LiDAR HAL interface đầy đủ (`hal_lidar.h/c`)
+- Safety Monitor framework (`safety_monitor.h/c`)
+- Main application loop (`main.c`)
+- API endpoints cho safety (`api_endpoints.c`)
+
+### **❌ CHƯA CÓ:**
+- LiDAR integration vào main loop
+- Safety zones implementation
+- Proximity detection logic
+- Real-time safety monitoring
+
+---
+
+## 🎯 **BẢNG PHÂN TÍCH CÔNG VIỆC CẦN LÀM**
+
+| **STT** | **Công việc** | **Mức độ ưu tiên** | **Thời gian ước tính** | **Lý do cần thiết** | **Rủi ro** | **Phụ thuộc** |
+|---------|---------------|-------------------|----------------------|-------------------|------------|---------------|
+| **1** | **LiDAR Integration vào Main Loop** | 🔴 **CRITICAL** | 2-3 giờ | LiDAR phải chạy liên tục để phát hiện chướng ngại vật | Thấp | Không |
+| **2** | **Basic Safety Zones (3 zones)** | 🔴 **CRITICAL** | 4-6 giờ | Cần 3 mức cảnh báo: Emergency(0.5m), Warning(1m), Safe(2m) | Trung bình | Task 1 |
+| **3** | **Proximity Detection Logic** | 🟡 **HIGH** | 3-4 giờ | Xử lý dữ liệu LiDAR để phát hiện vật thể gần | Trung bình | Task 1, 2 |
+| **4** | **Safety Zone Violation Handling** | 🟡 **HIGH** | 2-3 giờ | Xử lý khi vi phạm vùng an toàn | Trung bình | Task 2, 3 |
+| **5** | **API Integration cho Safety Data** | 🟡 **HIGH** | 2-3 giờ | BE cần lấy dữ liệu safety qua API | Thấp | Task 1, 2, 3 |
+| **6** | **E-Stop Integration với LiDAR** | 🟡 **HIGH** | 2-3 giờ | E-Stop tự động khi phát hiện vật thể quá gần | Trung bình | Task 1, 2, 3 |
+| **7** | **Safety Status LED Integration** | 🟢 **MEDIUM** | 1-2 giờ | LED hiển thị trạng thái safety zones | Thấp | Task 2, 3 |
+| **8** | **Configuration Management** | 🟢 **MEDIUM** | 2-3 giờ | Cấu hình safety zones qua API | Thấp | Task 2, 5 |
+| **9** | **Testing & Validation** | 🔴 **CRITICAL** | 4-6 giờ | Test toàn bộ safety system | Thấp | Tất cả tasks |
+| **10** | **Documentation Update** | 🟢 **MEDIUM** | 1-2 giờ | Cập nhật tài liệu kỹ thuật | Thấp | Tất cả tasks |
+
+---
+
+## 📊 **BẢNG TIẾN ĐỘ THỰC HIỆN**
+
+| **STT** | **Công việc** | **Trạng thái** | **Ngày bắt đầu** | **Ngày hoàn thành** | **Thời gian thực tế** | **Ghi chú** |
+|---------|---------------|----------------|------------------|---------------------|---------------------|-------------|
+| **1** | **LiDAR Integration vào Main Loop** | ✅ **COMPLETED** | 2025-01-28 | 2025-01-28 | 2.5 giờ | Hoàn thành |
+| **2** | **Basic Safety Zones (3 zones)** | ✅ **COMPLETED** | 2025-01-28 | 2025-01-28 | 4 giờ | Hoàn thành |
+| **3** | **Proximity Detection Logic** | ❌ **REMOVED** | - | - | - | Xóa - không cần thiết |
+| **4** | **Safety Zone Violation Handling** | ✅ **COMPLETED** | 2025-01-28 | 2025-01-28 | 2.5 giờ | Hoàn thành |
+| **5** | **API Integration cho Safety Data** | ✅ **COMPLETED** | 2025-01-28 | 2025-01-28 | 3 giờ | Hoàn thành |
+| **6** | **E-Stop Integration với LiDAR** | ✅ **COMPLETED** | 2025-01-28 | 2025-01-28 | 2.5 giờ | Hoàn thành |
+| **7** | **Safety Status LED Integration** | ✅ **COMPLETED** | 2025-01-28 | 2025-01-28 | 2 giờ | Hoàn thành |
+| **8** | **Configuration Management** | ✅ **COMPLETED** | 2025-01-28 | 2025-01-28 | 3 giờ | Hoàn thành |
+| **9** | **Testing & Validation** | ✅ **COMPLETED** | 2025-01-28 | 2025-01-28 | 3 giờ | Hoàn thành |
+| **10** | **Documentation Update** | ✅ **COMPLETED** | 2025-01-28 | 2025-01-28 | 2 giờ | Hoàn thành |
+
+**Chú thích trạng thái:**
+- 🔄 **IN PROGRESS** - Đang thực hiện
+- ✅ **COMPLETED** - Hoàn thành
+- ⏳ **PENDING** - Chờ thực hiện
+- ❌ **BLOCKED** - Bị chặn
+- 🔧 **REVIEW** - Cần review
+
+---
+
+## 🔧 **CHI TIẾT TỪNG TASK**
+
+### **Task 1: LiDAR Integration vào Main Loop**
+
+**File cần sửa:**
+- `firmware_new/src/main.c`
+
+**Code cần thêm:**
+```c
+// Trong main() function, sau khi init HAL
+lidar_config_t lidar_config = {
+    .device_path = "/dev/ttyUSB0",
+    .baud_rate = 460800,
+    .scan_rate_hz = 10,
+    .emergency_stop_mm = 500,
+    .warning_mm = 1000,
+    .safe_mm = 2000
+};
+
+if (hal_lidar_init(&lidar_config) == HAL_STATUS_OK) {
+    hal_lidar_start_scanning();
+    printf("[LIDAR] Started scanning\n");
+}
+
+// Trong main loop, thêm:
+if (hal_lidar_get_scan_data(&current_scan) == HAL_STATUS_OK) {
+    // Process scan data for safety
+}
+```
+
+**Lý do cần thiết:** LiDAR phải chạy liên tục để phát hiện chướng ngại vật trong thời gian thực.
+
+---
+
+### **Task 2: Basic Safety Zones (3 zones)**
+
+**File cần sửa:**
+- `firmware_new/src/app/core/safety_monitor.c`
+
+**Code cần implement:**
+```c
+typedef struct {
+    uint16_t emergency_zone_mm;    // 500mm - E-Stop
+    uint16_t warning_zone_mm;      // 1000mm - Warning
+    uint16_t safe_zone_mm;         // 2000mm - Safe
+    bool emergency_violated;
+    bool warning_violated;
+    bool safe_violated;
+} basic_safety_zones_t;
+
+static hal_status_t safety_monitor_check_zones(void)
+{
+    lidar_scan_data_t scan_data;
+    if (hal_lidar_get_scan_data(&scan_data) == HAL_STATUS_OK) {
+        // Check each zone based on minimum distance
+        uint16_t min_distance = lidar_calculate_min_distance(&scan_data);
+        
+        // Update zone violations
+        zones.emergency_violated = (min_distance < zones.emergency_zone_mm);
+        zones.warning_violated = (min_distance < zones.warning_zone_mm);
+        zones.safe_violated = (min_distance < zones.safe_zone_mm);
+    }
+    return HAL_STATUS_OK;
+}
+```
+
+**Lý do cần thiết:** Cần 3 mức cảnh báo an toàn để phản ứng phù hợp với khoảng cách.
+
+---
+
+### **Task 3: Proximity Detection Logic**
+
+**File cần tạo:**
+- `firmware_new/src/app/core/proximity_detector.c/h`
+
+**Code cần implement:**
+```c
+typedef struct {
+    uint16_t min_distance_mm;
+    uint16_t min_distance_angle;
+    bool obstacle_detected;
+    uint8_t obstacle_count;
+    uint16_t obstacle_angles[8];
+} proximity_status_t;
+
+hal_status_t proximity_detect_obstacles(const lidar_scan_data_t *scan_data, proximity_status_t *status)
+{
+    // Analyze scan data to find obstacles
+    // Count obstacles in different directions
+    // Calculate minimum distance and angle
+    return HAL_STATUS_OK;
+}
+```
+
+**Lý do cần thiết:** Cần logic xử lý dữ liệu LiDAR để phát hiện và phân tích chướng ngại vật.
+
+---
+
+### **Task 4: Safety Zone Violation Handling**
+
+**File cần sửa:**
+- `firmware_new/src/app/core/safety_monitor.c`
+
+**Code cần implement:**
+```c
+static hal_status_t safety_monitor_handle_zone_violation(void)
+{
+    if (zones.emergency_violated) {
+        // Trigger E-Stop immediately
+        system_state_machine_process_event(SYSTEM_EVENT_ESTOP_TRIGGERED);
+        hal_led_system_error(); // Red LED
+    } else if (zones.warning_violated) {
+        // Reduce speed, show warning
+        hal_led_system_warning(); // Yellow LED
+    } else if (zones.safe_violated) {
+        // Normal operation, monitor
+        hal_led_system_set(LED_STATE_ON); // Green LED
+    }
+    return HAL_STATUS_OK;
+}
+```
+
+**Lý do cần thiết:** Cần xử lý phù hợp khi vi phạm các vùng an toàn khác nhau.
+
+---
+
+### **Task 5: API Integration cho Safety Data**
+
+**File cần sửa:**
+- `firmware_new/src/app/api/api_endpoints.c`
+
+**Endpoints cần thêm:**
+```c
+// GET /api/v1/safety/zones
+// GET /api/v1/safety/proximity
+// GET /api/v1/lidar/status
+// GET /api/v1/lidar/scan_data
+```
+
+**Response format:**
+```json
+{
+  "safety_zones": {
+    "emergency_violated": false,
+    "warning_violated": false,
+    "safe_violated": false,
+    "min_distance_mm": 1500
+  },
+  "proximity": {
+    "obstacle_detected": false,
+    "obstacle_count": 0,
+    "min_distance_mm": 1500,
+    "min_distance_angle": 180
+  }
+}
+```
+
+**Lý do cần thiết:** Backend cần lấy dữ liệu safety để hiển thị trên dashboard và xử lý.
+
+---
+
+### **Task 6: E-Stop Integration với LiDAR**
+
+**File cần sửa:**
+- `firmware_new/src/app/core/safety_monitor.c`
+
+**Code cần implement:**
+```c
+static hal_status_t safety_monitor_check_emergency_stop(void)
+{
+    if (zones.emergency_violated) {
+        // Auto E-Stop when object too close
+        hal_estop_trigger_software();
+        safety_monitor_process_event(SAFETY_MONITOR_EVENT_EMERGENCY_STOP, "LiDAR emergency stop");
+        return HAL_STATUS_OK;
+    }
+    return HAL_STATUS_OK;
+}
+```
+
+**Lý do cần thiết:** Cần E-Stop tự động khi phát hiện vật thể quá gần (< 0.5m).
+
+---
+
+### **Task 7: Safety Status LED Integration**
+
+**File cần sửa:**
+- `firmware_new/src/app/core/safety_monitor.c`
+
+**Code cần implement:**
+```c
+static void update_safety_leds(void)
+{
+    if (zones.emergency_violated) {
+        hal_led_system_error(); // Red blinking
+    } else if (zones.warning_violated) {
+        hal_led_system_warning(); // Yellow blinking
+    } else {
+        hal_led_system_set(LED_STATE_ON); // Green solid
+    }
+}
+```
+
+**Lý do cần thiết:** LED hiển thị trạng thái safety zones để operator dễ nhận biết.
+
+---
+
+### **Task 8: Configuration Management**
+
+**File cần sửa:**
+- `firmware_new/src/app/api/api_endpoints.c`
+
+**Endpoints cần thêm:**
+```c
+// PUT /api/v1/safety/zones/config
+// GET /api/v1/safety/zones/config
+```
+
+**Configuration format:**
+```json
+{
+  "emergency_zone_mm": 500,
+  "warning_zone_mm": 1000,
+  "safe_zone_mm": 2000,
+  "enable_auto_estop": true,
+  "enable_led_feedback": true
+}
+```
+
+**Lý do cần thiết:** Cần cấu hình safety zones qua API để điều chỉnh theo môi trường.
+
+---
+
+### **Task 9: Testing & Validation**
+
+**Files cần tạo:**
+- `firmware_new/tests/integration/test_lidar_safety.c`
+- `firmware_new/tests/performance/test_safety_response.c`
+
+**Test cases:**
+```c
+void test_emergency_zone_violation(void)
+void test_warning_zone_violation(void)
+void test_safe_zone_violation(void)
+void test_auto_estop_response(void)
+void test_led_feedback(void)
+void test_api_integration(void)
+```
+
+**Lý do cần thiết:** Cần test toàn bộ safety system để đảm bảo hoạt động đúng.
+
+---
+
+### **Task 10: Documentation Update**
+
+**Files cần cập nhật:**
+- `docs/05-IMPLEMENTATION/FIRMWARE/SAFETY_SYSTEM.md`
+- `docs/05-IMPLEMENTATION/FIRMWARE/LIDAR_INTEGRATION.md`
+- `docs/05-IMPLEMENTATION/backend/03-API-SPECIFICATIONS/SAFETY_API.md`
+
+**Lý do cần thiết:** Cập nhật tài liệu kỹ thuật để team khác hiểu và sử dụng.
+
+---
+
+## 📊 **TỔNG KẾT**
+
+### **Thời gian tổng cộng:** 25-35 giờ
+### **Độ ưu tiên:** 
+- **Critical (3 tasks):** 10-15 giờ
+- **High (3 tasks):** 7-10 giờ  
+- **Medium (4 tasks):** 8-10 giờ
+
+### **Rủi ro chính:**
+1. **LiDAR hardware issues** - Cần test với hardware thực
+2. **Safety timing** - Đảm bảo response time < 100ms
+3. **Integration complexity** - Nhiều module tương tác
+
+### **Kết quả mong đợi:**
+- ✅ LiDAR chạy liên tục và ổn định
+- ✅ 3 safety zones hoạt động đúng
+- ✅ E-Stop tự động khi cần
+- ✅ API cung cấp dữ liệu safety
+- ✅ LED feedback rõ ràng
+- ✅ Configuration linh hoạt
+
+---
+
+**🚀 Khuyến nghị:** Bắt đầu với Task 1-3 trước, sau đó làm Task 4-6, cuối cùng là Task 7-10.

--- a/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/03-safety-configuration/SAFETY_CONFIGURATION_GUIDE.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/03-safety-configuration/SAFETY_CONFIGURATION_GUIDE.md
@@ -1,0 +1,513 @@
+# Safety Configuration Guide
+
+**Phiên bản:** 1.0.0  
+**Ngày cập nhật:** 2025-01-28  
+**Module:** Safety Configuration  
+**Team:** FIRMWARE  
+**Task:** LIDAR Safety Integration
+
+---
+
+## 📋 **TỔNG QUAN**
+
+Safety Configuration Guide mô tả cách cấu hình safety system của OHT-50 Master Module, bao gồm safety zones, monitoring parameters, và system behavior.
+
+---
+
+## 🎯 **CONFIGURATION OVERVIEW**
+
+### **Configuration Categories**
+- **Safety Zones:** Emergency, Warning, Safe zone distances
+- **Monitoring Parameters:** Timeouts, check periods, enable flags
+- **System Behavior:** E-Stop behavior, LED patterns, logging
+- **Performance Tuning:** Update rates, response times
+
+### **Configuration Sources**
+1. **Factory Defaults:** Built-in safe defaults
+2. **Persistent Storage:** `/etc/oht50/config.json`
+3. **API Interface:** REST API endpoints
+4. **Runtime Updates:** Dynamic configuration changes
+
+---
+
+## 🔧 **SAFETY ZONES CONFIGURATION**
+
+### **Zone Definitions**
+```c
+typedef struct {
+    bool enabled;                    // Enable/disable zones
+    uint16_t emergency_zone_mm;      // Emergency zone distance
+    uint16_t warning_zone_mm;        // Warning zone distance
+    uint16_t safe_zone_mm;           // Safe zone distance
+} basic_safety_zones_t;
+```
+
+### **Default Zone Values**
+| Zone | Distance | Description | Action |
+|------|----------|-------------|--------|
+| **Emergency** | 500mm | Critical safety zone | Immediate E-Stop |
+| **Warning** | 1000mm | Warning zone | Reduce speed, warning |
+| **Safe** | 2000mm | Safe operation zone | Normal monitoring |
+
+### **Zone Validation Rules**
+```c
+// Zone distances must be in ascending order
+if (emergency_zone_mm >= warning_zone_mm ||
+    warning_zone_mm >= safe_zone_mm) {
+    return HAL_STATUS_INVALID_PARAMETER;
+}
+
+// Minimum distances
+if (emergency_zone_mm < 100) return HAL_STATUS_INVALID_PARAMETER;
+if (warning_zone_mm < 200) return HAL_STATUS_INVALID_PARAMETER;
+if (safe_zone_mm < 500) return HAL_STATUS_INVALID_PARAMETER;
+
+// Maximum distances
+if (emergency_zone_mm > 2000) return HAL_STATUS_INVALID_PARAMETER;
+if (warning_zone_mm > 5000) return HAL_STATUS_INVALID_PARAMETER;
+if (safe_zone_mm > 10000) return HAL_STATUS_INVALID_PARAMETER;
+```
+
+---
+
+## ⚙️ **MONITORING PARAMETERS**
+
+### **Timeout Configuration**
+```c
+typedef struct {
+    uint32_t estop_timeout_ms;           // E-Stop response timeout
+    uint32_t zone_check_period_ms;       // Zone check frequency
+    uint32_t interlock_check_period_ms;  // Interlock check frequency
+    uint32_t sensor_check_period_ms;     // Sensor check frequency
+    uint32_t watchdog_timeout_ms;        // Watchdog timeout
+} safety_monitor_config_t;
+```
+
+### **Default Timeout Values**
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| **estop_timeout_ms** | 100ms | E-Stop response timeout |
+| **zone_check_period_ms** | 50ms | Zone check frequency (20Hz) |
+| **interlock_check_period_ms** | 100ms | Interlock check frequency (10Hz) |
+| **sensor_check_period_ms** | 200ms | Sensor check frequency (5Hz) |
+| **watchdog_timeout_ms** | 1000ms | Watchdog timeout |
+
+### **Enable Flags**
+```c
+typedef struct {
+    bool enable_zone_monitoring;      // Enable zone monitoring
+    bool enable_interlock_monitoring; // Enable interlock monitoring
+    bool enable_sensor_monitoring;    // Enable sensor monitoring
+    bool enable_watchdog_monitoring;  // Enable watchdog monitoring
+} safety_monitor_config_t;
+```
+
+---
+
+## 📄 **JSON CONFIGURATION FORMAT**
+
+### **Complete Configuration Schema**
+```json
+{
+  "safety_config": {
+    "version": "1.0.0",
+    "timestamp": 1234567890,
+    "safety_zones": {
+      "enabled": true,
+      "emergency_zone_mm": 500,
+      "warning_zone_mm": 1000,
+      "safe_zone_mm": 2000
+    },
+    "monitor_config": {
+      "estop_timeout_ms": 100,
+      "zone_check_period_ms": 50,
+      "interlock_check_period_ms": 100,
+      "sensor_check_period_ms": 200,
+      "watchdog_timeout_ms": 1000,
+      "enable_zone_monitoring": true,
+      "enable_interlock_monitoring": true,
+      "enable_sensor_monitoring": true,
+      "enable_watchdog_monitoring": true
+    },
+    "led_config": {
+      "enable_visual_feedback": true,
+      "blink_fast_period_ms": 100,
+      "blink_slow_period_ms": 500
+    },
+    "logging_config": {
+      "enable_safety_logging": true,
+      "log_level": "INFO",
+      "max_log_entries": 1000
+    }
+  }
+}
+```
+
+### **Minimal Configuration**
+```json
+{
+  "safety_zones": {
+    "enabled": true,
+    "emergency_zone_mm": 500,
+    "warning_zone_mm": 1000,
+    "safe_zone_mm": 2000
+  }
+}
+```
+
+---
+
+## 🔌 **API CONFIGURATION ENDPOINTS**
+
+### **Get Current Configuration**
+```bash
+GET /api/v1/safety/config
+```
+
+**Response:**
+```json
+{
+  "status": "success",
+  "data": {
+    "safety_config": {
+      "version": "1.0.0",
+      "timestamp": 1234567890,
+      "safety_zones": {
+        "enabled": true,
+        "emergency_zone_mm": 500,
+        "warning_zone_mm": 1000,
+        "safe_zone_mm": 2000
+      },
+      "monitor_config": {
+        "estop_timeout_ms": 100,
+        "zone_check_period_ms": 50,
+        "interlock_check_period_ms": 100,
+        "sensor_check_period_ms": 200,
+        "watchdog_timeout_ms": 1000,
+        "enable_zone_monitoring": true,
+        "enable_interlock_monitoring": true,
+        "enable_sensor_monitoring": true,
+        "enable_watchdog_monitoring": true
+      }
+    }
+  }
+}
+```
+
+### **Update Configuration**
+```bash
+PUT /api/v1/safety/config
+Content-Type: application/json
+
+{
+  "safety_zones": {
+    "enabled": true,
+    "emergency_zone_mm": 400,
+    "warning_zone_mm": 800,
+    "safe_zone_mm": 1500
+  },
+  "monitor_config": {
+    "zone_check_period_ms": 25,
+    "estop_timeout_ms": 50
+  }
+}
+```
+
+### **Export Configuration**
+```bash
+GET /api/v1/safety/config/export
+```
+
+**Response:** Configuration file download
+
+### **Import Configuration**
+```bash
+POST /api/v1/safety/config/import
+Content-Type: application/json
+
+{
+  "safety_config": {
+    "version": "1.0.0",
+    "safety_zones": {
+      "enabled": true,
+      "emergency_zone_mm": 500,
+      "warning_zone_mm": 1000,
+      "safe_zone_mm": 2000
+    }
+  }
+}
+```
+
+### **Reset to Factory Defaults**
+```bash
+POST /api/v1/safety/config/reset
+```
+
+**Response:**
+```json
+{
+  "status": "success",
+  "message": "Configuration reset to factory defaults"
+}
+```
+
+---
+
+## 🎨 **LED CONFIGURATION**
+
+### **LED Pattern Configuration**
+```c
+typedef struct {
+    bool enable_visual_feedback;     // Enable LED feedback
+    uint32_t blink_fast_period_ms;   // Fast blink period
+    uint32_t blink_slow_period_ms;   // Slow blink period
+} led_config_t;
+```
+
+### **Default LED Patterns**
+| State | Power LED | System LED | Comm LED | Network LED | Error LED |
+|-------|-----------|------------|----------|-------------|-----------|
+| **Safe** | ON (Green) | ON (Blue) | ON (Yellow) | ON (Green) | OFF |
+| **Warning** | ON (Green) | FAST (Blue) | SLOW (Yellow) | ON (Green) | OFF |
+| **Critical** | ON (Green) | FAST (Blue) | FAST (Yellow) | SLOW (Green) | SLOW (Red) |
+| **E-Stop** | ON (Green) | OFF | OFF | OFF | FAST (Red) |
+| **Fault** | ON (Green) | OFF | OFF | OFF | SLOW (Red) |
+
+### **LED Configuration API**
+```bash
+# Update LED configuration
+PUT /api/v1/safety/config
+{
+  "led_config": {
+    "enable_visual_feedback": true,
+    "blink_fast_period_ms": 100,
+    "blink_slow_period_ms": 500
+  }
+}
+```
+
+---
+
+## 📊 **PERFORMANCE TUNING**
+
+### **Update Rate Configuration**
+```c
+// High performance mode (50Hz)
+zone_check_period_ms = 20;      // 50Hz zone checking
+estop_timeout_ms = 50;          // 50ms E-Stop response
+
+// Standard mode (20Hz)
+zone_check_period_ms = 50;      // 20Hz zone checking
+estop_timeout_ms = 100;         // 100ms E-Stop response
+
+// Low power mode (10Hz)
+zone_check_period_ms = 100;     // 10Hz zone checking
+estop_timeout_ms = 200;         // 200ms E-Stop response
+```
+
+### **Memory Usage Optimization**
+```c
+// Minimal configuration
+enable_zone_monitoring = true;
+enable_interlock_monitoring = false;
+enable_sensor_monitoring = false;
+enable_watchdog_monitoring = false;
+
+// Full monitoring
+enable_zone_monitoring = true;
+enable_interlock_monitoring = true;
+enable_sensor_monitoring = true;
+enable_watchdog_monitoring = true;
+```
+
+---
+
+## 🔒 **SECURITY CONFIGURATION**
+
+### **Access Control**
+```c
+typedef struct {
+    bool require_authentication;     // Require API authentication
+    bool require_admin_for_config;   // Require admin for config changes
+    bool enable_audit_logging;       // Enable configuration audit logs
+} security_config_t;
+```
+
+### **Configuration Validation**
+```c
+// Validate zone configuration
+bool validate_zones(const basic_safety_zones_t *zones) {
+    if (!zones->enabled) return true;
+    
+    // Check distance order
+    if (zones->emergency_zone_mm >= zones->warning_zone_mm) return false;
+    if (zones->warning_zone_mm >= zones->safe_zone_mm) return false;
+    
+    // Check minimum distances
+    if (zones->emergency_zone_mm < 100) return false;
+    if (zones->warning_zone_mm < 200) return false;
+    if (zones->safe_zone_mm < 500) return false;
+    
+    return true;
+}
+```
+
+---
+
+## 🔄 **CONFIGURATION PERSISTENCE**
+
+### **Storage Locations**
+```
+/etc/oht50/
+├── config.json              # Primary configuration
+├── config_backup.json       # Backup configuration
+├── config_factory.json      # Factory defaults
+└── config_history/          # Configuration history
+    ├── config_v1.0.0.json
+    ├── config_v1.0.1.json
+    └── config_v1.1.0.json
+```
+
+### **Configuration Loading Order**
+1. **Factory Defaults:** Built-in safe defaults
+2. **Backup Configuration:** Last known good configuration
+3. **Primary Configuration:** Current configuration
+4. **Runtime Updates:** Dynamic configuration changes
+
+### **Configuration Backup**
+```bash
+# Automatic backup before changes
+safety_monitor_save_config();
+
+# Manual backup
+cp /etc/oht50/config.json /etc/oht50/config_backup_$(date +%Y%m%d_%H%M%S).json
+
+# Restore from backup
+cp /etc/oht50/config_backup.json /etc/oht50/config.json
+safety_monitor_load_config();
+```
+
+---
+
+## ⚠️ **TROUBLESHOOTING**
+
+### **Configuration Issues**
+
+#### **1. Invalid Zone Configuration**
+```bash
+# Check zone configuration
+curl -X GET "http://localhost:8000/api/v1/safety/zones"
+
+# Validate configuration
+safety_monitor_validate_config
+
+# Reset to factory defaults
+curl -X POST "http://localhost:8000/api/v1/safety/config/reset"
+```
+
+#### **2. Configuration Not Loading**
+```bash
+# Check configuration file
+cat /etc/oht50/config.json
+
+# Check file permissions
+ls -la /etc/oht50/config.json
+
+# Check configuration status
+safety_monitor_get_status
+```
+
+#### **3. Configuration Not Saving**
+```bash
+# Check storage space
+df -h /etc/oht50/
+
+# Check write permissions
+ls -la /etc/oht50/
+
+# Test configuration save
+safety_monitor_save_config
+```
+
+### **Debug Commands**
+```bash
+# Enable configuration debug
+export CONFIG_DEBUG=1
+
+# Check configuration logs
+tail -f /var/log/safety_config.log
+
+# Monitor configuration changes
+watch -n 1 'curl -s http://localhost:8000/api/v1/safety/config | jq'
+```
+
+---
+
+## 📋 **CONFIGURATION CHECKLIST**
+
+### **Pre-Deployment Checklist**
+- [ ] **Zone Configuration:** Valid zone distances
+- [ ] **Timeout Values:** Reasonable timeout values
+- [ ] **Enable Flags:** Required monitoring enabled
+- [ ] **LED Configuration:** Visual feedback configured
+- [ ] **Security Settings:** Access control configured
+- [ ] **Performance Settings:** Update rates appropriate
+- [ ] **Backup Configuration:** Backup created
+- [ ] **Validation Tests:** Configuration validated
+
+### **Post-Deployment Checklist**
+- [ ] **Configuration Loaded:** Configuration loaded successfully
+- [ ] **API Endpoints:** All endpoints responding
+- [ ] **Safety Zones:** Zones working correctly
+- [ ] **LED Indicators:** Visual feedback working
+- [ ] **E-Stop Response:** E-Stop triggering correctly
+- [ ] **Performance:** Response times acceptable
+- [ ] **Logging:** Configuration changes logged
+- [ ] **Backup:** Configuration backed up
+
+---
+
+## 🔄 **MAINTENANCE PROCEDURES**
+
+### **Regular Maintenance**
+- **Daily:** Check configuration status
+- **Weekly:** Validate zone configuration
+- **Monthly:** Backup configuration
+- **Quarterly:** Review performance settings
+- **Annually:** Full configuration audit
+
+### **Configuration Updates**
+```bash
+# 1. Backup current configuration
+curl -X GET "http://localhost:8000/api/v1/safety/config/export" > backup.json
+
+# 2. Update configuration
+curl -X PUT "http://localhost:8000/api/v1/safety/config" \
+  -H "Content-Type: application/json" \
+  -d @new_config.json
+
+# 3. Validate configuration
+curl -X GET "http://localhost:8000/api/v1/safety/config"
+
+# 4. Test safety system
+# ... perform safety tests ...
+
+# 5. Rollback if needed
+curl -X POST "http://localhost:8000/api/v1/safety/config/import" \
+  -H "Content-Type: application/json" \
+  -d @backup.json
+```
+
+---
+
+**Changelog v1.0:**
+- ✅ Created comprehensive configuration guide
+- ✅ Added JSON configuration format
+- ✅ Added API endpoints documentation
+- ✅ Added LED configuration guide
+- ✅ Added performance tuning guide
+- ✅ Added security configuration
+- ✅ Added troubleshooting section
+- ✅ Added maintenance procedures
+
+**🚨 Lưu ý:** Luôn backup configuration trước khi thay đổi và validate sau khi apply.

--- a/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/04-safety-api/SAFETY_MONITOR_API_REFERENCE.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/04-safety-api/SAFETY_MONITOR_API_REFERENCE.md
@@ -1,0 +1,440 @@
+# Safety Monitor API Reference
+
+**Phiên bản:** 1.0.0  
+**Ngày cập nhật:** 2025-01-28  
+**Module:** Safety Monitor  
+**Team:** FIRMWARE  
+**Task:** LIDAR Safety Integration
+
+---
+
+## 📋 **TỔNG QUAN**
+
+Safety Monitor API cung cấp interface để quản lý safety system của OHT-50 Master Module, bao gồm:
+- Safety zones monitoring với LiDAR integration
+- E-Stop handling (hardware & software)
+- LED status indication
+- Configuration management
+- Real-time safety status
+
+---
+
+## 🔧 **CORE FUNCTIONS**
+
+### **Initialization & Management**
+
+#### `safety_monitor_init()`
+```c
+hal_status_t safety_monitor_init(void);
+```
+**Mô tả:** Khởi tạo safety monitor system  
+**Returns:** `HAL_STATUS_OK` nếu thành công  
+**Lưu ý:** Phải gọi trước khi sử dụng các functions khác
+
+#### `safety_monitor_deinit()`
+```c
+hal_status_t safety_monitor_deinit(void);
+```
+**Mô tả:** Deinitialize safety monitor system  
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+#### `safety_monitor_update()`
+```c
+hal_status_t safety_monitor_update(void);
+```
+**Mô tả:** Update safety monitor state (gọi định kỳ)  
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+#### `safety_monitor_update_with_lidar()`
+```c
+hal_status_t safety_monitor_update_with_lidar(const lidar_scan_data_t *scan_data);
+```
+**Mô tả:** Update safety monitor với LiDAR data  
+**Parameters:**
+- `scan_data`: LiDAR scan data pointer
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+---
+
+### **Safety Zones Management**
+
+#### `safety_monitor_set_basic_zones()`
+```c
+hal_status_t safety_monitor_set_basic_zones(const basic_safety_zones_t *zones);
+```
+**Mô tả:** Set safety zones configuration  
+**Parameters:**
+- `zones`: Safety zones configuration pointer
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+#### `safety_monitor_get_basic_zones()`
+```c
+hal_status_t safety_monitor_get_basic_zones(basic_safety_zones_t *zones);
+```
+**Mô tả:** Get current safety zones configuration  
+**Parameters:**
+- `zones`: Pointer để store safety zones data
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+---
+
+### **E-Stop Management**
+
+#### `safety_monitor_trigger_emergency_stop()`
+```c
+hal_status_t safety_monitor_trigger_emergency_stop(const char* reason);
+```
+**Mô tả:** Trigger software emergency stop  
+**Parameters:**
+- `reason`: Lý do emergency stop
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+#### `safety_monitor_trigger_lidar_emergency_stop()`
+```c
+hal_status_t safety_monitor_trigger_lidar_emergency_stop(const lidar_scan_data_t *scan_data, const char* reason);
+```
+**Mô tả:** Trigger emergency stop từ LiDAR data  
+**Parameters:**
+- `scan_data`: LiDAR scan data
+- `reason`: Lý do emergency stop
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+#### `safety_monitor_is_estop_active()`
+```c
+hal_status_t safety_monitor_is_estop_active(bool* estop_active);
+```
+**Mô tả:** Check if E-Stop is active  
+**Parameters:**
+- `estop_active`: Pointer để store E-Stop status
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+---
+
+### **Status & Information**
+
+#### `safety_monitor_get_status()`
+```c
+hal_status_t safety_monitor_get_status(safety_monitor_status_t *status);
+```
+**Mô tả:** Get safety monitor status  
+**Parameters:**
+- `status`: Pointer để store status data
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+#### `safety_monitor_get_config()`
+```c
+hal_status_t safety_monitor_get_config(safety_monitor_config_t *config);
+```
+**Mô tả:** Get safety monitor configuration  
+**Parameters:**
+- `config`: Pointer để store configuration data
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+---
+
+### **LED Status Management**
+
+#### `safety_monitor_set_communication_led_pattern()`
+```c
+hal_status_t safety_monitor_set_communication_led_pattern(bool modules_online, uint32_t online_count);
+```
+**Mô tả:** Set communication LED pattern based on module status  
+**Parameters:**
+- `modules_online`: Whether modules are online
+- `online_count`: Number of online modules
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+---
+
+## ⚙️ **CONFIGURATION MANAGEMENT**
+
+### **Configuration Persistence**
+
+#### `safety_monitor_load_config()`
+```c
+hal_status_t safety_monitor_load_config(void);
+```
+**Mô tả:** Load configuration từ persistent storage  
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+#### `safety_monitor_save_config()`
+```c
+hal_status_t safety_monitor_save_config(void);
+```
+**Mô tả:** Save configuration vào persistent storage  
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+### **JSON Import/Export**
+
+#### `safety_monitor_export_config_json()`
+```c
+hal_status_t safety_monitor_export_config_json(char *buffer, size_t buffer_size, size_t *actual_size);
+```
+**Mô tả:** Export configuration ra JSON string  
+**Parameters:**
+- `buffer`: Buffer để store JSON string
+- `buffer_size`: Size của buffer
+- `actual_size`: Actual size của JSON string
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+#### `safety_monitor_import_config_json()`
+```c
+hal_status_t safety_monitor_import_config_json(const char *json_string);
+```
+**Mô tả:** Import configuration từ JSON string  
+**Parameters:**
+- `json_string`: JSON configuration string
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+### **Factory Reset & Validation**
+
+#### `safety_monitor_reset_config_to_factory()`
+```c
+hal_status_t safety_monitor_reset_config_to_factory(void);
+```
+**Mô tả:** Reset configuration về factory defaults  
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+#### `safety_monitor_validate_config()`
+```c
+hal_status_t safety_monitor_validate_config(bool *valid);
+```
+**Mô tả:** Validate configuration  
+**Parameters:**
+- `valid`: Pointer để store validation result
+**Returns:** `HAL_STATUS_OK` nếu thành công
+
+---
+
+## 📊 **DATA STRUCTURES**
+
+### **Safety Monitor Status**
+```c
+typedef struct {
+    safety_monitor_state_t current_state;
+    safety_monitor_state_t previous_state;
+    uint64_t state_entry_time;
+    uint32_t state_transition_count;
+    uint64_t last_update_time;
+    uint64_t last_safety_check;
+    uint32_t violation_count;
+    uint32_t fault_count;
+    bool zone_violation;
+    basic_safety_zones_t safety_zones;
+} safety_monitor_status_t;
+```
+
+### **Safety Monitor Configuration**
+```c
+typedef struct {
+    uint32_t estop_timeout_ms;
+    uint32_t zone_check_period_ms;
+    uint32_t interlock_check_period_ms;
+    uint32_t sensor_check_period_ms;
+    uint32_t watchdog_timeout_ms;
+    bool enable_zone_monitoring;
+    bool enable_interlock_monitoring;
+    bool enable_sensor_monitoring;
+    bool enable_watchdog_monitoring;
+} safety_monitor_config_t;
+```
+
+### **Basic Safety Zones**
+```c
+typedef struct {
+    bool enabled;
+    uint16_t emergency_zone_mm;
+    uint16_t warning_zone_mm;
+    uint16_t safe_zone_mm;
+    uint16_t min_distance_mm;
+    uint16_t min_distance_angle;
+    bool emergency_violated;
+    bool warning_violated;
+    bool safe_violated;
+    uint64_t last_violation_time;
+} basic_safety_zones_t;
+```
+
+---
+
+## 🚨 **SAFETY STATES**
+
+### **State Definitions**
+```c
+typedef enum {
+    SAFETY_MONITOR_STATE_INIT = 0,
+    SAFETY_MONITOR_STATE_SAFE,
+    SAFETY_MONITOR_STATE_WARNING,
+    SAFETY_MONITOR_STATE_CRITICAL,
+    SAFETY_MONITOR_STATE_ESTOP,
+    SAFETY_MONITOR_STATE_FAULT
+} safety_monitor_state_t;
+```
+
+### **State Transitions**
+- **INIT → SAFE:** System initialized successfully
+- **SAFE → WARNING:** Warning zone violated
+- **SAFE → CRITICAL:** Critical condition detected
+- **ANY → ESTOP:** Emergency stop triggered
+- **ANY → FAULT:** System fault detected
+- **WARNING → SAFE:** Conditions returned to safe
+- **CRITICAL → WARNING:** Conditions improved
+- **ESTOP → SAFE:** E-Stop cleared (manual reset required)
+- **FAULT → SAFE:** Fault cleared (manual reset required)
+
+---
+
+## 🔌 **API ENDPOINTS**
+
+### **Safety Status**
+```
+GET /api/v1/safety/status
+```
+**Response:** Current safety status và zone information
+
+### **E-Stop Control**
+```
+POST /api/v1/safety/estop
+```
+**Request:** Trigger software E-Stop  
+**Response:** E-Stop status
+
+### **Safety Zones**
+```
+GET /api/v1/safety/zones
+```
+**Response:** Current safety zones configuration
+
+```
+PUT /api/v1/safety/zones
+```
+**Request:** Update safety zones configuration  
+**Response:** Update status
+
+### **Configuration Management**
+```
+GET /api/v1/safety/config
+```
+**Response:** Current safety configuration
+
+```
+PUT /api/v1/safety/config
+```
+**Request:** Update safety configuration  
+**Response:** Update status
+
+```
+GET /api/v1/safety/config/export
+```
+**Response:** Configuration file download
+
+```
+POST /api/v1/safety/config/import
+```
+**Request:** Import configuration file  
+**Response:** Import status
+
+```
+POST /api/v1/safety/config/reset
+```
+**Response:** Factory reset status
+
+---
+
+## ⚠️ **ERROR CODES**
+
+| Code | Description |
+|------|-------------|
+| `HAL_STATUS_OK` | Operation successful |
+| `HAL_STATUS_INVALID_PARAMETER` | Invalid parameter |
+| `HAL_STATUS_NOT_INITIALIZED` | Safety monitor not initialized |
+| `HAL_STATUS_INVALID_STATE` | Invalid state transition |
+| `HAL_STATUS_ERROR` | General error |
+
+---
+
+## 📝 **USAGE EXAMPLES**
+
+### **Basic Initialization**
+```c
+// Initialize safety monitor
+hal_status_t status = safety_monitor_init();
+if (status != HAL_STATUS_OK) {
+    printf("Failed to initialize safety monitor\n");
+    return status;
+}
+
+// Set safety zones
+basic_safety_zones_t zones = {
+    .enabled = true,
+    .emergency_zone_mm = 500,
+    .warning_zone_mm = 1000,
+    .safe_zone_mm = 2000
+};
+safety_monitor_set_basic_zones(&zones);
+
+// Main loop
+while (running) {
+    safety_monitor_update();
+    usleep(50000); // 50ms
+}
+```
+
+### **LiDAR Integration**
+```c
+// Update with LiDAR data
+lidar_scan_data_t scan_data;
+// ... populate scan_data ...
+safety_monitor_update_with_lidar(&scan_data);
+
+// Check for violations
+basic_safety_zones_t zones;
+safety_monitor_get_basic_zones(&zones);
+if (zones.emergency_violated) {
+    printf("Emergency zone violated!\n");
+}
+```
+
+### **Configuration Management**
+```c
+// Load configuration
+safety_monitor_load_config();
+
+// Export configuration
+char json_buffer[2048];
+size_t actual_size;
+safety_monitor_export_config_json(json_buffer, sizeof(json_buffer), &actual_size);
+printf("Configuration: %s\n", json_buffer);
+
+// Reset to factory defaults
+safety_monitor_reset_config_to_factory();
+```
+
+---
+
+## 🔒 **SAFETY CONSIDERATIONS**
+
+### **Critical Safety Rules**
+1. **E-Stop Priority:** E-Stop có priority cao nhất
+2. **Zone Validation:** Emergency < Warning < Safe zones
+3. **State Transitions:** Chỉ allow valid state transitions
+4. **Configuration Validation:** Validate trước khi apply
+5. **LED Feedback:** Visual feedback cho mọi safety events
+
+### **Error Handling**
+- **Initialization Failures:** System không start nếu safety monitor fail
+- **Configuration Errors:** Fallback to factory defaults
+- **LiDAR Failures:** Fallback to basic safety monitoring
+- **State Errors:** Transition to FAULT state
+
+---
+
+**Changelog v1.0:**
+- ✅ Created comprehensive API reference
+- ✅ Added all function descriptions
+- ✅ Added data structures documentation
+- ✅ Added API endpoints reference
+- ✅ Added usage examples
+- ✅ Added safety considerations
+
+**🚨 Lưu ý:** Luôn tuân thủ safety rules và error handling guidelines.

--- a/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/README.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/05-SAFETY/README.md
@@ -1,0 +1,297 @@
+# Safety Systems - OHT-50 Firmware
+
+**Phiên bản:** 2.0  
+**Ngày cập nhật:** 2025-01-28  
+**Mục tiêu:** Safety systems documentation cho OHT-50 firmware
+
+---
+
+## 📋 **Safety Systems Overview**
+
+### **Safety Management:**
+- **Safety Architecture:** Safety system architecture
+- **Safety Integration:** Safety system integration
+- **Safety Configuration:** Safety system configuration
+- **Safety API:** Safety system API
+- **Safety Monitoring:** Safety system monitoring
+
+---
+
+## 📚 **Safety Documentation**
+
+### **Safety Integration:**
+- [LiDAR Safety Integration Guide](02-safety-integration/LIDAR_SAFETY_INTEGRATION_GUIDE.md) - LiDAR safety integration
+- [LiDAR Safety Integration Plan](02-safety-integration/LIDAR_SAFETY_INTEGRATION_PLAN.md) - LiDAR safety planning
+- [LiDAR Safety Integration Final Report](02-safety-integration/LIDAR_SAFETY_INTEGRATION_FINAL_REPORT.md) - LiDAR safety final report
+
+### **Safety Configuration:**
+- [Safety Configuration Guide](03-safety-configuration/SAFETY_CONFIGURATION_GUIDE.md) - Safety configuration procedures
+
+### **Safety API:**
+- [Safety Monitor API Reference](04-safety-api/SAFETY_MONITOR_API_REFERENCE.md) - Safety monitor API documentation
+
+---
+
+## 🎯 **Safety Architecture**
+
+### **Safety System Components:**
+```
+┌─────────────────────────────────────┐
+│         Safety Monitor              │
+│     (Safety State Management)       │
+├─────────────────────────────────────┤
+│         E-Stop System               │
+│     (Emergency Stop Control)        │
+├─────────────────────────────────────┤
+│         LiDAR Safety                │
+│     (Obstacle Detection)            │
+├─────────────────────────────────────┤
+│         Safety Sensors              │
+│     (Safety Sensor Management)      │
+├─────────────────────────────────────┤
+│         Safety HAL                  │
+│     (Hardware Abstraction)          │
+└─────────────────────────────────────┘
+```
+
+### **Safety States:**
+- **SAFE:** System in safe state
+- **WARNING:** Warning condition detected
+- **DANGER:** Danger condition detected
+- **EMERGENCY:** Emergency stop activated
+- **FAULT:** Safety system fault
+
+---
+
+## 🔧 **Safety Implementation**
+
+### **1. Safety Monitor:**
+```c
+// Safety monitor configuration
+typedef struct {
+    uint32_t update_period_ms;
+    uint32_t estop_timeout_ms;
+    bool enable_emergency_procedures;
+    safety_thresholds_t thresholds;
+} safety_monitor_config_t;
+
+// Safety monitor functions
+hal_status_t safety_monitor_init(const safety_monitor_config_t *config);
+hal_status_t safety_monitor_update(void);
+hal_status_t safety_monitor_get_status(safety_monitor_status_t *status);
+hal_status_t safety_monitor_trigger_emergency_stop(const char *reason);
+```
+
+### **2. E-Stop System:**
+```c
+// E-Stop system functions
+hal_status_t estop_system_init(const estop_config_t *config);
+hal_status_t estop_system_get_state(estop_state_t *state);
+hal_status_t estop_system_trigger_emergency_stop(void);
+hal_status_t estop_system_reset_emergency_stop(void);
+hal_status_t estop_system_is_emergency_active(bool *active);
+```
+
+### **3. LiDAR Safety:**
+```c
+// LiDAR safety functions
+hal_status_t lidar_safety_init(const lidar_safety_config_t *config);
+hal_status_t lidar_safety_start_monitoring(void);
+hal_status_t lidar_safety_stop_monitoring(void);
+hal_status_t lidar_safety_get_obstacle_data(obstacle_data_t *data);
+hal_status_t lidar_safety_check_safety_zones(safety_zone_status_t *status);
+```
+
+### **4. Safety Sensors:**
+```c
+// Safety sensor functions
+hal_status_t safety_sensors_init(const safety_sensors_config_t *config);
+hal_status_t safety_sensors_read_analog(uint8_t sensor_id, uint16_t *value);
+hal_status_t safety_sensors_read_digital(uint8_t sensor_id, bool *value);
+hal_status_t safety_sensors_check_proximity(bool *proximity_alert);
+```
+
+---
+
+## 🔒 **Safety Requirements**
+
+### **1. Safety Standards:**
+- **IEC 61508:** Functional safety standards
+- **ISO 13849:** Safety of machinery
+- **IEC 62061:** Functional safety of electrical systems
+- **SIL 2:** Safety Integrity Level 2
+
+### **2. Safety Functions:**
+- **Emergency Stop:** Immediate system stop
+- **Safety Monitoring:** Continuous safety monitoring
+- **Hazard Detection:** Hazard detection and prevention
+- **Safe State:** Safe state maintenance
+- **Fault Detection:** Fault detection and handling
+
+### **3. Safety Performance:**
+- **Response Time:** < 100ms emergency response
+- **Availability:** > 99.9% safety system availability
+- **Reliability:** > 99.99% safety system reliability
+- **Fault Tolerance:** Single fault tolerance
+- **Diagnostic Coverage:** > 90% diagnostic coverage
+
+---
+
+## 📊 **Safety Status**
+
+### **✅ IMPLEMENTED SAFETY FEATURES:**
+- **Safety Monitor:** Basic safety monitoring system
+- **E-Stop System:** Emergency stop system
+- **LiDAR Safety:** LiDAR obstacle detection
+- **Safety Sensors:** Basic safety sensor support
+- **Safety HAL:** Safety hardware abstraction layer
+
+### **⚠️ PARTIALLY IMPLEMENTED:**
+- **Advanced Safety Features:** Advanced safety features
+- **Safety Analytics:** Safety analytics and reporting
+- **Safety Diagnostics:** Advanced safety diagnostics
+- **Safety Configuration:** Advanced safety configuration
+
+### **❌ NOT IMPLEMENTED:**
+- **Safety Certification:** Safety system certification
+- **Safety Validation:** Comprehensive safety validation
+- **Safety Testing:** Advanced safety testing
+- **Safety Documentation:** Complete safety documentation
+
+---
+
+## 🧪 **Safety Testing**
+
+### **Safety Test Categories:**
+- **Functional Safety Tests:** Test safety functions
+- **Performance Safety Tests:** Test safety performance
+- **Integration Safety Tests:** Test safety integration
+- **Validation Safety Tests:** Test safety validation
+
+### **Safety Test Procedures:**
+- **E-Stop Testing:** Test emergency stop functionality
+- **LiDAR Safety Testing:** Test LiDAR safety features
+- **Sensor Testing:** Test safety sensor functionality
+- **System Testing:** Test complete safety system
+
+### **Safety Test Results:**
+- **Test Coverage:** > 90% safety test coverage
+- **Test Pass Rate:** > 95% test pass rate
+- **Performance Compliance:** 100% performance compliance
+- **Safety Compliance:** 100% safety compliance
+
+---
+
+## 📈 **Safety Monitoring**
+
+### **Safety Metrics:**
+- **Safety Incidents:** Safety incident tracking
+- **E-Stop Activations:** Emergency stop activations
+- **Safety Alerts:** Safety alert notifications
+- **System Uptime:** Safety system uptime
+- **Response Time:** Safety response time
+
+### **Safety Reporting:**
+- **Daily Reports:** Daily safety status reports
+- **Weekly Reports:** Weekly safety assessment reports
+- **Monthly Reports:** Monthly safety review reports
+- **Incident Reports:** Safety incident reports
+- **Trend Reports:** Safety trend analysis reports
+
+### **Safety Alerts:**
+- **Critical Alerts:** Critical safety alerts
+- **Warning Alerts:** Warning safety alerts
+- **Info Alerts:** Information safety alerts
+- **System Alerts:** System safety alerts
+- **Maintenance Alerts:** Maintenance safety alerts
+
+---
+
+## 🔧 **Safety Configuration**
+
+### **Safety Configuration Parameters:**
+```c
+// Safety configuration structure
+typedef struct {
+    uint32_t safety_timeout_ms;
+    uint32_t estop_timeout_ms;
+    uint32_t lidar_safety_threshold_mm;
+    uint32_t sensor_safety_threshold;
+    bool enable_automatic_recovery;
+    bool enable_safety_logging;
+} safety_config_t;
+```
+
+### **Safety Configuration Management:**
+- **Configuration Loading:** Load safety configuration
+- **Configuration Saving:** Save safety configuration
+- **Configuration Validation:** Validate safety configuration
+- **Configuration Backup:** Backup safety configuration
+- **Configuration Restore:** Restore safety configuration
+
+---
+
+## 📚 **Safety Documentation**
+
+### **Safety Procedures:**
+- **Emergency Procedures:** Emergency response procedures
+- **Safety Procedures:** Safety operation procedures
+- **Maintenance Procedures:** Safety maintenance procedures
+- **Testing Procedures:** Safety testing procedures
+- **Training Procedures:** Safety training procedures
+
+### **Safety Guidelines:**
+- **Safety Guidelines:** Safety operation guidelines
+- **Best Practices:** Safety best practices
+- **Troubleshooting:** Safety troubleshooting guide
+- **Maintenance:** Safety maintenance guide
+- **Training:** Safety training guide
+
+---
+
+## 🔄 **Safety Management**
+
+### **Safety Lifecycle:**
+1. **Safety Planning:** Safety system planning
+2. **Safety Design:** Safety system design
+3. **Safety Implementation:** Safety system implementation
+4. **Safety Testing:** Safety system testing
+5. **Safety Validation:** Safety system validation
+6. **Safety Operation:** Safety system operation
+7. **Safety Maintenance:** Safety system maintenance
+
+### **Safety Responsibilities:**
+- **Safety Officer:** Overall safety responsibility
+- **Safety Engineer:** Safety system engineering
+- **Safety Technician:** Safety system maintenance
+- **Safety Operator:** Safety system operation
+- **Safety Manager:** Safety system management
+
+---
+
+## 📚 **Related Documents**
+
+### **Firmware Documentation:**
+- [Firmware README](../README.md) - Main firmware documentation
+- [HAL Documentation](../02-HAL/) - Hardware Abstraction Layer
+- [Quality Documentation](../05-QUALITY/) - Quality assurance
+- [Risk Documentation](../02-RISK/) - Risk assessment
+
+### **Project Documentation:**
+- [Safety Requirements](../../../02-REQUIREMENTS/04-SAFETY/) - Safety requirements
+- [System Architecture](../../../03-ARCHITECTURE/) - System architecture
+- [Safety Standards](../../../02-REQUIREMENTS/04-SAFETY/) - Safety standards
+
+---
+
+**Changelog v2.0:**
+- ✅ Updated safety systems documentation
+- ✅ Added comprehensive safety architecture
+- ✅ Added safety implementation details
+- ✅ Added safety requirements and standards
+- ✅ Added safety testing procedures
+- ✅ Added safety monitoring and reporting
+- ✅ Added safety configuration management
+- ✅ Integrated with firmware documentation cleanup
+
+**🚨 Lưu ý:** Safety systems documentation đã được updated để reflect current safety implementation status và integration với project structure.

--- a/firmware_new/docs/02-IMPLEMENTATION/06-QUALITY/01-qa-reports/QA_QC_FIRMWARE_REPORT.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/06-QUALITY/01-qa-reports/QA_QC_FIRMWARE_REPORT.md
@@ -1,0 +1,357 @@
+# 🔍 **BÁO CÁO QA/QC FIRMWARE OHT-50**
+
+**Phiên bản:** v2.0.0  
+**Ngày tạo:** 2025-01-28  
+**Ngày cập nhật:** 2025-01-28  
+**Team:** QA/QC  
+**Mục tiêu:** Đánh giá chất lượng firmware và đưa ra khuyến nghị khắc phục
+
+---
+
+## 📊 **TỔNG QUAN TÌNH TRẠNG**
+
+### **Trạng thái tổng thể:** ❌ **CRITICAL**
+- **Build Status:** ❌ FAILED (linker errors + warnings as errors)
+- **Safety Tests:** ❌ FAILED (critical safety failure)
+- **Code Quality:** ⚠️ MEDIUM (nhiều TODO items)
+- **Test Coverage:** ⚠️ LOW (incomplete test suite)
+
+### **Thống kê tổng quan:**
+- **Total Files:** 50+ source files
+- **TODO Items:** 20+ chưa implement
+- **Build Errors:** 6+ critical errors
+- **Safety Failures:** 1 critical failure
+- **Unused Functions:** 5+ functions
+- **Files with TODOs:** 15 files
+- **Linker Errors:** Multiple definition errors
+
+---
+
+## 🚨 **BẢNG THEO DÕI VẤN ĐỀ (ISSUE TRACKING TABLE)**
+
+### **1. BUILD ERRORS & COMPILATION ISSUES**
+
+| **ID** | **Vấn đề** | **Mức độ** | **File/Line** | **Mô tả** | **Người fix** | **Ngày fix** | **QA/QC thông qua** | **Ghi chú** |
+|--------|------------|------------|---------------|-----------|---------------|--------------|-------------------|-------------|
+| BE-001 | Unused functions | 🔴 CRITICAL | safety_monitor.c:875-912 | 5 functions không được sử dụng | | | | Cần thêm `__attribute__((unused))` |
+| BE-002 | Unused parameters | 🟡 HIGH | http_server.c:446 | server parameter không sử dụng | | | | Thêm `(void)server;` |
+| BE-003 | Unused parameters | 🟡 HIGH | hal_usb.c | max_length, timeout_ms không sử dụng | | | | Thêm `(void)parameter;` |
+| BE-004 | Build warnings as errors | 🔴 CRITICAL | CMakeLists.txt | Warnings được treat như errors | | | | Cần update compiler flags |
+| BE-005 | Missing implementations | 🟡 HIGH | Multiple files | 20+ TODO items chưa implement | | | | Ưu tiên critical TODOs |
+| BE-006 | Unused functions | 🟡 HIGH | hal_config_persistence.c:514-516 | config_validate_file, config_parse_json_line | | | | Thêm `__attribute__((unused))` |
+| BE-007 | Unused variables | 🟡 MEDIUM | http_server.c:503 | version_str không sử dụng | | | | Thêm `(void)version_str;` |
+| BE-008 | Multiple definition errors | 🔴 CRITICAL | hal_relay.c vs hal_gpio.c | hal_relay functions defined in both files | | | | Remove duplicate definitions |
+
+### **2. SAFETY SYSTEM FAILURES**
+
+| **ID** | **Vấn đề** | **Mức độ** | **File/Line** | **Mô tả** | **Người fix** | **Ngày fix** | **QA/QC thông qua** | **Ghi chú** |
+|--------|------------|------------|---------------|-----------|---------------|--------------|-------------------|-------------|
+| SS-001 | Safety Basic test failed | 🔴 CRITICAL | test_safety_monitor.c | Safety system không hoạt động đúng | | | | Cần fix safety monitor logic |
+| SS-002 | E-Stop handling incomplete | 🔴 CRITICAL | safety_monitor.c:797 | E-Stop event handling chưa hoàn thiện | | | | Implement emergency procedures |
+| SS-003 | Zone violation handling | ✅ IMPLEMENTED | safety_monitor.c:819 | Zone violation logic đã implement | | | | Đã hoàn thành, cần test |
+| SS-004 | Interlock checking | 🟡 HIGH | safety_monitor.c:684 | Interlock logic chưa implement | | | | TODO: Implement interlock checking |
+| SS-005 | Sensor checking | 🟡 HIGH | safety_monitor.c:691 | Sensor logic chưa implement | | | | TODO: Implement sensor checking |
+| SS-006 | Watchdog checking | 🟡 HIGH | safety_monitor.c:698 | Watchdog logic chưa implement | | | | TODO: Implement watchdog checking |
+
+### **3. INCOMPLETE IMPLEMENTATIONS**
+
+| **ID** | **Vấn đề** | **Mức độ** | **File/Line** | **Mô tả** | **Người fix** | **Ngày fix** | **QA/QC thông qua** | **Ghi chú** |
+|--------|------------|------------|---------------|-----------|---------------|--------------|-------------------|-------------|
+| II-001 | Module manager TODOs | 🔴 CRITICAL | module_manager.c | 20 TODO items chưa implement | | | | Ưu tiên module discovery |
+| II-002 | HAL common TODOs | 🟡 HIGH | hal_common.c | 11 TODO items chưa implement | | | | Config loading/saving |
+| II-003 | LiDAR integration | 🟡 HIGH | hal_lidar.c | 17 TODO items chưa implement | | | | Real-time safety monitoring |
+| II-004 | Safety monitor TODOs | 🔴 CRITICAL | safety_monitor.c | 6 TODO items chưa implement | | | | Critical safety functions |
+| II-005 | API authentication | 🟡 HIGH | api_manager.c | Authentication chưa implement | | | | Security requirement |
+| II-006 | Module discovery | ✅ IMPLEMENTED | module_manager.c:136 | Module discovery đã implement | | | | Đã hoàn thành, cần test |
+| II-007 | Configuration loading | 🟡 HIGH | hal_common.c:176 | Config loading chưa implement | | | | TODO: Implement file loading |
+
+### **4. TESTING & VALIDATION ISSUES**
+
+| **ID** | **Vấn đề** | **Mức độ** | **File/Line** | **Mô tả** | **Người fix** | **Ngày fix** | **QA/QC thông qua** | **Ghi chú** |
+|--------|------------|------------|---------------|-----------|---------------|--------------|-------------------|-------------|
+| TV-001 | Safety test suite failed | 🔴 CRITICAL | tests/ | Safety tests không pass | | | | Fix safety basic test |
+| TV-002 | Missing unit tests | 🟡 HIGH | tests/ | Thiếu comprehensive unit tests | | | | Add test coverage |
+| TV-003 | Integration tests | 🟡 HIGH | tests/ | Integration tests chưa đầy đủ | | | | End-to-end testing |
+| TV-004 | Performance tests | 🟡 MEDIUM | tests/ | Performance tests chưa có | | | | Real-time requirements |
+| TV-005 | Stress tests | 🟡 MEDIUM | tests/ | Stress tests chưa có | | | | Error condition testing |
+| TV-006 | Module discovery tests | 🟡 HIGH | test_module_discovery.c | 17 TODO items trong tests | | | | Complete test implementation |
+
+### **5. CODE QUALITY ISSUES**
+
+| **ID** | **Vấn đề** | **Mức độ** | **File/Line** | **Mô tả** | **Người fix** | **Ngày fix** | **QA/QC thông qua** | **Ghi chú** |
+|--------|------------|------------|---------------|-----------|---------------|--------------|-------------------|-------------|
+| CQ-001 | Error handling | 🟡 HIGH | Multiple files | Error handling chưa đầy đủ | | | | Add proper error handling |
+| CQ-002 | Input validation | 🟡 HIGH | Multiple files | Input validation chưa đầy đủ | | | | Validate all inputs |
+| CQ-003 | Logging system | 🟡 MEDIUM | Multiple files | Logging chưa comprehensive | | | | Add debug logging |
+| CQ-004 | Documentation | 🟡 MEDIUM | Multiple files | Code documentation chưa đầy đủ | | | | Add function comments |
+| CQ-005 | Code review | 🟡 MEDIUM | Multiple files | Code review chưa hoàn thành | | | | Complete code review |
+| CQ-006 | Debug prints | 🟡 MEDIUM | module_manager.c | Nhiều debug prints cần cleanup | | | | Remove debug prints |
+
+### **6. NEWLY DISCOVERED ISSUES**
+
+| **ID** | **Vấn đề** | **Mức độ** | **File/Line** | **Mô tả** | **Người fix** | **Ngày fix** | **QA/QC thông qua** | **Ghi chú** |
+|--------|------------|------------|---------------|-----------|---------------|--------------|-------------------|-------------|
+| ND-001 | Constants file TODOs | 🟡 HIGH | include/constants.h | 9 TODO items trong constants | | | | Define missing constants |
+| ND-002 | Main.c TODOs | 🟡 HIGH | src/main.c | 6 TODO items trong main | | | | Complete main initialization |
+| ND-003 | System controller TODOs | 🟡 HIGH | system_controller.c | 5 TODO items | | | | Complete system controller |
+| ND-004 | Control loop TODOs | 🟡 HIGH | control_loop.c | Multiple TODO items | | | | Complete control implementation |
+| ND-005 | API manager TODOs | 🟡 HIGH | api_manager.c | 4 TODO items | | | | Complete API implementation |
+
+### **7. LINKER & ARCHITECTURE ISSUES**
+
+| **ID** | **Vấn đề** | **Mức độ** | **File/Line** | **Mô tả** | **Người fix** | **Ngày fix** | **QA/QC thông qua** | **Ghi chú** |
+|--------|------------|------------|---------------|-----------|---------------|--------------|-------------------|-------------|
+| LA-001 | Duplicate function definitions | 🔴 CRITICAL | hal_relay.c vs hal_gpio.c | hal_relay functions defined in both files | | | | Remove from hal_gpio.c |
+| LA-002 | Library organization | 🟡 HIGH | CMakeLists.txt | HAL libraries not properly organized | | | | Fix library dependencies |
+| LA-003 | Header conflicts | 🟡 HIGH | Multiple files | Header files may have conflicts | | | | Review header organization |
+
+---
+
+## 🎯 **KHUYẾN NGHỊ KHẮC PHỤC**
+
+### **ƯU TIÊN 1: FIX BUILD ERRORS (IMMEDIATE)**
+
+#### **1.1 Fix Linker Errors (CRITICAL):**
+```c
+// Remove duplicate relay functions from hal_gpio.c
+// Keep only in hal_relay.c
+
+// In hal_gpio.c - REMOVE these functions:
+// hal_relay_init, hal_relay_deinit, hal_relay_set, hal_relay_get,
+// hal_relay_pulse, hal_relay_toggle, hal_relay_reset_statistics
+```
+
+#### **1.2 Fix Unused Functions:**
+```c
+// Add __attribute__((unused)) to all unused functions
+static hal_status_t safety_monitor_set_safe_led_pattern(void) __attribute__((unused));
+static hal_status_t safety_monitor_set_warning_led_pattern(void) __attribute__((unused));
+static hal_status_t safety_monitor_set_critical_led_pattern(void) __attribute__((unused));
+static hal_status_t safety_monitor_set_estop_led_pattern(void) __attribute__((unused));
+static hal_status_t safety_monitor_handle_emergency_stop(const char* reason) __attribute__((unused));
+```
+
+#### **1.3 Fix Unused Parameters:**
+```c
+// Add (void)parameter; to suppress warnings
+static void http_log_request(http_server_t *server, ...) {
+    (void)server; // Suppress unused parameter warning
+    // Implementation
+}
+```
+
+#### **1.4 Update Build Configuration:**
+```cmake
+# CMakeLists.txt - Add compiler flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-parameter -Wno-unused-function")
+```
+
+### **ƯU TIÊN 2: COMPLETE SAFETY SYSTEM (CRITICAL)**
+
+#### **2.1 Implement Missing Safety Functions:**
+```c
+static hal_status_t safety_monitor_check_interlocks(void)
+{
+    // Check door sensors
+    bool door_sensor_ok = hal_gpio_read_pin(DOOR_SENSOR_PIN);
+    
+    // Check light curtains
+    bool light_curtain_ok = hal_gpio_read_pin(LIGHT_CURTAIN_PIN);
+    
+    // Update status
+    safety_monitor_instance.status.interlock_open = !(door_sensor_ok && light_curtain_ok);
+    
+    return HAL_STATUS_OK;
+}
+
+static hal_status_t safety_monitor_check_sensors(void)
+{
+    // Check all safety sensors
+    bool sensors_ok = true;
+    
+    // Check proximity sensors
+    for (int i = 0; i < MAX_SAFETY_SENSORS; i++) {
+        if (safety_monitor_instance.sensors[i].enabled) {
+            uint16_t distance;
+            if (hal_lidar_get_distance(&distance) == HAL_STATUS_OK) {
+                if (distance < safety_monitor_instance.sensors[i].threshold) {
+                    sensors_ok = false;
+                    break;
+                }
+            }
+        }
+    }
+    
+    safety_monitor_instance.status.sensor_fault = !sensors_ok;
+    return HAL_STATUS_OK;
+}
+```
+
+### **ƯU TIÊN 3: COMPLETE TODO ITEMS (HIGH)**
+
+#### **3.1 HAL Common TODOs:**
+```c
+hal_status_t hal_load_configuration(const char *config_file)
+{
+    // Load configuration from JSON/YAML file
+    FILE *fp = fopen(config_file, "r");
+    if (!fp) return HAL_STATUS_ERROR;
+    
+    // Parse configuration file
+    // Implementation here
+    
+    fclose(fp);
+    return HAL_STATUS_OK;
+}
+```
+
+#### **3.2 Constants Definition:**
+```c
+// include/constants.h - Define missing constants
+#define DOOR_SENSOR_PIN GPIO_PIN_XX
+#define LIGHT_CURTAIN_PIN GPIO_PIN_XX
+#define MAX_SAFETY_SENSORS 4
+#define HAL_TIMEOUT_MS 1000
+```
+
+---
+
+## 📋 **CHECKLIST KHẮC PHỤC**
+
+### **BUILD & COMPILATION:**
+- [ ] Fix linker errors (BE-008) 🔴 CRITICAL
+- [ ] Fix all unused function warnings (BE-001, BE-006)
+- [ ] Fix all unused parameter warnings (BE-002, BE-003)
+- [ ] Fix unused variable warnings (BE-007)
+- [ ] Update build configuration (BE-004)
+- [ ] Ensure clean build without warnings
+- [ ] Complete critical TODO items (BE-005)
+
+### **SAFETY SYSTEM:**
+- [ ] Fix safety basic test (SS-001)
+- [ ] Complete E-Stop handling (SS-002)
+- [ ] Test zone violation handling (SS-003) ✅
+- [ ] Complete interlock checking (SS-004)
+- [ ] Complete sensor checking (SS-005)
+- [ ] Complete watchdog checking (SS-006)
+
+### **TODO IMPLEMENTATIONS:**
+- [ ] Complete module manager TODOs (II-001)
+- [ ] Complete HAL common TODOs (II-002, II-007)
+- [ ] Complete LiDAR integration TODOs (II-003)
+- [ ] Complete safety monitor TODOs (II-004)
+- [ ] Implement API authentication (II-005)
+- [ ] Test module discovery (II-006) ✅
+
+### **TESTING:**
+- [ ] Fix safety test suite (TV-001)
+- [ ] Add comprehensive unit tests (TV-002)
+- [ ] Add integration tests (TV-003)
+- [ ] Add performance tests (TV-004)
+- [ ] Add stress tests (TV-005)
+- [ ] Complete module discovery tests (TV-006)
+
+### **CODE QUALITY:**
+- [ ] Improve error handling (CQ-001)
+- [ ] Add input validation (CQ-002)
+- [ ] Add comprehensive logging (CQ-003)
+- [ ] Add documentation (CQ-004)
+- [ ] Complete code review (CQ-005)
+- [ ] Clean up debug prints (CQ-006)
+
+### **NEWLY DISCOVERED:**
+- [ ] Define missing constants (ND-001)
+- [ ] Complete main initialization (ND-002)
+- [ ] Complete system controller (ND-003)
+- [ ] Complete control loop (ND-004)
+- [ ] Complete API manager (ND-005)
+
+### **LINKER & ARCHITECTURE:**
+- [ ] Remove duplicate relay functions (LA-001) 🔴 CRITICAL
+- [ ] Fix library organization (LA-002)
+- [ ] Review header conflicts (LA-003)
+
+---
+
+## 🎯 **KẾ HOẠCH THỰC HIỆN**
+
+### **Phase 1: Build Fixes (1-2 days)**
+- Fix linker errors (CRITICAL)
+- Fix compilation errors
+- Resolve unused function/parameter warnings
+- Ensure clean build
+
+### **Phase 2: Safety System (3-5 days)**
+- Implement missing safety functions
+- Complete zone violation handling
+- Fix E-Stop integration
+- Test safety functionality
+
+### **Phase 3: TODO Completion (5-7 days)**
+- Implement critical TODO items
+- Complete module manager functionality
+- Complete HAL implementations
+- Add proper error handling
+
+### **Phase 4: Testing & Validation (3-4 days)**
+- Fix existing tests
+- Add comprehensive test suite
+- Performance testing
+- Integration testing
+
+### **Phase 5: Final Validation (2-3 days)**
+- End-to-end testing
+- Safety validation
+- Performance optimization
+- Documentation update
+
+---
+
+## 🚨 **KẾT LUẬN**
+
+### **Trạng thái hiện tại:** ❌ **NOT PRODUCTION READY**
+
+**Lý do:**
+1. **Build failures** - Linker errors + warnings treated as errors
+2. **Safety failures** - Hệ thống safety không hoạt động
+3. **Incomplete implementations** - Nhiều core functions chưa hoàn thiện
+4. **Poor test coverage** - Thiếu comprehensive testing
+
+### **Khuyến nghị:**
+
+#### **IMMEDIATE ACTIONS:**
+1. **STOP development** cho đến khi fix linker errors
+2. **Prioritize build fixes** trước safety system
+3. **Implement critical TODOs** trước khi tiếp tục
+
+#### **BEFORE PRODUCTION:**
+1. **Complete all TODO items**
+2. **Pass all safety tests**
+3. **Comprehensive testing** completion
+4. **Code review** approval
+5. **Performance validation**
+
+#### **DEPLOYMENT CRITERIA:**
+- ✅ Clean build without warnings
+- ✅ All safety tests pass
+- ✅ All TODO items implemented
+- ✅ Comprehensive test coverage (>90%)
+- ✅ Performance requirements met
+- ✅ Security validation complete
+
+---
+
+**📅 Next Review:** Sau khi hoàn thành Phase 1 (Build Fixes)  
+**👥 Responsible:** FW Team + QA Team  
+**📊 Success Metrics:** Clean build, passing tests, complete implementations
+
+---
+
+**Changelog v2.0.0:**
+- ✅ Added linker errors (BE-008) - CRITICAL
+- ✅ Added architecture issues (LA-001 to LA-003)
+- ✅ Updated build status to include linker errors
+- ✅ Enhanced priority system with CRITICAL markers
+- ✅ Added specific fix instructions for linker errors
+- ✅ Updated checklist with new critical items
+- ✅ Improved issue descriptions and recommendations

--- a/firmware_new/docs/02-IMPLEMENTATION/06-QUALITY/README.md
+++ b/firmware_new/docs/02-IMPLEMENTATION/06-QUALITY/README.md
@@ -1,0 +1,269 @@
+# Quality Assurance - OHT-50 Firmware
+
+**Phiên bản:** 2.0  
+**Ngày cập nhật:** 2025-01-28  
+**Mục tiêu:** Quality assurance documentation cho OHT-50 firmware
+
+---
+
+## 📋 **Quality Assurance Overview**
+
+### **Quality Management:**
+- **QA Reports:** Quality assurance reports
+- **Testing:** Testing procedures and results
+- **Quality Metrics:** Quality performance metrics
+- **Quality Control:** Quality control procedures
+- **Continuous Improvement:** Quality improvement processes
+
+---
+
+## 📚 **Quality Documentation**
+
+### **QA Reports:**
+- [QA/QC Firmware Report](01-qa-reports/QA_QC_FIRMWARE_REPORT.md) - Comprehensive QA/QC report
+
+### **Testing:**
+- [Test Validation Report](02-testing/TEST_VALIDATION_REPORT.md) - Test validation results
+
+---
+
+## 🎯 **Quality Objectives**
+
+### **Primary Quality Objectives:**
+- **Code Quality:** 90%+ test coverage
+- **Safety Compliance:** 100% safety requirements compliance
+- **Performance:** Meet all performance targets
+- **Documentation:** 100% API and technical documentation
+- **Reliability:** 99.9% system uptime
+
+### **Quality Metrics:**
+- **Defect Rate:** < 1% in production
+- **Response Time:** < 100ms for critical operations
+- **Build Success Rate:** > 95%
+- **Code Review Coverage:** 100%
+- **Documentation Completeness:** 100%
+
+---
+
+## 🔧 **Quality Assurance Processes**
+
+### **1. Quality Planning:**
+- **Quality Objectives:** Define quality objectives
+- **Quality Standards:** Establish quality standards
+- **Quality Procedures:** Develop quality procedures
+- **Quality Metrics:** Define quality metrics
+- **Quality Tools:** Select quality tools
+
+### **2. Quality Control:**
+- **Code Review:** Mandatory code review process
+- **Static Analysis:** Automated code quality checks
+- **Unit Testing:** Comprehensive unit testing
+- **Integration Testing:** End-to-end integration testing
+- **Performance Testing:** Load and stress testing
+
+### **3. Quality Assurance:**
+- **Process Audits:** Regular process audits
+- **Quality Reviews:** Regular quality reviews
+- **Quality Assessments:** Quality assessments
+- **Quality Reports:** Quality reporting
+- **Quality Improvement:** Continuous quality improvement
+
+---
+
+## 📊 **Quality Status**
+
+### **✅ COMPLETED QUALITY FEATURES:**
+- **Basic QA Framework:** Basic quality assurance framework
+- **Code Review Process:** Code review process implementation
+- **Basic Testing:** Basic testing framework
+- **Quality Metrics:** Basic quality metrics
+- **Quality Reporting:** Basic quality reporting
+
+### **⚠️ PARTIALLY IMPLEMENTED:**
+- **Advanced Testing:** Advanced testing features
+- **Quality Analytics:** Quality analytics and reporting
+- **Quality Automation:** Quality process automation
+- **Quality Integration:** Quality system integration
+
+### **❌ NOT IMPLEMENTED:**
+- **Quality Certification:** Quality system certification
+- **Advanced Quality Tools:** Advanced quality tools
+- **Quality Benchmarking:** Quality benchmarking
+- **Quality Optimization:** Quality process optimization
+
+---
+
+## 🧪 **Quality Testing**
+
+### **Testing Categories:**
+- **Unit Testing:** Individual component testing
+- **Integration Testing:** Component integration testing
+- **System Testing:** Complete system testing
+- **Performance Testing:** Performance and load testing
+- **Safety Testing:** Safety system testing
+
+### **Testing Procedures:**
+- **Test Planning:** Test planning and design
+- **Test Execution:** Test execution and monitoring
+- **Test Analysis:** Test result analysis
+- **Test Reporting:** Test result reporting
+- **Test Maintenance:** Test maintenance and updates
+
+### **Testing Results:**
+- **Test Coverage:** > 90% test coverage
+- **Test Pass Rate:** > 95% test pass rate
+- **Performance Compliance:** 100% performance compliance
+- **Safety Compliance:** 100% safety compliance
+- **Quality Compliance:** 100% quality compliance
+
+---
+
+## 📈 **Quality Monitoring**
+
+### **Quality Metrics:**
+- **Code Quality:** Code quality metrics
+- **Test Coverage:** Test coverage metrics
+- **Build Success:** Build success metrics
+- **Defect Rate:** Defect rate metrics
+- **Performance:** Performance metrics
+
+### **Quality Reporting:**
+- **Daily Reports:** Daily quality status reports
+- **Weekly Reports:** Weekly quality assessment reports
+- **Monthly Reports:** Monthly quality review reports
+- **Quarterly Reports:** Quarterly quality analysis reports
+- **Annual Reports:** Annual quality management reports
+
+### **Quality Alerts:**
+- **Quality Alerts:** Quality issue alerts
+- **Performance Alerts:** Performance issue alerts
+- **Defect Alerts:** Defect issue alerts
+- **Compliance Alerts:** Compliance issue alerts
+- **Process Alerts:** Process issue alerts
+
+---
+
+## 🔧 **Quality Tools**
+
+### **Quality Management Tools:**
+- **Static Analysis:** Clang-tidy, SonarQube
+- **Testing Frameworks:** Unit tests, integration tests
+- **Code Review:** Code review tools
+- **Documentation:** Doxygen, Markdown
+- **Monitoring:** Performance monitoring, logging
+
+### **Quality Automation:**
+- **Automated Testing:** Automated test execution
+- **Automated Analysis:** Automated code analysis
+- **Automated Reporting:** Automated quality reporting
+- **Automated Monitoring:** Automated quality monitoring
+- **Automated Alerts:** Automated quality alerts
+
+---
+
+## 📚 **Quality Documentation**
+
+### **Quality Procedures:**
+- **Quality Procedures:** Quality management procedures
+- **Testing Procedures:** Testing procedures
+- **Review Procedures:** Code review procedures
+- **Audit Procedures:** Quality audit procedures
+- **Improvement Procedures:** Quality improvement procedures
+
+### **Quality Guidelines:**
+- **Quality Guidelines:** Quality management guidelines
+- **Best Practices:** Quality best practices
+- **Standards:** Quality standards and specifications
+- **Troubleshooting:** Quality troubleshooting guide
+- **Training:** Quality training guide
+
+---
+
+## 🔄 **Quality Management**
+
+### **Quality Lifecycle:**
+1. **Quality Planning:** Quality system planning
+2. **Quality Design:** Quality system design
+3. **Quality Implementation:** Quality system implementation
+4. **Quality Testing:** Quality system testing
+5. **Quality Validation:** Quality system validation
+6. **Quality Operation:** Quality system operation
+7. **Quality Improvement:** Quality system improvement
+
+### **Quality Responsibilities:**
+- **Quality Manager:** Overall quality responsibility
+- **Quality Engineer:** Quality system engineering
+- **Quality Analyst:** Quality analysis and reporting
+- **Quality Auditor:** Quality auditing and compliance
+- **Quality Technician:** Quality system maintenance
+
+---
+
+## 📊 **Quality Performance**
+
+### **Quality KPIs:**
+- **Code Quality Score:** > 8.5/10
+- **Test Coverage:** > 90%
+- **Build Success Rate:** > 95%
+- **Defect Rate:** < 1%
+- **Documentation Coverage:** 100%
+- **Code Review Coverage:** 100%
+
+### **Quality Trends:**
+- **Quality Improvement:** Continuous quality improvement
+- **Defect Reduction:** Defect rate reduction
+- **Performance Improvement:** Performance improvement
+- **Process Improvement:** Process improvement
+- **Tool Improvement:** Tool improvement
+
+---
+
+## 🎯 **Quality Goals**
+
+### **Short-term Goals (3 months):**
+- Achieve 90% test coverage
+- Implement automated testing
+- Establish quality metrics
+- Improve code review process
+
+### **Medium-term Goals (6 months):**
+- Achieve 95% test coverage
+- Implement quality automation
+- Establish quality benchmarking
+- Improve quality processes
+
+### **Long-term Goals (12 months):**
+- Achieve 98% test coverage
+- Implement advanced quality tools
+- Establish quality certification
+- Optimize quality processes
+
+---
+
+## 📚 **Related Documents**
+
+### **Firmware Documentation:**
+- [Firmware README](../README.md) - Main firmware documentation
+- [QMS Documentation](../01-QMS/) - Quality Management System
+- [Safety Documentation](../04-SAFETY/) - Safety systems
+- [HAL Documentation](../02-HAL/) - Hardware Abstraction Layer
+
+### **Project Documentation:**
+- [Quality Requirements](../../../02-REQUIREMENTS/05-QUALITY/) - Quality requirements
+- [System Architecture](../../../03-ARCHITECTURE/) - System architecture
+- [Quality Standards](../../../02-REQUIREMENTS/05-QUALITY/) - Quality standards
+
+---
+
+**Changelog v2.0:**
+- ✅ Updated quality assurance documentation
+- ✅ Added comprehensive quality overview
+- ✅ Added quality objectives and metrics
+- ✅ Added quality assurance processes
+- ✅ Added quality testing procedures
+- ✅ Added quality monitoring and reporting
+- ✅ Added quality tools and automation
+- ✅ Added quality management and responsibilities
+- ✅ Integrated with firmware documentation cleanup
+
+**🚨 Lưu ý:** Quality assurance documentation đã được updated để reflect current quality implementation status và integration với project structure.

--- a/firmware_new/docs/02-QUALITY_MANUAL/QM-001_Project_Overview.md
+++ b/firmware_new/docs/02-QUALITY_MANUAL/QM-001_Project_Overview.md
@@ -1,0 +1,395 @@
+# OHT-50 Firmware
+
+**Version:** 1.0.1 - Domain-Driven Architecture  
+**Platform:** Orange Pi 5B (RK3588)  
+**Standard:** ISO/IEC 12207 Compliant  
+**Architecture:** Domain-Driven Design (DDD)
+
+Firmware for OHT-50 (Overhead Hoist and Transfer) Master Module - A professionally organized and production-ready codebase with Domain-Driven Architecture.
+
+## Overview
+
+OHT-50 firmware provides comprehensive control and monitoring for automated material handling systems. It features:
+
+- **Multi-protocol Communication:** RS485, Ethernet, WiFi
+- **Safety System:** Real-time monitoring with E-Stop support
+- **LiDAR Integration:** 360° obstacle detection
+- **HTTP/WebSocket API:** RESTful API with real-time telemetry
+- **Module Management:** Auto-discovery and control of slave modules
+
+## Quick Start
+
+```bash
+# Build
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+
+# Run
+./oht50_main
+```
+
+For detailed build instructions, see [BUILD_GUIDE.md](BUILD_GUIDE.md).
+
+## Directory Structure
+
+```
+firmware_new/
+├── build/              # Build directory (created during build)
+├── config/             # Build and safety configuration
+├── docs/               # Technical documentation
+├── include/            # Public header files
+├── scripts/            # Organized by functionality
+│   ├── build/          # Build scripts
+│   ├── deploy/         # Deployment scripts
+│   ├── test/           # Test scripts
+│   ├── rs485/          # RS485 scripts
+│   ├── lidar/          # LiDAR scripts
+│   └── safety/         # Safety scripts
+├── src/                # Main source code
+│   ├── app/            # ⭐ Application Layer (Domain-Driven Architecture v1.0.1)
+│   │   ├── core/       # 🎛️ CORE LAYER (Independent, no external deps)
+│   │   │   ├── state_management/  # State machine & controller
+│   │   │   ├── safety/            # Safety monitoring (CRITICAL)
+│   │   │   ├── control/           # Motion control & estimation
+│   │   │   └── _backup/           # Historical backups
+│   │   ├── infrastructure/  # 🔌 INFRASTRUCTURE LAYER (Technical services)
+│   │   │   ├── communication/    # RS485/Modbus communication
+│   │   │   ├── network/          # WiFi/LAN management
+│   │   │   └── telemetry/        # Telemetry collection
+│   │   ├── domain/     # 🏭 DOMAIN LAYER (Business logic)
+│   │   │   ├── module_management/  # Module discovery & registry
+│   │   │   ├── power/              # Power module (0x02)
+│   │   │   ├── motion/             # Motor module (0x04)
+│   │   │   ├── safety_module/      # Safety module (0x03)
+│   │   │   └── dock/               # Dock module (0x05)
+│   │   ├── application/  # 🔐 APPLICATION LAYER (Orchestration)
+│   │   │   ├── safety_orchestrator/  # Multi-source safety coordination
+│   │   │   └── system_orchestrator/  # System coordination (future)
+│   │   ├── api/        # 🌐 API Layer (REST/WebSocket endpoints)
+│   │   ├── validation/ # ✅ Validation (cross-cutting)
+│   │   ├── storage/    # 💾 Storage (cross-cutting)
+│   │   ├── managers/   # ⚠️ DEPRECATED (compatibility shim → infrastructure/application)
+│   │   └── modules/    # ⚠️ DEPRECATED (compatibility shim → domain)
+│   ├── hal/            # Hardware Abstraction Layer
+│   │   ├── common/     # Common HAL definitions
+│   │   ├── communication/  # RS485, Network communication
+│   │   ├── peripherals/    # LED, Relay, LiDAR
+│   │   ├── safety/     # E-Stop, Safety hardware
+│   │   ├── gpio/       # GPIO operations
+│   │   └── register/   # Register operations
+│   └── main.c          # Entry point
+├── tests/              # Test suites
+│   ├── unit/           # Unit tests
+│   └── integration/    # Integration tests
+├── third_party/        # Third-party libraries
+├── CMakeLists.txt      # Root CMake configuration
+├── modules.yaml        # Module registry (runtime state)
+├── MIGRATION_LOG_v1.0.1.md  # Architecture migration log
+└── README.md           # This file
+```
+
+## Architecture (Domain-Driven Design v1.0.1)
+
+Firmware đã được tổ chức lại theo **Domain-Driven Architecture** với 4 layers chính:
+
+### 🎛️ **CORE LAYER** (`src/app/core/`)
+Independent business logic layer - không depend on external systems.
+
+**Domains:**
+- **State Management** - System lifecycle (INIT → READY → RUNNING → FAULT → E-STOP)
+- **Safety System** - Real-time safety monitoring (< 50ms response)
+- **Control System** - Motion control & estimation
+
+**Libraries:** `app_core` (includes: state_management, safety, control)
+
+### 🔌 **INFRASTRUCTURE LAYER** (`src/app/infrastructure/`)
+Technical services layer - handles I/O, networking, persistence.
+
+**Services:**
+- **Communication** - RS485/Modbus RTU communication
+- **Network** - WiFi/LAN management with fallback
+- **Telemetry** - Data collection & serialization
+
+**Libraries:** `app_infrastructure` (includes: communication, network, telemetry)
+
+### 🏭 **DOMAIN LAYER** (`src/app/domain/`)
+Business domain layer - module-specific logic.
+
+**Domains:**
+- **Module Management** - Discovery, polling, registry
+- **Power Domain** - Power module (0x02) handler
+- **Motion Domain** - Travel motor (0x04) handler
+- **Safety Module Domain** - Safety module (0x03) handler
+- **Dock Domain** - Dock module (0x05) handler
+
+**Libraries:** `app_domain` (includes: module_management, power, motion, safety_module, dock)
+
+### 🔐 **APPLICATION LAYER** (`src/app/application/`)
+Orchestration layer - coordinates multiple domains.
+
+**Services:**
+- **Safety Orchestrator** - Multi-source safety coordination
+- **System Orchestrator** - System-wide coordination (future)
+
+**Libraries:** `app_application` (includes: safety_orchestrator)
+
+### 📊 **Dependency Flow**
+
+```
+┌─────────────────────────────────────────────┐
+│           APPLICATION LAYER                 │
+│  (Safety Orchestrator, System Orchestrator) │
+└─────────────────┬───────────────────────────┘
+                  │
+┌─────────────────▼───────────────────────────┐
+│             DOMAIN LAYER                     │
+│   (Modules, Power, Motion, Safety, Dock)    │
+└─────────────────┬───────────────────────────┘
+                  │
+┌─────────────────▼───────────────────────────┐
+│         INFRASTRUCTURE LAYER                 │
+│  (Communication, Network, Telemetry)         │
+└─────────────────┬───────────────────────────┘
+                  │
+┌─────────────────▼───────────────────────────┐
+│             CORE LAYER                       │
+│    (State, Safety, Control)                  │
+└─────────────────┬───────────────────────────┘
+                  │
+┌─────────────────▼───────────────────────────┐
+│             HAL LAYER                        │
+│    (Hardware Abstraction Layer)              │
+└──────────────────────────────────────────────┘
+```
+
+**Design Principles:**
+- ✅ Clear separation of concerns
+- ✅ Single responsibility per domain
+- ✅ Minimal coupling between domains
+- ✅ Easy to test và maintain
+
+## Key Features
+
+### Communication
+- **RS485 (Modbus RTU):** Slave module communication
+- **Ethernet:** 10/100/1000 Mbps for Center connection
+- **WiFi (5G/2.4G):** Backup connection and mobile app support
+- **HTTP/REST API:** RESTful endpoints on port 8080
+- **WebSocket:** Real-time telemetry streaming
+
+### Safety System
+- **E-Stop:** Single-channel emergency stop
+- **Safety Monitor:** Real-time safety monitoring
+- **Graduated Response:** Multi-level safety response
+- **Fault Detection:** Comprehensive error detection and recovery
+
+### Hardware Interface
+- **GPIO Control:** 2x Relay outputs (GPIO1_D3, GPIO1_D2)
+- **LED Status:** 5x status indicators (Power, System, Comm, Network, Error)
+- **LiDAR:** RPLiDAR integration for 360° scanning
+
+### API Endpoints
+- Robot control and status
+- Module management
+- Configuration management
+- Telemetry streaming
+- Safety monitoring
+
+## Documentation
+
+### Getting Started
+- **[INDEX.md](INDEX.md)** - Quick navigation index
+- **[README.md](README.md)** - This file (project overview)
+- **[BUILD_GUIDE.md](BUILD_GUIDE.md)** - Complete build instructions
+- **[CODE_STRUCTURE.md](CODE_STRUCTURE.md)** - Code organization
+- **[CODE_QUALITY.md](CODE_QUALITY.md)** - Code quality tools and practices
+
+### Component Documentation
+- **[src/README.md](src/README.md)** - Source code structure (TBD)
+- **[include/README.md](include/README.md)** - Header files
+- **[tests/README.md](tests/README.md)** - Test suite
+- **[cmake/README.md](cmake/README.md)** - CMake configuration
+
+### Comprehensive Docs
+- **[DOCUMENTATION.md](DOCUMENTATION.md)** - Documentation index
+- **[docs/](docs/)** - Full technical documentation
+
+## Scripts
+
+Scripts are organized by function in `scripts/`:
+
+- **build/** - Build scripts (`build.sh`, `build_phase1.sh`)
+- **deploy/** - Deployment scripts (`deploy.sh`, `start_firmware.sh`)
+- **test/** - Test scripts (`run_all_tests.sh`, `setup_tests.sh`)
+- **rs485/** - RS485 utilities (`rs485_quick_test.py`)
+- **lidar/** - LiDAR utilities (`99-rplidar.rules`)
+- **safety/** - Safety tests (`safety_test.sh`)
+
+See `scripts/*/README.md` for details on each category.
+
+## Testing
+
+```bash
+# Build with tests
+cmake -DBUILD_TESTING=ON ..
+make -j$(nproc)
+
+# Run all tests
+ctest -V
+
+# Run specific category
+cd tests/unit && ctest -V
+cd tests/integration && ctest -V
+```
+
+For detailed testing guide, see [tests/README.md](tests/README.md).
+
+## Code Quality
+
+### Standards Compliance
+- **ISO/IEC 12207:** Software lifecycle compliance
+- **MISRA C:2012:** Partial compliance
+- **C11 Standard:** Full compliance
+
+### Build Quality
+- **Warnings:** Comprehensive warning flags enabled
+- **Static Analysis:** clang-tidy support
+- **Code Coverage:** gcov/lcov integration
+- **Sanitizers:** ASan and UBSan support
+
+### Code Statistics
+- **Total Lines:** 58,265 lines
+- **Source Files:** 35 files (C/H)
+- **Test Coverage:** >90% (target)
+
+## Platform
+
+### Hardware
+- **Board:** Orange Pi 5B
+- **Chipset:** RK3588 (ARM Cortex-A76/A55)
+- **RAM:** 4GB+ recommended
+- **Storage:** 16GB+ SD card
+
+### Software
+- **OS:** Linux (Ubuntu 20.04+ or Armbian)
+- **Kernel:** 6.1.43-rockchip-rk3588
+- **Compiler:** GCC 9.0+ with C11 support
+
+### Interfaces
+- **RS485:** `/dev/ttyOHT485` (UART1)
+- **GPIO:** GPIO1_D3 (Relay1), GPIO1_D2 (Relay2)
+- **Network:** Ethernet + WiFi
+
+## Project Status
+
+### ✅ Completed (Deep Cleanup)
+- [x] Cleaned build artifacts
+- [x] Organized test structure
+- [x] Removed duplicate headers
+- [x] Structured scripts by function
+- [x] Created comprehensive documentation
+- [x] Optimized CMake configuration
+- [x] Added .gitignore
+- [x] Created README for each directory
+
+### Architecture
+- [x] Multi-layer architecture (App, HAL, Drivers)
+- [x] Modular component design
+- [x] Clear separation of concerns
+- [x] Hardware abstraction layer
+
+### Features
+- [x] HTTP/WebSocket server
+- [x] RS485 communication
+- [x] Safety system
+- [x] Module management
+- [x] LiDAR integration
+- [x] Network management
+
+## Contributing
+
+### Code Style
+- Follow existing code style
+- Use C11 standard features
+- Add comprehensive error handling
+- Document all public APIs
+
+### Testing
+- Write unit tests for new features
+- Ensure integration tests pass
+- Test on target hardware
+- Add performance benchmarks
+
+### Documentation
+- Update relevant README files
+- Document API changes
+- Add code examples
+- Update changelog
+
+## License
+
+[Specify your license here]
+
+## Contact
+
+**Project:** OHT-50 Master Module  
+**Team:** Firmware Development Team  
+
+## Changelog
+
+### v1.0.1 (2025-10-07)
+**🏗️ Major Architecture Migration - Domain-Driven Design**
+
+**Breaking Changes:** NONE (Backward compatible)
+
+**Major Changes:**
+- ✅ **Complete 4-layer architecture** - Core, Infrastructure, Domain, Application
+- ✅ **Migrated 27 files** across 4 layers với git history preservation
+- ✅ **Infrastructure layer** (12 files) - Communication, Network, Telemetry
+- ✅ **Domain layer** (13 files) - Module Management, Power, Motion, Safety Module, Dock
+- ✅ **Application layer** (2 files) - Safety Orchestrator
+- ✅ **17 new CMakeLists.txt** - Modular build system
+- ✅ **Legacy compatibility** - Old paths vẫn work via shims
+- ✅ **Build successful** - oht50_main (473KB)
+
+**Architecture Benefits:**
+- 📦 Better organization & separation of concerns
+- 🔧 Easier to maintain & extend
+- 👥 Better team collaboration
+- 🧪 Easier to test individual domains
+- 📈 Improved scalability
+
+**Migration Details:** See [MIGRATION_LOG_v1.0.1.md](MIGRATION_LOG_v1.0.1.md)  
+**Architecture Guide:** See [src/app/ARCHITECTURE_v1.0.1.md](src/app/ARCHITECTURE_v1.0.1.md)
+
+**Technical Details:**
+- Migrated 18 files vào domain-specific folders
+- Created 3 subdomain libraries (state_management, safety, control)
+- Unified INTERFACE library cho backward compatibility
+- Fixed 2 bugs: HAL constants và include placement
+- Moved backup files vào `_backup/` folder
+
+**Build System:**
+- `app_core_state_management.a` - State management library
+- `app_core_safety.a` - Safety system library  
+- `app_core_control.a` - Control system library
+- `app_core` - INTERFACE library aggregating all domains
+
+**Benefits:**
+- 🎯 Clear separation of concerns
+- 📦 Better modularity và reusability
+- 👥 Easier team collaboration
+- 📈 Better scalability cho future features
+
+### v1.0.0 (2025-10-07)
+- Initial release with deep cleanup
+- Comprehensive documentation structure
+- Optimized build system
+- Professional code organization
+
+---
+
+**Last Updated:** 2025-10-07  
+**Status:** Production Ready  
+**Architecture:** Domain-Driven Design (v1.0.1+)

--- a/firmware_new/docs/02-QUALITY_MANUAL/QM-002_Code_Structure.md
+++ b/firmware_new/docs/02-QUALITY_MANUAL/QM-002_Code_Structure.md
@@ -1,0 +1,537 @@
+# OHT-50 Firmware Code Structure
+
+**Version:** 1.1.0  
+**Last Updated:** 2025-10-07  
+**Status:** Production Ready
+
+## Complete Directory Structure
+
+```
+firmware_new/
+├── 📄 Configuration Files (5)
+│   ├── .clang-format          # Code formatting (LLVM-based, 100 col)
+│   ├── .clang-format-ignore   # Format exclusions (third_party, build)
+│   ├── .clang-tidy            # Static analysis (7 check categories)
+│   ├── .editorconfig          # Editor consistency (UTF-8, LF, spaces)
+│   └── .gitignore             # Git ignore rules (comprehensive)
+│
+├── 📚 Documentation (8 main docs + 12 READMEs)
+│   ├── INDEX.md               # Quick navigation index
+│   ├── README.md              # Project overview and quick start
+│   ├── BUILD_GUIDE.md         # Complete build instructions
+│   ├── CODE_STRUCTURE.md      # This file - Code organization
+│   ├── CODE_QUALITY.md        # Code quality tools and practices
+│   ├── DOCUMENTATION.md       # Documentation navigation
+│   ├── CLEANUP_SUMMARY.md     # Detailed cleanup report
+│   └── FINAL_CLEANUP_REPORT.md # Executive cleanup summary
+│
+├── 🔧 Build System
+│   ├── CMakeLists.txt         # Main CMake configuration (modular)
+│   ├── cmake/                 # CMake modules (3 files)
+│   │   ├── CompilerOptions.cmake  # C11, warnings, optimizations
+│   │   ├── BuildOptions.cmake     # Build/feature options
+│   │   └── Dependencies.cmake     # External dependencies
+│   ├── config/                # Build configuration
+│   │   ├── build_config.h.in  # Build config template
+│   │   └── safety/            # Safety configuration
+│   └── modules.yaml           # Module registry (clean state)
+│
+├── 💻 Source Code (58,265 lines)
+│   ├── src/                   # Source files (35 files)
+│   │   ├── app/               # Application layer (12,000+ lines)
+│   │   │   ├── api/           # HTTP API endpoints (2,494 lines)
+│   │   │   ├── core/          # ⭐ Domain-Driven Core (6,337 lines)
+│   │   │   │   ├── state_management/  # State machine & controller (1,714 lines)
+│   │   │   │   ├── safety/            # Safety system (3,923 lines)
+│   │   │   │   ├── control/           # Control loop & estimator (700 lines)
+│   │   │   │   └── _backup/           # Historical backups
+│   │   │   ├── managers/      # System managers (communication, telemetry)
+│   │   │   ├── modules/       # Module handlers (Power, Motor, Dock, Safety)
+│   │   │   ├── config/        # Configuration management
+│   │   │   ├── storage/       # Data storage
+│   │   │   └── validation/    # Input validation
+│   │   ├── hal/               # Hardware Abstraction Layer (8,000+ lines)
+│   │   │   ├── common/        # Common HAL utilities
+│   │   │   ├── communication/ # RS485, Network, WiFi (2,917 lines)
+│   │   │   ├── gpio/          # GPIO control
+│   │   │   ├── peripherals/   # LED, LiDAR (3,438 lines), Relay
+│   │   │   ├── register/      # Register management
+│   │   │   ├── safety/        # E-Stop HAL
+│   │   │   └── storage/       # Storage HAL
+│   │   ├── utils/             # Utility functions
+│   │   └── main.c             # Main application (1,091 lines)
+│   │
+│   └── include/               # Public headers (4 files)
+│       ├── constants.h        # Global constants (7.3 KB)
+│       ├── register_map.h     # Hardware registers (30 KB)
+│       ├── safety_types.h     # Safety definitions (4.9 KB)
+│       └── version.h          # Version information (272 bytes)
+│
+├── 🧪 Testing (47 test files)
+│   └── tests/                 # Test suites (8 categories)
+│       ├── unit/              # Unit tests (component-level)
+│       ├── integration/       # Integration tests
+│       │   └── issues/        # Issue-specific tests (issue_135_*)
+│       ├── performance/       # Performance benchmarks
+│       ├── network/           # Network tests (6 files, moved from src/)
+│       ├── safety/            # Safety system validation
+│       ├── smoke/             # Quick sanity checks
+│       ├── hal/               # HAL layer tests
+│       └── api/               # Python API tests (3 scripts)
+│
+├── 🔨 Utilities & Scripts
+│   └── scripts/               # Organized by function (6 categories)
+│       ├── build/             # Build scripts (6 scripts)
+│       │   └── README.md
+│       ├── deploy/            # Deployment scripts (8 scripts)
+│       │   └── README.md
+│       ├── test/              # Test scripts (13 scripts)
+│       │   └── README.md
+│       ├── rs485/             # RS485 utilities (2 scripts)
+│       │   └── README.md
+│       ├── lidar/             # LiDAR utilities (1 file)
+│       │   └── README.md
+│       ├── safety/            # Safety tests (1 script)
+│       │   └── README.md
+│       └── module_cli.py      # Module management CLI
+│
+├── 📦 Dependencies
+│   └── third_party/           # External libraries
+│       └── unity/             # Unit testing framework
+│
+└── 📁 Generated (excluded by .gitignore)
+    └── build/                 # CMake build directory (empty after cleanup)
+```
+
+## Code Statistics
+
+### Total Lines of Code
+- **Total:** 58,265 lines
+- **Source files:** ~35 files (C/H)
+
+### Largest Components
+1. `hal_lidar.c` - 3,438 lines (LiDAR peripheral driver)
+2. `api_endpoints.c` - 2,494 lines (HTTP API endpoints)
+3. **`safety_monitor.c`** - 1,762 lines (Safety domain - Main monitor)
+4. `communication_manager.c` - 1,658 lines (Communication management)
+5. `http_server.c` - 1,386 lines (HTTP server implementation)
+6. `telemetry_manager.c` - 1,112 lines (Telemetry management)
+7. `hal_wifi_ap.c` - 1,110 lines (WiFi Access Point HAL)
+8. `main.c` - 1,091 lines (Main application)
+9. `hal_network.c` - 1,047 lines (Network HAL)
+10. **`critical_module_detector.c`** - 985 lines (Safety domain - Detection)
+11. **`graduated_response_system.c`** - 936 lines (Safety domain - Response)
+12. **`system_state_machine.c`** - 962 lines (State Management domain)
+13. **`system_controller.c`** - 752 lines (State Management domain)
+14. **`control_loop.c`** - 664 lines (Control domain)
+
+## Architecture Layers
+
+### Application Layer (app/)
+- **Purpose:** High-level application logic
+- **Architecture:** Domain-Driven Design (since v1.0.1)
+- **Components:**
+  - **Core Domains** (3 domains với modular libraries):
+    - 🎛️ State Management - System state machine & controller
+    - 🛡️ Safety System - Multi-level safety monitoring
+    - ⚙️ Control System - Motion control & estimation
+  - API endpoints and HTTP server
+  - Communication management
+  - Module management  
+  - Configuration management
+  - Data storage và validation
+
+### HAL Layer (hal/)
+- **Purpose:** Hardware abstraction
+- **Components:**
+  - RS485 communication (760 lines)
+  - Network interfaces (1,047 lines)
+  - WiFi Access Point (1,110 lines)
+  - LiDAR peripheral (3,438 lines)
+  - GPIO, LED, Relay control
+  - E-Stop safety system
+
+### Driver Layer (drivers/)
+- **Purpose:** Platform-specific implementations
+- **Components:**
+  - Orange Pi 5B board support
+  - RK3588 chipset drivers
+
+## Key Features
+
+### Communication
+- **RS485:** Modbus RTU for slave modules
+- **Ethernet:** 10/100/1000 Mbps for Center connection
+- **WiFi:** 5G/2.4G for backup and mobile app
+- **HTTP/WebSocket:** API for frontend
+
+### Safety System
+- **E-Stop:** Single-channel emergency stop
+- **Safety Monitor:** Real-time safety monitoring
+- **Graduated Response:** Multi-level safety response
+- **Fault Detection:** Comprehensive error detection
+
+### API Endpoints
+- **Robot Control:** Movement, docking, emergency stop
+- **Status Monitoring:** Real-time status and telemetry
+- **Configuration:** System and safety configuration
+- **Module Management:** Slave module discovery and control
+- **Network Management:** WiFi AP, fallback, connectivity
+
+## Testing Infrastructure
+
+### Test Categories
+- **Unit Tests:** Component-level testing
+- **Integration Tests:** System integration testing
+- **Performance Tests:** Load and stress testing
+- **Network Tests:** Communication testing
+- **Safety Tests:** Safety system validation
+- **Smoke Tests:** Basic functionality verification
+
+## Project Organization
+
+### Configuration Files (5 files)
+Professional development tooling:
+- **`.clang-format`** - LLVM-based formatting (4 spaces, 100 columns)
+- **`.clang-tidy`** - Static analysis (7 check categories enabled)
+- **`.editorconfig`** - Cross-editor consistency
+- **`.clang-format-ignore`** - Exclude third-party code
+- **`.gitignore`** - Comprehensive ignore rules
+
+### Documentation Structure (20 files)
+**Main Documentation (8 files):**
+1. `INDEX.md` - Quick navigation guide
+2. `README.md` - Project overview
+3. `BUILD_GUIDE.md` - Build instructions (457 lines)
+4. `CODE_STRUCTURE.md` - This file
+5. `CODE_QUALITY.md` - Quality tools guide (478 lines)
+6. `DOCUMENTATION.md` - Doc navigation
+7. `CLEANUP_SUMMARY.md` - Cleanup details
+8. `FINAL_CLEANUP_REPORT.md` - Executive summary
+
+**Component Documentation (12 READMEs):**
+- `include/README.md` - Header organization
+- `tests/README.md` - Test suite guide
+- `cmake/README.md` - CMake configuration
+- `scripts/*/README.md` - 6 script category guides
+
+### Build System Organization
+**Modular CMake (4 files):**
+- `CMakeLists.txt` - Main configuration (139 lines)
+- `cmake/CompilerOptions.cmake` - Compiler flags
+- `cmake/BuildOptions.cmake` - Build options
+- `cmake/Dependencies.cmake` - External deps
+
+**Build Options Available:**
+- `BUILD_TESTING` - Enable/disable tests
+- `ENABLE_COVERAGE` - Code coverage
+- `ENABLE_SANITIZERS` - ASan/UBSan
+- `ENABLE_STATIC_ANALYSIS` - clang-tidy
+- `ENABLE_LIDAR` - LiDAR support
+- `ENABLE_WIFI_AP` - WiFi AP support
+- `ENABLE_WEBSOCKET` - WebSocket support
+- `ENABLE_HTTPS` - HTTPS support
+
+### Test Organization (8 categories)
+**Test Structure:**
+```
+tests/ (47 test files)
+├── unit/              # Component-level tests
+├── integration/       # System integration tests
+│   └── issues/        # Issue-specific regression tests
+├── performance/       # Performance benchmarks
+├── network/           # Network communication tests (6 files)
+├── safety/            # Safety system validation
+├── smoke/             # Quick sanity checks
+├── hal/               # HAL layer tests
+└── api/               # Python API tests (3 scripts)
+```
+
+### Script Organization (6 categories)
+**Scripts by Function:**
+```
+scripts/ (30+ scripts)
+├── build/    (6)   # Build-related scripts
+├── deploy/   (8)   # Deployment scripts
+├── test/     (13)  # Testing scripts
+├── rs485/    (2)   # RS485 utilities
+├── lidar/    (1)   # LiDAR utilities
+└── safety/   (1)   # Safety tests
+```
+
+## Deep Cleanup Summary
+
+### Changes Made
+
+**🏗️ Core Architecture Migration (2025-10-07 - v1.0.1):**
+- ✅ **Restructured `src/app/core/`** thành Domain-Driven Architecture
+- ✅ Created 3 domain subfolders: `state_management/`, `safety/`, `control/`
+- ✅ Migrated 18 files vào domain-specific folders
+- ✅ Created modular CMakeLists.txt cho mỗi domain
+- ✅ Moved backup files vào `_backup/` folder
+- ✅ Fixed 2 bugs: HAL constants và include placement
+- ✅ Created README.md cho mỗi domain
+- ✅ Backward compatible - KHÔNG phá vỡ existing code
+
+**Build System Changes:**
+- ✅ `app_core_state_management.a` - State management library
+- ✅ `app_core_safety.a` - Safety system library
+- ✅ `app_core_control.a` - Control system library
+- ✅ `app_core` - INTERFACE library tổng hợp
+
+**Deep Cleanup (2025-10-07 - v1.0.0):**
+
+**1. Source Code Organization:**
+- ✅ Moved 7 test files from `src/tests/network/` → `tests/network/`
+- ✅ Moved `src/tests/test_register_info.c` → `tests/unit/`
+- ✅ Removed duplicate `include/http_server.h`
+- ✅ Removed unused `include/module_registry.h`
+- ✅ Deleted `src/app/modules/` (empty, non-existent files)
+- ✅ Deleted `src/drivers/` (completely empty)
+- ✅ Deleted 4 empty subdirectories in `include/`
+- ✅ Deleted empty `src/tests/` directory
+
+**2. Build Artifacts Cleanup:**
+- ✅ Cleaned entire `build/` directory
+- ✅ Removed `*.o` files
+- ✅ Removed old test executables
+- ✅ Created comprehensive `.gitignore`
+
+**3. Test Structure:**
+- ✅ Organized into 8 categories
+- ✅ Created `integration/issues/` subfolder
+- ✅ Moved Python API tests to `tests/api/`
+- ✅ Created `tests/README.md` (comprehensive guide)
+
+**4. Scripts Reorganization:**
+- ✅ Created 6 functional directories
+- ✅ Moved 30+ scripts to appropriate categories
+- ✅ Created README.md for each category
+
+**5. CMake Optimization:**
+- ✅ Modularized into 3 separate files
+- ✅ Added 8+ build options
+- ✅ Added feature toggles
+- ✅ Improved dependency management
+- ✅ Added build summary output
+
+**6. Documentation Creation:**
+- ✅ Created 8 main documentation files
+- ✅ Created 12 component READMEs
+- ✅ Total: 20 documentation files
+
+**7. Code Quality Tools:**
+- ✅ Created `.clang-format` configuration
+- ✅ Optimized `.clang-tidy` settings
+- ✅ Created `.editorconfig`
+- ✅ Created `.clang-format-ignore`
+- ✅ Created comprehensive `CODE_QUALITY.md`
+
+### Files Summary
+- **Created:** 20 files (docs + configs)
+- **Moved:** 10 files (tests to proper location)
+- **Deleted:** 13 items (1 header + 7 directories + 5 artifacts)
+- **Directories Created:** 12 (test categories + script categories)
+
+### Unused Files Removed (2025-10-07)
+- ❌ `include/module_registry.h` - No corresponding .c file
+- ❌ `src/app/modules/` - Directory with non-existent .c files
+- ❌ `src/drivers/` - Completely empty directory
+- ❌ `include/common/` - Empty subdirectory
+- ❌ `include/drivers/` - Empty subdirectory
+- ❌ `include/app/` - Empty subdirectory
+- ❌ `include/hal/` - Empty subdirectory
+- ✅ Updated `CMakeLists.txt` - Removed app_modules link
+- ✅ Updated `src/app/CMakeLists.txt` - Removed modules subdirectory
+
+## Naming Conventions
+
+### Files
+- **Source files:** `module_name.c`
+- **Header files:** `module_name.h`
+- **Test files:** `test_module_name.c`
+- **Script files:** `action_name.sh`
+
+### Functions
+- **HAL functions:** `hal_module_action()`
+- **API functions:** `api_resource_action()`
+- **Manager functions:** `manager_name_action()`
+- **Utility functions:** `util_category_action()`
+
+### Constants
+- **Macros:** `MODULE_CONSTANT_NAME`
+- **Types:** `module_name_t`
+- **Enums:** `MODULE_ENUM_VALUE`
+
+## Dependencies
+
+### External Libraries
+- **Unity:** Unit testing framework
+- **OpenSSL:** SSL/TLS support
+- **pthread:** Multi-threading
+- **math (libm):** Mathematical functions
+
+### Build System
+- **CMake:** Build configuration (version 3.16+)
+- **C Standard:** C11
+- **Compiler:** GCC with strict warnings
+
+## Compliance
+
+### Standards
+- **ISO/IEC 12207:** Software lifecycle compliance
+- **MISRA C:2012:** C coding standard (partial)
+- **Safety Standards:** Basic safety compliance
+
+### Code Quality
+**Compiler Warnings (15+ flags):**
+- `-Wall -Wextra -Wpedantic`
+- `-Werror=implicit-function-declaration`
+- `-Werror=return-type`
+- `-Werror=uninitialized`
+- `-Wformat=2 -Wformat-security`
+- `-Wnull-dereference`
+- `-Wstrict-prototypes -Wmissing-prototypes`
+- `-Wold-style-definition`
+- `-Wshadow -Wcast-align`
+- `-Wconversion -Wsign-conversion`
+
+**Static Analysis:**
+- `clang-tidy` with 7 check categories
+- `clang-format` for consistent formatting
+- Mock detection guard (build-time)
+
+**Quality Tools:**
+- Code coverage: gcov/lcov
+- Memory checking: AddressSanitizer
+- Undefined behavior: UBSan
+- Thread safety: ThreadSanitizer (available)
+
+## Version Information
+
+- **Firmware Version:** 1.0.0
+- **HTTP Server Version:** 1.0.0
+- **Schema Version:** 1
+
+## Notes
+
+### Performance Targets
+- **HTTP API:** < 50ms response time
+- **WebSocket:** < 20ms latency
+- **Safety Response:** < 100ms E-Stop response
+
+### Platform
+- **Board:** Orange Pi 5B
+- **Chipset:** RK3588
+- **OS:** Linux (6.1.43-rockchip-rk3588)
+
+### Key Interfaces
+- **RS485:** `/dev/ttyOHT485` (UART1)
+- **GPIO:** GPIO1_D3 (Relay1), GPIO1_D2 (Relay2)
+- **LED:** 5x status LEDs
+- **HTTP:** Port 8080 (default)
+
+## Quick Reference
+
+### Key Files
+```
+📄 Main Entry:          src/main.c (1,091 lines)
+🌐 HTTP Server:         src/app/http_server.c (1,386 lines)
+📡 API Endpoints:       src/app/api/api_endpoints.c (2,494 lines)
+
+🎛️ State Management Domain:
+   - system_state_machine.c (962 lines)
+   - system_controller.c (752 lines)
+
+🛡️ Safety System Domain:
+   - safety_monitor.c (1,762 lines)
+   - critical_module_detector.c (985 lines)
+   - graduated_response_system.c (936 lines)
+   - safety_rs485_integration.c (239 lines)
+
+⚙️ Control System Domain:
+   - control_loop.c (664 lines)
+   - estimator_1d.c (36 lines)
+
+🔧 HAL Layer:
+   - hal_rs485.c (760 lines)
+   - hal_network.c (1,047 lines)
+   - hal_wifi_ap.c (1,110 lines)
+   - hal_lidar.c (3,438 lines)
+
+📊 Managers:
+   - communication_manager.c (1,658 lines)
+   - telemetry_manager.c (1,112 lines)
+```
+
+### Key Headers
+```
+🔢 Constants:          include/constants.h (7.3 KB)
+📋 Register Map:       include/register_map.h (30 KB - largest)
+🛡️ Safety Types:       include/safety_types.h (4.9 KB)
+ℹ️ Version Info:       include/version.h (272 bytes)
+```
+
+### Build Commands
+```bash
+# Quick build
+mkdir build && cd build && cmake .. && make -j$(nproc)
+
+# Debug with coverage
+cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON ..
+
+# Release with static analysis
+cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_STATIC_ANALYSIS=ON ..
+
+# With sanitizers
+cmake -DENABLE_SANITIZERS=ON ..
+```
+
+### Documentation Map
+```
+📚 Start:              INDEX.md
+📖 Overview:           README.md
+🔨 Build:              BUILD_GUIDE.md
+🏗️ Structure:          CODE_STRUCTURE.md (this file)
+✨ Quality:            CODE_QUALITY.md
+📁 Docs Index:         DOCUMENTATION.md
+🧹 Cleanup:            CLEANUP_SUMMARY.md
+📊 Final Report:       FINAL_CLEANUP_REPORT.md
+```
+
+### Project Metrics
+
+| Metric | Value |
+|--------|-------|
+| **Total Code** | 58,265 lines |
+| **Source Files** | 70 (C/H) |
+| **Test Files** | 47 (C/Python) |
+| **Documentation** | 20 files |
+| **Config Files** | 5 quality tools |
+| **CMake Modules** | 3 modules |
+| **Build Options** | 8+ options |
+| **Test Categories** | 8 categories |
+| **Script Categories** | 6 categories |
+
+### Component Sizes
+
+| Component | Lines | Description |
+|-----------|-------|-------------|
+| LiDAR HAL | 3,438 | Largest component |
+| API Endpoints | 2,494 | HTTP REST API |
+| Safety Monitor | 1,762 | Safety system |
+| Comm Manager | 1,658 | Communication |
+| HTTP Server | 1,386 | Web server |
+| Telemetry Mgr | 1,112 | Telemetry |
+| WiFi AP HAL | 1,110 | WiFi Access Point |
+| Main | 1,091 | Application entry |
+| Network HAL | 1,047 | Network interface |
+
+---
+
+**Document Version:** 1.1.0  
+**Last Updated:** 2025-10-07  
+**Status:** ✅ Production Ready  
+**Maintained By:** Firmware Team
+
+

--- a/firmware_new/docs/02-QUALITY_MANUAL/README.md
+++ b/firmware_new/docs/02-QUALITY_MANUAL/README.md
@@ -1,0 +1,63 @@
+# 📘 02-QUALITY_MANUAL (Sổ Tay Chất Lượng)
+
+**Theo ISO 9001:2015 Section 7.5 - Documented Information**
+
+---
+
+## 🎯 **MỤC ĐÍCH**
+
+Thư mục này chứa **Sổ tay chất lượng** - tài liệu mô tả tổng quan về hệ thống, cấu trúc, và cam kết chất lượng.
+
+---
+
+## 📄 **DANH SÁCH TÀI LIỆU**
+
+| **Mã** | **Tên tài liệu** | **Mô tả** | **Version** |
+|--------|------------------|-----------|-------------|
+| **QM-001** | Project_Overview.md | Tổng quan dự án, features, architecture | 1.0.1 |
+| **QM-002** | Code_Structure.md | Cấu trúc code chi tiết, 58K lines | 1.1.0 |
+
+---
+
+## 📖 **QM-001: Project Overview**
+
+**Nội dung:**
+- Giới thiệu OHT-50 firmware
+- Multi-protocol communication
+- Safety system
+- Domain-Driven Architecture (5 layers)
+- Key features và capabilities
+- Platform specifications
+
+**Khi nào đọc:** Khi bắt đầu làm việc với dự án, onboarding
+
+---
+
+## 🏗️ **QM-002: Code Structure**
+
+**Nội dung:**
+- Complete directory structure (58,265 lines)
+- Architecture layers (App, HAL, Core, Domain)
+- Largest components analysis
+- Naming conventions
+- Dependencies và compliance
+- Build commands và quick reference
+
+**Khi nào đọc:** Khi cần hiểu cấu trúc code, architecture review
+
+---
+
+## ✅ **TUÂN THỦ**
+
+Quality Manual là **tài liệu bắt buộc** cho:
+- ✅ Architecture review
+- ✅ Code review process
+- ✅ Quality audits
+- ✅ Team onboarding
+
+---
+
+**Version:** 1.0  
+**Last Updated:** 2025-10-07  
+**Maintained By:** Quality Team
+

--- a/firmware_new/docs/03-PROCEDURES/PR-001_Build_Procedure.md
+++ b/firmware_new/docs/03-PROCEDURES/PR-001_Build_Procedure.md
@@ -1,0 +1,459 @@
+# OHT-50 Firmware Build Guide
+
+Complete guide for building, testing, and deploying OHT-50 firmware.
+
+## Prerequisites
+
+### System Requirements
+- **OS:** Linux (Ubuntu 20.04+ recommended)
+- **RAM:** 4GB minimum, 8GB recommended
+- **Disk:** 2GB free space
+- **CPU:** Multi-core processor recommended
+
+### Software Requirements
+
+#### Required
+- **CMake:** >= 3.16
+- **GCC:** >= 9.0 (C11 support)
+- **Make:** GNU Make
+- **Git:** For version control
+
+#### Optional
+- **Clang:** For clang-tidy static analysis
+- **Python3:** >= 3.8 (for API tests)
+- **lcov/gcov:** For code coverage
+- **Doxygen:** For API documentation
+
+### Dependencies
+
+#### System Libraries
+```bash
+# Ubuntu/Debian
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    libssl-dev \
+    libpthread-stubs0-dev \
+    pkg-config
+
+# Fedora/RHEL
+sudo dnf install -y \
+    gcc \
+    make \
+    cmake \
+    git \
+    openssl-devel \
+    glibc-devel
+```
+
+#### Python Dependencies (for tests)
+```bash
+pip3 install requests websocket-client
+```
+
+## Quick Start
+
+### 1. Clone Repository
+```bash
+cd /home/orangepi/Desktop/OHT_V2/firmware_new
+```
+
+### 2. Create Build Directory
+```bash
+mkdir -p build
+cd build
+```
+
+### 3. Configure
+```bash
+cmake ..
+```
+
+### 4. Build
+```bash
+make -j$(nproc)
+```
+
+### 5. Run
+```bash
+./oht50_main
+```
+
+## Build Configurations
+
+### Debug Build
+For development with debug symbols:
+```bash
+mkdir -p build/debug
+cd build/debug
+cmake -DCMAKE_BUILD_TYPE=Debug ../..
+make -j$(nproc)
+```
+
+### Release Build
+Optimized for production:
+```bash
+mkdir -p build/release
+cd build/release
+cmake -DCMAKE_BUILD_TYPE=Release ../..
+make -j$(nproc)
+```
+
+### RelWithDebInfo Build
+Release with debug info:
+```bash
+mkdir -p build/relwithdebinfo
+cd build/relwithdebinfo
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
+make -j$(nproc)
+```
+
+### MinSizeRel Build
+Optimized for size:
+```bash
+mkdir -p build/minsizerel
+cd build/minsizerel
+cmake -DCMAKE_BUILD_TYPE=MinSizeRel ../..
+make -j$(nproc)
+```
+
+## Build Options
+
+### Enable Code Coverage
+```bash
+cmake -DENABLE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug ..
+make -j$(nproc)
+make test
+```
+
+Generate coverage report:
+```bash
+lcov --capture --directory . --output-file coverage.info
+lcov --remove coverage.info '/usr/*' --output-file coverage.info
+genhtml coverage.info --output-directory coverage_html
+```
+
+### Enable Sanitizers
+AddressSanitizer and UndefinedBehaviorSanitizer:
+```bash
+cmake -DENABLE_SANITIZERS=ON -DCMAKE_BUILD_TYPE=Debug ..
+make -j$(nproc)
+./oht50_main
+```
+
+### Enable Static Analysis
+Using clang-tidy:
+```bash
+cmake -DENABLE_STATIC_ANALYSIS=ON ..
+make -j$(nproc)
+```
+
+### Disable Tests
+```bash
+cmake -DBUILD_TESTING=OFF ..
+make -j$(nproc)
+```
+
+### Feature Toggles
+```bash
+cmake \
+    -DENABLE_LIDAR=ON \
+    -DENABLE_WIFI_AP=ON \
+    -DENABLE_WEBSOCKET=ON \
+    -DENABLE_HTTPS=ON \
+    ..
+```
+
+## Building Tests
+
+### Build All Tests
+```bash
+cmake -DBUILD_TESTING=ON ..
+make -j$(nproc)
+```
+
+### Build Specific Test Category
+```bash
+make test_hal_common        # Unit test
+make test_basic_integration # Integration test
+make test_performance       # Performance test
+```
+
+### Run Tests
+```bash
+# Run all tests
+ctest -V
+
+# Run specific test
+ctest -R test_hal_common -V
+
+# Run with parallel execution
+ctest -j$(nproc)
+```
+
+## Cross-Compilation
+
+### ARM (Orange Pi 5B)
+```bash
+# Set toolchain
+export CC=aarch64-linux-gnu-gcc
+export CXX=aarch64-linux-gnu-g++
+
+# Configure for ARM
+cmake \
+    -DCMAKE_SYSTEM_NAME=Linux \
+    -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+    -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+    ..
+
+# Build
+make -j$(nproc)
+```
+
+## Installation
+
+### Local Installation
+```bash
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
+make -j$(nproc)
+sudo make install
+```
+
+### Custom Installation
+```bash
+cmake -DCMAKE_INSTALL_PREFIX=/opt/oht50 ..
+make -j$(nproc)
+sudo make install
+```
+
+### Installation Structure
+```
+${CMAKE_INSTALL_PREFIX}/
+├── bin/
+│   └── oht50_main
+└── share/oht50/
+    └── config/
+        └── modules.yaml
+```
+
+## Build Scripts
+
+### Automated Build
+```bash
+./scripts/build/build.sh
+```
+
+### Clean Build
+```bash
+./scripts/build/build.sh clean
+```
+
+### Deploy Build
+```bash
+./scripts/deploy/deploy.sh
+```
+
+## Troubleshooting
+
+### CMake Configuration Fails
+
+**Problem:** CMake can't find OpenSSL
+```bash
+# Check OpenSSL installation
+pkg-config --modversion openssl
+
+# Install if missing
+sudo apt-get install libssl-dev
+```
+
+**Problem:** CMake version too old
+```bash
+# Check version
+cmake --version
+
+# Install newer version
+sudo apt-get install cmake
+```
+
+### Build Fails
+
+**Problem:** Compiler errors
+```bash
+# Check compiler version
+gcc --version
+
+# Ensure C11 support
+gcc -std=c11 --version
+```
+
+**Problem:** Missing headers
+```bash
+# Check include paths
+echo | gcc -E -Wp,-v -
+
+# Install development packages
+sudo apt-get install build-essential
+```
+
+**Problem:** Linker errors
+```bash
+# Check library paths
+ldconfig -p | grep ssl
+
+# Install missing libraries
+sudo apt-get install libssl-dev
+```
+
+### Runtime Issues
+
+**Problem:** Shared library not found
+```bash
+# Check dependencies
+ldd build/oht50_main
+
+# Add library path
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+```
+
+**Problem:** Permission denied
+```bash
+# Check permissions
+ls -la build/oht50_main
+
+# Make executable
+chmod +x build/oht50_main
+```
+
+## Build Performance
+
+### Parallel Builds
+```bash
+# Use all cores
+make -j$(nproc)
+
+# Specific number of cores
+make -j4
+```
+
+### Ccache
+Speed up rebuilds with ccache:
+```bash
+# Install ccache
+sudo apt-get install ccache
+
+# Use ccache
+cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache ..
+make -j$(nproc)
+```
+
+### Ninja Build System
+Faster alternative to Make:
+```bash
+# Install ninja
+sudo apt-get install ninja-build
+
+# Use ninja
+cmake -GNinja ..
+ninja
+```
+
+## Best Practices
+
+### Clean Builds
+```bash
+# Remove build directory
+rm -rf build
+
+# Recreate and rebuild
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+```
+
+### Incremental Builds
+```bash
+# Just run make
+cd build
+make -j$(nproc)
+```
+
+### Build Type Selection
+- **Development:** Use Debug
+- **Testing:** Use Debug or RelWithDebInfo
+- **Production:** Use Release
+- **Embedded:** Use MinSizeRel
+
+### Version Control
+```bash
+# Don't commit build artifacts
+echo "build/" >> .gitignore
+echo "*.o" >> .gitignore
+```
+
+## Advanced Topics
+
+### Custom Compiler Flags
+```bash
+cmake -DCMAKE_C_FLAGS="-march=native -mtune=native" ..
+```
+
+### Static Linking
+```bash
+cmake -DBUILD_SHARED_LIBS=OFF ..
+```
+
+### LTO (Link Time Optimization)
+```bash
+cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON ..
+```
+
+### Profile-Guided Optimization
+```bash
+# Step 1: Build with profiling
+cmake -DCMAKE_C_FLAGS="-fprofile-generate" ..
+make
+
+# Step 2: Run to generate profile
+./oht50_main
+
+# Step 3: Build with profile
+cmake -DCMAKE_C_FLAGS="-fprofile-use" ..
+make
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+```yaml
+- name: Build
+  run: |
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Release ..
+    make -j$(nproc)
+```
+
+### GitLab CI
+```yaml
+build:
+  script:
+    - mkdir build && cd build
+    - cmake -DCMAKE_BUILD_TYPE=Release ..
+    - make -j$(nproc)
+```
+
+## Related Documentation
+
+- `README.md` - Project overview
+- `CODE_STRUCTURE.md` - Code organization
+- `cmake/README.md` - CMake configuration
+- `tests/README.md` - Testing guide
+
+---
+
+**Last Updated:** 2025-10-07  
+**Version:** 1.0
+
+

--- a/firmware_new/docs/03-PROCEDURES/PR-002_Contributing_Procedure.md
+++ b/firmware_new/docs/03-PROCEDURES/PR-002_Contributing_Procedure.md
@@ -1,0 +1,679 @@
+# 🤝 Hướng Dẫn Đóng Góp - OHT-50 Firmware
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07
+
+---
+
+## 📋 **MỤC LỤC**
+
+1. [Quy Tắc Chung](#quy-tắc-chung)
+2. [Code Style](#code-style)
+3. [Quy Trình Phát Triển](#quy-trình-phát-triển)
+4. [Pull Request Process](#pull-request-process)
+5. [Báo Cáo Lỗi](#báo-cáo-lỗi)
+6. [Đề Xuất Tính Năng](#đề-xuất-tính-năng)
+7. [Testing Requirements](#testing-requirements)
+8. [Documentation](#documentation)
+
+---
+
+## 📜 **QUY TẮC CHUNG**
+
+### **Code of Conduct**
+
+Khi đóng góp vào dự án, bạn đồng ý:
+
+✅ Tôn trọng tất cả contributors  
+✅ Chấp nhận constructive criticism  
+✅ Focus vào điều tốt nhất cho cộng đồng  
+✅ Thể hiện empathy với contributors khác  
+✅ Tuân thủ các quy tắc coding standards
+
+❌ Không sử dụng ngôn ngữ offensive hoặc imagery  
+❌ Không trolling, insulting, hoặc derogatory comments  
+❌ Không public hoặc private harassment  
+❌ Không publish thông tin cá nhân của người khác
+
+### **Ai Có Thể Đóng Góp?**
+
+Tất cả mọi người! Chúng tôi welcome:
+
+- 🐛 **Bug fixes** - Sửa lỗi, cải thiện stability
+- ✨ **New features** - Thêm tính năng mới
+- 📚 **Documentation** - Cải thiện docs, examples
+- 🧪 **Tests** - Thêm test cases, coverage
+- 🎨 **Code quality** - Refactoring, optimization
+- 🌐 **Translations** - Dịch sang ngôn ngữ khác
+
+---
+
+## 🎨 **CODE STYLE**
+
+### **1. C Code Style**
+
+Chúng tôi sử dụng **LLVM style** với một số customization:
+
+#### **1.1. File Structure**
+
+```c
+// Header guard
+#ifndef HAL_MODULE_NAME_H
+#define HAL_MODULE_NAME_H
+
+// Includes (system → project)
+#include <stdint.h>
+#include <stdbool.h>
+#include "hal_common.h"
+
+// Constants
+#define MODULE_CONSTANT 100
+
+// Type definitions
+typedef struct {
+    uint32_t field1;
+    bool field2;
+} module_config_t;
+
+// Function declarations
+hal_status_t module_init(module_config_t *config);
+hal_status_t module_update(void);
+hal_status_t module_deinit(void);
+
+#endif // HAL_MODULE_NAME_H
+```
+
+#### **1.2. Naming Conventions**
+
+| **Type** | **Convention** | **Example** |
+|----------|----------------|-------------|
+| **Functions** | `snake_case` | `hal_rs485_init()` |
+| **Variables** | `snake_case` | `module_count` |
+| **Constants** | `UPPER_SNAKE_CASE` | `MAX_MODULES` |
+| **Types** | `snake_case_t` | `module_config_t` |
+| **Enums** | `UPPER_SNAKE_CASE` | `MODULE_TYPE_POWER` |
+| **Structs** | `snake_case_t` | `safety_status_t` |
+
+#### **1.3. Formatting Rules**
+
+```c
+// Indentation: 4 spaces (NO TABS)
+void function_name(int param1, int param2) {
+    if (condition) {
+        // Code block
+        int result = param1 + param2;
+        return result;
+    }
+}
+
+// Braces: Same line for functions, if/else, loops
+if (condition) {
+    // true case
+} else {
+    // false case
+}
+
+// Line length: Max 100 characters
+// Break long lines:
+int result = some_long_function_name(
+    parameter1, parameter2, parameter3, parameter4);
+
+// Comments: Use // for single line, /* */ for multi-line
+// Single line comment
+
+/*
+ * Multi-line comment
+ * Explains complex logic
+ */
+
+// Function comments: Doxygen style
+/**
+ * @brief Initialize RS485 communication
+ * @param config Configuration parameters
+ * @return HAL_STATUS_OK on success, error code otherwise
+ */
+hal_status_t hal_rs485_init(rs485_config_t *config);
+```
+
+#### **1.4. Auto-formatting**
+
+```bash
+# Format single file
+clang-format -i src/hal/hal_module.c
+
+# Format all files
+find src -name "*.c" -o -name "*.h" | xargs clang-format -i
+
+# Check formatting (CI)
+clang-format --dry-run --Werror src/**/*.c
+```
+
+### **2. CMake Style**
+
+```cmake
+# Function names: lowercase with underscores
+add_library(module_name STATIC
+    file1.c
+    file2.c
+)
+
+# Variables: UPPERCASE
+set(MODULE_VERSION "1.0.0")
+
+# Indentation: 4 spaces
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
+```
+
+### **3. YAML Style**
+
+```yaml
+# Indentation: 2 spaces
+modules:
+  - address: 0x02
+    type: POWER
+    enabled: true
+```
+
+---
+
+## 🔄 **QUY TRÌNH PHÁT TRIỂN**
+
+### **1. Fork và Clone**
+
+```bash
+# Fork trên GitHub UI
+
+# Clone fork về local
+git clone https://github.com/YOUR_USERNAME/OHT-50-firmware.git
+cd OHT-50-firmware/firmware_new
+
+# Add upstream remote
+git remote add upstream https://github.com/ORIGINAL_ORG/OHT-50-firmware.git
+
+# Verify remotes
+git remote -v
+```
+
+### **2. Create Branch**
+
+```bash
+# Update main
+git checkout main
+git pull upstream main
+
+# Create feature branch
+git checkout -b feature/my-awesome-feature
+
+# Hoặc bugfix branch
+git checkout -b bugfix/fix-rs485-timeout
+```
+
+**Branch naming convention:**
+- `feature/description` - Tính năng mới
+- `bugfix/description` - Sửa lỗi
+- `hotfix/description` - Sửa lỗi khẩn cấp
+- `docs/description` - Cập nhật docs
+- `refactor/description` - Refactoring code
+
+### **3. Make Changes**
+
+```bash
+# Code your changes
+vim src/hal/hal_module.c
+
+# Test your changes
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+./oht50_main --dry-run
+
+# Run tests
+make test
+```
+
+### **4. Commit Changes**
+
+#### **4.1. Commit Message Format**
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Types:**
+- `feat` - Tính năng mới
+- `fix` - Sửa lỗi
+- `docs` - Cập nhật documentation
+- `style` - Formatting, missing semicolons, etc.
+- `refactor` - Code refactoring
+- `test` - Adding tests
+- `chore` - Build process, tools, etc.
+
+**Examples:**
+
+```bash
+# Good commit message
+git commit -m "feat(rs485): add CRC validation for Modbus frames
+
+- Implement CRC16 algorithm
+- Add unit tests for CRC validation
+- Update documentation
+
+Fixes #123"
+
+# Another good example
+git commit -m "fix(safety): correct E-Stop response time
+
+Response time was 150ms, now reduced to 80ms by
+optimizing interrupt handler.
+
+Related to #456"
+```
+
+#### **4.2. Commit Guidelines**
+
+✅ **DO:**
+- Write clear, concise commit messages
+- Use present tense ("add feature" not "added feature")
+- Reference issue numbers
+- Keep commits atomic (one logical change per commit)
+- Test before committing
+
+❌ **DON'T:**
+- Commit broken code
+- Mix multiple unrelated changes
+- Use vague messages ("fix stuff", "update")
+- Commit generated files (build artifacts)
+
+### **5. Push và Create PR**
+
+```bash
+# Push to your fork
+git push origin feature/my-awesome-feature
+
+# Create Pull Request trên GitHub UI
+```
+
+---
+
+## 📝 **PULL REQUEST PROCESS**
+
+### **1. Before Creating PR**
+
+**Checklist:**
+
+```bash
+# ✅ Code builds without errors
+mkdir build && cd build
+cmake .. && make -j$(nproc)
+
+# ✅ All tests pass
+make test
+
+# ✅ Code formatted
+clang-format -i src/**/*.c
+
+# ✅ No lint errors
+clang-tidy src/**/*.c
+
+# ✅ Documentation updated
+# - README.md
+# - API_REFERENCE.md
+# - CHANGELOG.md
+
+# ✅ Commit messages follow convention
+git log --oneline -n 5
+```
+
+### **2. PR Template**
+
+```markdown
+## Description
+Brief description of changes
+
+## Type of Change
+- [ ] Bug fix (non-breaking change)
+- [ ] New feature (non-breaking change)
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Testing
+- [ ] Unit tests added/updated
+- [ ] Integration tests pass
+- [ ] Manual testing completed
+
+## Checklist
+- [ ] Code follows style guidelines
+- [ ] Self-review completed
+- [ ] Comments added for complex code
+- [ ] Documentation updated
+- [ ] No new warnings
+- [ ] Tests added/updated
+- [ ] Passes all CI checks
+
+## Related Issues
+Fixes #123
+Related to #456
+
+## Screenshots (if applicable)
+```
+
+### **3. PR Review Process**
+
+1. **Automated Checks** (CI/CD)
+   - ✅ Build successful
+   - ✅ All tests pass
+   - ✅ Code coverage acceptable
+   - ✅ No security vulnerabilities
+
+2. **Manual Review** (Reviewers)
+   - 👀 Code quality
+   - 🔍 Logic correctness
+   - 📚 Documentation completeness
+   - 🧪 Test coverage
+
+3. **Approval**
+   - ✅ Minimum 1 approval required
+   - ✅ All comments addressed
+   - ✅ CI checks pass
+
+4. **Merge**
+   - Squash and merge (default)
+   - Merge commit (for large features)
+   - Rebase and merge (linear history)
+
+### **4. After Merge**
+
+```bash
+# Update your local main
+git checkout main
+git pull upstream main
+
+# Delete feature branch
+git branch -d feature/my-awesome-feature
+git push origin --delete feature/my-awesome-feature
+```
+
+---
+
+## 🐛 **BÁO CÁO LỖI**
+
+### **Bug Report Template**
+
+```markdown
+## Bug Description
+Clear description of the bug
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected Behavior
+What you expected to happen
+
+## Actual Behavior
+What actually happened
+
+## Environment
+- **Firmware Version:** 1.0.1
+- **Platform:** Orange Pi 5B
+- **OS:** Ubuntu 22.04
+- **Build Type:** Debug/Release
+
+## Logs
+```
+[Paste relevant logs here]
+```
+
+## Screenshots
+If applicable, add screenshots
+
+## Additional Context
+Any other context about the problem
+```
+
+### **Bug Reporting Guidelines**
+
+✅ **Good Bug Reports:**
+- Clear, concise description
+- Steps to reproduce
+- Expected vs actual behavior
+- Logs và screenshots
+- Environment information
+
+❌ **Bad Bug Reports:**
+- "It doesn't work"
+- "Fix this bug"
+- No details, no logs
+- Can't reproduce
+
+---
+
+## ✨ **ĐỀ XUẤT TÍNH NĂNG**
+
+### **Feature Request Template**
+
+```markdown
+## Feature Description
+Clear description of the proposed feature
+
+## Problem Statement
+What problem does this solve?
+
+## Proposed Solution
+How do you propose to implement this?
+
+## Alternatives Considered
+What other approaches did you consider?
+
+## Additional Context
+Any other context, screenshots, mockups
+
+## Implementation Checklist
+- [ ] Design document
+- [ ] API design
+- [ ] Implementation plan
+- [ ] Test plan
+- [ ] Documentation plan
+```
+
+---
+
+## 🧪 **TESTING REQUIREMENTS**
+
+### **1. Unit Tests**
+
+```c
+// Test file: tests/unit/test_module.c
+#include "unity.h"
+#include "hal_module.h"
+
+void setUp(void) {
+    // Setup before each test
+}
+
+void tearDown(void) {
+    // Cleanup after each test
+}
+
+void test_module_init_success(void) {
+    module_config_t config = {0};
+    hal_status_t result = module_init(&config);
+    TEST_ASSERT_EQUAL(HAL_STATUS_OK, result);
+}
+
+void test_module_init_null_config(void) {
+    hal_status_t result = module_init(NULL);
+    TEST_ASSERT_EQUAL(HAL_STATUS_INVALID_ARG, result);
+}
+```
+
+### **2. Integration Tests**
+
+```bash
+# Run integration tests
+cd tests/integration
+./test_rs485_communication.sh
+./test_module_discovery.sh
+```
+
+### **3. Test Coverage**
+
+```bash
+# Build with coverage
+cmake -DENABLE_COVERAGE=ON ..
+make
+
+# Run tests
+make test
+
+# Generate coverage report
+lcov --capture --directory . --output-file coverage.info
+genhtml coverage.info --output-directory coverage_report
+
+# Target: > 80% coverage
+```
+
+---
+
+## 📚 **DOCUMENTATION**
+
+### **1. Code Documentation**
+
+```c
+/**
+ * @brief Initialize RS485 communication
+ * 
+ * This function initializes the RS485 hardware and configures
+ * the UART with specified parameters.
+ * 
+ * @param config Pointer to configuration structure
+ * @return HAL_STATUS_OK on success
+ * @return HAL_STATUS_INVALID_ARG if config is NULL
+ * @return HAL_STATUS_ERROR on hardware failure
+ * 
+ * @note This function must be called before any RS485 operations
+ * @warning Config must remain valid during operation
+ * 
+ * @example
+ * rs485_config_t config = {
+ *     .baud_rate = 115200,
+ *     .data_bits = 8
+ * };
+ * hal_status_t result = hal_rs485_init(&config);
+ */
+hal_status_t hal_rs485_init(rs485_config_t *config);
+```
+
+### **2. API Documentation**
+
+Update `API_REFERENCE.md` khi thêm/sửa API:
+
+```markdown
+## POST /api/v1/robot/command
+
+Execute robot command.
+
+### Request
+
+```json
+{
+  "command": "move",
+  "parameters": {
+    "velocity": 1000,
+    "position": 5000
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "message": "Command executed"
+}
+```
+
+### Errors
+
+- `400` - Invalid command
+- `500` - Execution failed
+```
+
+---
+
+## 🎯 **REVIEW CHECKLIST**
+
+Khi review PR, check:
+
+### **Code Quality**
+- [ ] Follows coding style
+- [ ] No duplicate code
+- [ ] No magic numbers (use constants)
+- [ ] Error handling comprehensive
+- [ ] No memory leaks
+- [ ] Thread-safe (if applicable)
+
+### **Testing**
+- [ ] Unit tests added
+- [ ] Integration tests pass
+- [ ] Manual testing done
+- [ ] Edge cases covered
+
+### **Documentation**
+- [ ] Code comments clear
+- [ ] API docs updated
+- [ ] README updated (if needed)
+- [ ] CHANGELOG updated
+
+### **Performance**
+- [ ] No performance regression
+- [ ] Resource usage acceptable
+- [ ] Scalability considered
+
+### **Security**
+- [ ] No security vulnerabilities
+- [ ] Input validation added
+- [ ] No hardcoded secrets
+
+---
+
+## 🏆 **RECOGNITION**
+
+Contributors được ghi nhận trong:
+- `CONTRIBUTORS.md` - Danh sách contributors
+- Release notes
+- GitHub contributors page
+
+Top contributors có thể được:
+- 🌟 Invited làm maintainer
+- 🎁 Swag (stickers, t-shirts)
+- 📣 Featured trên blog/social media
+
+---
+
+## 📞 **LIÊN HỆ**
+
+Có câu hỏi về contribution?
+
+- 💬 **Slack:** #oht50-contributors
+- 📧 **Email:** contributors@oht50.com
+- 🐛 **Issues:** GitHub Issues
+- 💡 **Discussions:** GitHub Discussions
+
+---
+
+**Thank you for contributing to OHT-50! 🚀**
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07  
+**Maintained By:** OHT-50 Core Team
+

--- a/firmware_new/docs/03-PROCEDURES/PR-003_Code_Quality_Procedure.md
+++ b/firmware_new/docs/03-PROCEDURES/PR-003_Code_Quality_Procedure.md
@@ -1,0 +1,477 @@
+# OHT-50 Firmware Code Quality Guide
+
+**Version:** 1.0.0  
+**Last Updated:** 2025-10-07
+
+## Overview
+
+This document describes the code quality tools and practices used in the OHT-50 firmware project.
+
+## Code Formatting
+
+### Clang-Format
+
+**Configuration:** `.clang-format`
+
+**Style:** LLVM-based with custom modifications:
+- **Indentation:** 4 spaces
+- **Column Limit:** 100 characters
+- **Pointer Alignment:** Left (`int* ptr`)
+- **No Short Functions:** Functions not on single line
+
+**Usage:**
+
+```bash
+# Format single file
+clang-format -i src/hal/hal_rs485.c
+
+# Format all C/H files
+find src/ include/ -name "*.c" -o -name "*.h" | xargs clang-format -i
+
+# Check formatting without modifying
+clang-format --dry-run --Werror src/hal/hal_rs485.c
+```
+
+**IDE Integration:**
+- **VSCode:** Install "C/C++" extension
+- **Vim:** Use `clang-format` plugin
+- **CLion:** Built-in support
+
+### EditorConfig
+
+**Configuration:** `.editorconfig`
+
+Ensures consistent coding styles across different editors and IDEs:
+- **Encoding:** UTF-8
+- **Line Endings:** LF (Unix)
+- **Trailing Whitespace:** Removed
+- **Final Newline:** Required
+
+**Supported Editors:**
+- VSCode (built-in)
+- Vim/Neovim (plugin required)
+- Sublime Text (plugin required)
+- CLion/IntelliJ (built-in)
+
+## Static Analysis
+
+### Clang-Tidy
+
+**Configuration:** `.clang-tidy`
+
+**Enabled Check Categories:**
+- `clang-diagnostic-*` - Compiler diagnostics
+- `clang-analyzer-*` - Static analyzer checks
+- `readability-*` - Code readability checks
+- `modernize-*` - Modern C++ practices (C11 for us)
+- `bugprone-*` - Bug-prone code patterns
+- `performance-*` - Performance improvements
+- `portability-*` - Portability issues
+- `concurrency-*` - Thread safety issues
+
+**Disabled Checks:**
+- `readability-identifier-naming` - We have our own naming conventions
+- `readability-magic-numbers` - Too noisy for embedded code
+- `bugprone-easily-swappable-parameters` - False positives
+
+**Usage:**
+
+```bash
+# Run on single file
+clang-tidy src/hal/hal_rs485.c -- -Iinclude -Isrc
+
+# Run on all files (with compile_commands.json)
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+run-clang-tidy
+
+# Run with fixes
+clang-tidy -fix src/hal/hal_rs485.c -- -Iinclude -Isrc
+```
+
+**CMake Integration:**
+
+```bash
+cmake -DENABLE_STATIC_ANALYSIS=ON ..
+make
+```
+
+### Ignored Files
+
+**Configuration:** `.clang-format-ignore`
+
+Files/directories excluded from formatting:
+- `third_party/**` - External libraries
+- `build/**` - Build artifacts
+- Generated files
+
+## Code Coverage
+
+### GCov/LCov
+
+**Enable Coverage:**
+
+```bash
+cmake -DENABLE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug ..
+make -j$(nproc)
+make test
+```
+
+**Generate Report:**
+
+```bash
+# Capture coverage data
+lcov --capture --directory . --output-file coverage.info
+
+# Remove external code
+lcov --remove coverage.info '/usr/*' --output-file coverage.info
+
+# Generate HTML report
+genhtml coverage.info --output-directory coverage_html
+
+# View report
+firefox coverage_html/index.html
+```
+
+**Coverage Goals:**
+- **Overall:** > 90%
+- **Safety-critical code:** 100%
+- **HAL layer:** > 95%
+- **Application layer:** > 85%
+
+## Sanitizers
+
+### AddressSanitizer (ASan)
+
+Detects memory errors:
+- Buffer overflows
+- Use-after-free
+- Memory leaks
+- Double-free
+
+**Enable:**
+
+```bash
+cmake -DENABLE_SANITIZERS=ON -DCMAKE_BUILD_TYPE=Debug ..
+make
+./oht50_main
+```
+
+### UndefinedBehaviorSanitizer (UBSan)
+
+Detects undefined behavior:
+- Integer overflow
+- Division by zero
+- Null pointer dereference
+- Misaligned pointers
+
+**Already included with ASan option**
+
+## Compiler Warnings
+
+### Warning Flags
+
+**Enabled in `cmake/CompilerOptions.cmake`:**
+
+```c
+-Wall                     // All standard warnings
+-Wextra                   // Extra warnings
+-Wpedantic                // Pedantic warnings
+-Werror=implicit-function-declaration
+-Werror=return-type
+-Werror=uninitialized
+-Wformat=2
+-Wformat-security
+-Wnull-dereference
+-Wstrict-prototypes
+-Wmissing-prototypes
+-Wold-style-definition
+-Wshadow
+-Wcast-align
+-Wconversion
+-Wsign-conversion
+```
+
+**Treat as Errors:**
+- Implicit function declarations
+- Missing return statements
+- Uninitialized variables
+
+## Pre-commit Checks
+
+### Recommended Pre-commit Hook
+
+Create `.git/hooks/pre-commit`:
+
+```bash
+#!/bin/bash
+
+# Format check
+echo "Checking code formatting..."
+CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(c|h)$')
+
+if [ -n "$CHANGED_FILES" ]; then
+    for file in $CHANGED_FILES; do
+        clang-format --dry-run --Werror "$file" 2>&1 | grep -q "warning:"
+        if [ $? -eq 0 ]; then
+            echo "Error: $file needs formatting"
+            echo "Run: clang-format -i $file"
+            exit 1
+        fi
+    done
+fi
+
+# Static analysis (optional, can be slow)
+# echo "Running clang-tidy..."
+# for file in $CHANGED_FILES; do
+#     clang-tidy "$file" -- -Iinclude -Isrc || exit 1
+# done
+
+echo "Pre-commit checks passed!"
+```
+
+Make executable:
+```bash
+chmod +x .git/hooks/pre-commit
+```
+
+## Continuous Integration
+
+### CI Pipeline Stages
+
+1. **Build Check**
+   ```bash
+   cmake -DCMAKE_BUILD_TYPE=Release ..
+   make -j$(nproc)
+   ```
+
+2. **Code Formatting**
+   ```bash
+   find src include -name "*.c" -o -name "*.h" | \
+       xargs clang-format --dry-run --Werror
+   ```
+
+3. **Static Analysis**
+   ```bash
+   cmake -DENABLE_STATIC_ANALYSIS=ON ..
+   make
+   ```
+
+4. **Unit Tests**
+   ```bash
+   ctest -V
+   ```
+
+5. **Coverage Report**
+   ```bash
+   cmake -DENABLE_COVERAGE=ON ..
+   make test
+   lcov --capture --directory . --output-file coverage.info
+   ```
+
+6. **Sanitizer Tests**
+   ```bash
+   cmake -DENABLE_SANITIZERS=ON ..
+   make
+   ./oht50_main
+   ```
+
+## Best Practices
+
+### Code Style
+
+1. **Consistent Formatting**
+   - Run `clang-format` before committing
+   - Use `.editorconfig` in your editor
+   - Follow LLVM style guide
+
+2. **Naming Conventions**
+   - Functions: `snake_case`
+   - Variables: `snake_case`
+   - Constants: `UPPER_CASE`
+   - Types: `snake_case_t`
+
+3. **Documentation**
+   - Document all public functions
+   - Use Doxygen-style comments
+   - Include examples for complex functions
+
+### Error Handling
+
+1. **Always Check Return Values**
+   ```c
+   int result = hal_rs485_init(&config);
+   if (result != HAL_OK) {
+       // Handle error
+   }
+   ```
+
+2. **Use Meaningful Error Codes**
+   ```c
+   typedef enum {
+       HAL_OK = 0,
+       HAL_ERROR = -1,
+       HAL_TIMEOUT = -2,
+       HAL_BUSY = -3
+   } hal_status_t;
+   ```
+
+3. **Log Errors Appropriately**
+   ```c
+   if (result != HAL_OK) {
+       LOG_ERROR("Failed to initialize RS485: %d", result);
+       return result;
+   }
+   ```
+
+### Memory Management
+
+1. **Always Free What You Allocate**
+   ```c
+   void* buffer = malloc(size);
+   if (buffer == NULL) {
+       return HAL_ERROR;
+   }
+   // Use buffer
+   free(buffer);
+   ```
+
+2. **Check for NULL Pointers**
+   ```c
+   void function(void* ptr) {
+       if (ptr == NULL) {
+           return HAL_ERROR;
+       }
+       // Use ptr
+   }
+   ```
+
+3. **Avoid Memory Leaks**
+   - Use ASan to detect leaks
+   - Free in error paths
+   - Use RAII-like patterns
+
+### Thread Safety
+
+1. **Protect Shared Data**
+   ```c
+   pthread_mutex_lock(&mutex);
+   shared_data = value;
+   pthread_mutex_unlock(&mutex);
+   ```
+
+2. **Avoid Race Conditions**
+   - Use atomic operations where possible
+   - Minimize critical sections
+   - Use thread-local storage
+
+3. **Test Concurrent Code**
+   - Use ThreadSanitizer (TSan)
+   - Write specific concurrency tests
+   - Test under load
+
+## Quality Metrics
+
+### Current Status
+
+- **Code Coverage:** ~90%
+- **Static Analysis:** 0 high-priority issues
+- **Compiler Warnings:** 0 (all treated as errors)
+- **Memory Leaks:** 0 (verified with ASan)
+
+### Quality Gates
+
+**Before Merge:**
+- [ ] Code formatted (clang-format)
+- [ ] Static analysis passed (clang-tidy)
+- [ ] All tests passing
+- [ ] Coverage maintained/improved
+- [ ] No sanitizer errors
+
+**Before Release:**
+- [ ] Full test suite passing
+- [ ] Coverage > 90%
+- [ ] No critical static analysis issues
+- [ ] Documentation updated
+- [ ] Performance benchmarks met
+
+## Tools Installation
+
+### Ubuntu/Debian
+
+```bash
+# Formatting
+sudo apt-get install clang-format
+
+# Static Analysis
+sudo apt-get install clang-tidy
+
+# Coverage
+sudo apt-get install lcov
+
+# Sanitizers (included in GCC/Clang)
+sudo apt-get install gcc clang
+```
+
+### VSCode Extensions
+
+- C/C++ (Microsoft)
+- Clang-Format
+- EditorConfig for VS Code
+- Code Coverage
+
+### Vim/Neovim Plugins
+
+```vim
+Plug 'rhysd/vim-clang-format'
+Plug 'editorconfig/editorconfig-vim'
+```
+
+## Troubleshooting
+
+### Clang-Format Not Working
+
+```bash
+# Check version (need 10+)
+clang-format --version
+
+# Install newer version
+sudo apt-get install clang-format-14
+```
+
+### Clang-Tidy Too Slow
+
+```bash
+# Run on changed files only
+git diff --name-only | grep '\.[ch]$' | xargs clang-tidy
+
+# Use compilation database
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+```
+
+### Coverage Report Empty
+
+```bash
+# Ensure debug build
+cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON ..
+
+# Run tests to generate coverage data
+make test
+
+# Check .gcda files exist
+find . -name "*.gcda"
+```
+
+## References
+
+- [Clang-Format Documentation](https://clang.llvm.org/docs/ClangFormat.html)
+- [Clang-Tidy Documentation](https://clang.llvm.org/extra/clang-tidy/)
+- [EditorConfig](https://editorconfig.org/)
+- [GCC Warning Options](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html)
+- [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer)
+
+---
+
+**Last Updated:** 2025-10-07  
+**Version:** 1.0.0  
+**Maintained By:** Firmware Team
+

--- a/firmware_new/docs/03-PROCEDURES/README.md
+++ b/firmware_new/docs/03-PROCEDURES/README.md
@@ -1,0 +1,83 @@
+# 🔧 03-PROCEDURES (Thủ Tục)
+
+**Theo ISO 9001:2015 Section 8 - Operation**
+
+---
+
+## 🎯 **MỤC ĐÍCH**
+
+Thư mục này chứa các **thủ tục chuẩn** cho quy trình phát triển, build, và quality control.
+
+---
+
+## 📄 **DANH SÁCH TÀI LIỆU**
+
+| **Mã** | **Tên tài liệu** | **Mô tả** | **Version** |
+|--------|------------------|-----------|-------------|
+| **PR-001** | Build_Procedure.md | Quy trình build firmware (CMake, options) | 1.0 |
+| **PR-002** | Contributing_Procedure.md | Quy trình đóng góp (Git workflow, PR) | 1.0.1 |
+| **PR-003** | Code_Quality_Procedure.md | Quy trình quality control (format, lint) | 1.0 |
+
+---
+
+## 🏗️ **PR-001: Build Procedure**
+
+**Nội dung:**
+- Prerequisites (system + software requirements)
+- Quick start (4 bước: clone → configure → build → run)
+- Build configurations (Debug, Release, RelWithDebInfo)
+- Build options (Coverage, Sanitizers, Static Analysis)
+- Cross-compilation cho ARM
+- Installation procedures
+- Troubleshooting build issues
+
+**Khi nào dùng:** Khi build firmware lần đầu hoặc build với config mới
+
+---
+
+## 🤝 **PR-002: Contributing Procedure**
+
+**Nội dung:**
+- Code of Conduct
+- Code style (LLVM, naming conventions)
+- Git workflow (Fork → Branch → Commit → PR)
+- Commit message convention
+- PR process (template, review, approval)
+- Bug report và feature request templates
+- Testing requirements (>80% coverage)
+- Documentation standards
+
+**Khi nào dùng:** Trước khi contribute code, tạo PR
+
+---
+
+## ✨ **PR-003: Code Quality Procedure**
+
+**Nội dung:**
+- Code formatting (clang-format)
+- Static analysis (clang-tidy)
+- Code coverage (gcov/lcov)
+- Sanitizers (ASan/UBSan)
+- Compiler warnings (15+ flags)
+- Pre-commit checks
+- CI/CD pipeline
+- Quality metrics
+
+**Khi nào dùng:** Development, code review, CI/CD setup
+
+---
+
+## ✅ **TUÂN THỦ**
+
+Procedures phải được tuân thủ **BẮT BUỘC** cho:
+- ✅ Pull requests
+- ✅ Code reviews
+- ✅ Quality gates
+- ✅ Release process
+
+---
+
+**Version:** 1.0  
+**Last Updated:** 2025-10-07  
+**Maintained By:** Process Team
+

--- a/firmware_new/docs/04-WORK_INSTRUCTIONS/README.md
+++ b/firmware_new/docs/04-WORK_INSTRUCTIONS/README.md
@@ -1,0 +1,115 @@
+# 📚 04-WORK_INSTRUCTIONS (Hướng Dẫn Công Việc)
+
+**Theo ISO 9001:2015 Section 7.5 - Work Instructions**
+
+---
+
+## 🎯 **MỤC ĐÍCH**
+
+Thư mục này chứa **hướng dẫn công việc chi tiết** - step-by-step instructions cho các tác vụ cụ thể.
+
+---
+
+## 📄 **DANH SÁCH TÀI LIỆU**
+
+| **Mã** | **Tên tài liệu** | **Mô tả** | **Version** |
+|--------|------------------|-----------|-------------|
+| **WI-001** | Installation_Guide.md | Hướng dẫn cài đặt đầy đủ (HW + SW) | 1.0.1 |
+| **WI-002** | Usage_Guide.md | Hướng dẫn sử dụng firmware | 1.0.1 |
+| **WI-003** | Development_Guide.md | Hướng dẫn phát triển | 1.0.1 |
+| **WI-004** | Troubleshooting_Guide.md | Khắc phục 10+ sự cố | 1.0.1 |
+| **WI-005** | LiDAR_Debug_Guide.md | Debug LiDAR HAL system | 1.2 |
+| **WI-006** | Network_Deployment.md | Triển khai network management | 1.0 |
+
+---
+
+## 🔧 **WI-001: Installation Guide**
+
+**Scope:** Cài đặt firmware lên Orange Pi 5B
+
+**Nội dung:**
+- ✅ Yêu cầu hệ thống (hardware + software)
+- ✅ Chuẩn bị môi trường (OS, SSH)
+- ✅ Cài đặt phụ thuộc (build tools, libraries)
+- ✅ Build firmware (Debug/Release)
+- ✅ Cấu hình hardware (UART1, GPIO, udev)
+- ✅ Triển khai (systemd service)
+- ✅ Xác minh cài đặt
+- ✅ Troubleshooting (4 issues)
+
+**Thời gian:** ~30-60 phút (lần đầu)
+
+---
+
+## 📖 **WI-002: Usage Guide**
+
+**Scope:** Sử dụng firmware trong operation
+
+**Nội dung:**
+- ✅ Khởi động firmware (basic, service)
+- ✅ State machine (8 states)
+- ✅ Cấu hình (modules.yaml, safety_config)
+- ✅ API usage (5 endpoints)
+- ✅ Module management (auto-discovery)
+- ✅ System monitoring (telemetry, LED)
+- ✅ Emergency stop procedures
+- ✅ Error handling
+
+**Thời gian:** ~10-15 phút đọc hiểu
+
+---
+
+## 🛠️ **WI-003: Development Guide**
+
+**Scope:** Development workflow cho contributors
+
+**Nội dung:**
+- ✅ IDE setup (VS Code + extensions)
+- ✅ Architecture overview (5 layers)
+- ✅ Development workflow
+- ✅ Debugging (GDB, Valgrind)
+- ✅ Testing strategy
+- ✅ Performance profiling
+- ✅ Best practices
+
+**Thời gian:** ~20-30 phút setup
+
+---
+
+## 🐛 **WI-004: Troubleshooting Guide**
+
+**Scope:** Khắc phục các sự cố phổ biến
+
+**Nội dung:**
+- ✅ 10 vấn đề phổ biến:
+  1. Build failed
+  2. /dev/ttyOHT485 not found
+  3. Permission denied
+  4. Port in use
+  5. Module not discovered
+  6. High CPU usage
+  7. RS485 errors
+  8. LiDAR not responding
+  9. State machine stuck
+  10. Memory leak
+- ✅ Diagnostic tools
+- ✅ Support channels
+
+**Thời gian:** ~5-10 phút giải quyết issue
+
+---
+
+## ✅ **SỬ DỤNG**
+
+Work Instructions phải được:
+- ✅ Đọc trước khi thực hiện tác vụ
+- ✅ Tuân thủ từng bước
+- ✅ Update nếu có thay đổi process
+- ✅ Review định kỳ (quarterly)
+
+---
+
+**Version:** 1.0  
+**Last Updated:** 2025-10-07  
+**Maintained By:** Operations Team
+

--- a/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-001_Installation_Guide.md
+++ b/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-001_Installation_Guide.md
@@ -1,0 +1,539 @@
+# 🔧 Hướng Dẫn Cài Đặt OHT-50 Firmware
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07  
+**Platform:** Orange Pi 5B (RK3588)
+
+---
+
+## 📋 **MỤC LỤC**
+
+1. [Yêu Cầu Hệ Thống](#yêu-cầu-hệ-thống)
+2. [Chuẩn Bị Môi Trường](#chuẩn-bị-môi-trường)
+3. [Cài Đặt Phụ Thuộc](#cài-đặt-phụ-thuộc)
+4. [Build Firmware](#build-firmware)
+5. [Cấu Hình Hardware](#cấu-hình-hardware)
+6. [Triển Khai Lên Thiết Bị](#triển-khai-lên-thiết-bị)
+7. [Xác Minh Cài Đặt](#xác-minh-cài-đặt)
+8. [Troubleshooting](#troubleshooting)
+
+---
+
+## 📌 **YÊU CẦU HỆ THỐNG**
+
+### **Hardware Requirements**
+
+| **Component** | **Specification** | **Required** |
+|---------------|-------------------|--------------|
+| 🖥️ **Board** | Orange Pi 5B (RK3588) | ✅ Bắt buộc |
+| 💾 **RAM** | 4GB minimum, 8GB khuyến nghị | ✅ Bắt buộc |
+| 💽 **Storage** | 16GB eMMC/SD Card minimum | ✅ Bắt buộc |
+| 📡 **RS485** | UART1 `/dev/ttyOHT485` @ 115200 baud | ✅ Bắt buộc |
+| 🔌 **GPIO** | GPIO1_D3 (Relay1), GPIO1_D2 (Relay2) | ✅ Bắt buộc |
+| 💡 **LED** | 5x status LEDs (Power, System, Comm, Network, Error) | ✅ Bắt buộc |
+| 🛑 **E-Stop** | Hardware E-Stop button | ✅ Bắt buộc |
+| 🌐 **Network** | Ethernet 10/100/1000 hoặc WiFi 5G/2.4G | ✅ Bắt buộc |
+| 🔵 **LiDAR** | RPLiDAR A1/A2 (tùy chọn) | ⚠️ Tùy chọn |
+
+### **Software Requirements**
+
+| **Software** | **Version** | **Purpose** |
+|--------------|-------------|-------------|
+| 🐧 **Linux** | Ubuntu 20.04/22.04 hoặc Armbian | OS cho Orange Pi 5B |
+| 🔧 **GCC** | 9.0+ | C11 compiler |
+| 🏗️ **CMake** | 3.16+ | Build system |
+| 📦 **Git** | 2.0+ | Version control |
+| 🔐 **OpenSSL** | 1.1.1+ | SSL/TLS support |
+| 🧵 **pthread** | POSIX threads | Multi-threading |
+| 📊 **libm** | Math library | Mathematical functions |
+
+---
+
+## 🛠️ **CHUẨN BỊ MÔI TRƯỜNG**
+
+### **Bước 1: Cài Đặt Hệ Điều Hành**
+
+#### **1.1. Flash Armbian/Ubuntu lên Orange Pi 5B**
+
+```bash
+# Download Armbian cho Orange Pi 5B
+wget https://github.com/armbian/build/releases/download/latest/Armbian_XX.XX_Orangepi5b.img.xz
+
+# Flash lên SD Card (thay /dev/sdX bằng đường dẫn SD Card)
+xz -d Armbian_XX.XX_Orangepi5b.img.xz
+sudo dd if=Armbian_XX.XX_Orangepi5b.img of=/dev/sdX bs=4M status=progress
+sync
+```
+
+#### **1.2. Boot và Cấu Hình Ban Đầu**
+
+```bash
+# Đăng nhập lần đầu (mặc định)
+# Username: root
+# Password: 1234
+
+# Đổi password root và tạo user mới
+passwd
+adduser oht50
+
+# Update hệ thống
+apt update && apt upgrade -y
+```
+
+### **Bước 2: Cài Đặt SSH (Tùy chọn)**
+
+```bash
+# Enable SSH
+systemctl enable ssh
+systemctl start ssh
+
+# Cho phép SSH qua firewall
+ufw allow 22/tcp
+ufw enable
+```
+
+---
+
+## 📦 **CÀI ĐẶT PHỤ THUỘC**
+
+### **Bước 1: Cài Đặt Build Tools**
+
+```bash
+# Update package list
+sudo apt update
+
+# Cài đặt build essentials
+sudo apt install -y \
+    build-essential \
+    gcc \
+    g++ \
+    cmake \
+    make \
+    git \
+    pkg-config
+
+# Xác nhận version
+gcc --version      # Should be >= 9.0
+cmake --version    # Should be >= 3.16
+```
+
+### **Bước 2: Cài Đặt Libraries**
+
+```bash
+# Cài đặt OpenSSL development
+sudo apt install -y \
+    libssl-dev \
+    libcrypto++-dev
+
+# Cài đặt pthread (thường đã có sẵn)
+sudo apt install -y libc6-dev
+
+# Cài đặt math library (thường đã có sẵn)
+sudo apt install -y libm-dev
+
+# Cài đặt YAML parser (tùy chọn)
+sudo apt install -y libyaml-dev
+```
+
+### **Bước 3: Cài Đặt Development Tools (Tùy chọn)**
+
+```bash
+# Cài đặt clang-format (code formatting)
+sudo apt install -y clang-format
+
+# Cài đặt clang-tidy (static analysis)
+sudo apt install -y clang-tidy
+
+# Cài đặt valgrind (memory debugging)
+sudo apt install -y valgrind
+
+# Cài đặt gdb (debugging)
+sudo apt install -y gdb
+```
+
+---
+
+## 🏗️ **BUILD FIRMWARE**
+
+### **Bước 1: Clone Repository**
+
+```bash
+# Clone từ Git repository
+git clone https://github.com/your-org/OHT-50-firmware.git
+cd OHT-50-firmware/firmware_new
+
+# Hoặc nếu đã có source code
+cd /path/to/OHT_V2/firmware_new
+```
+
+### **Bước 2: Tạo Build Directory**
+
+```bash
+# Tạo build directory
+mkdir -p build
+cd build
+```
+
+### **Bước 3: Configure CMake**
+
+#### **3.1. Build Debug (cho development)**
+
+```bash
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DENABLE_COVERAGE=ON \
+    -DENABLE_SANITIZERS=ON \
+    -DBUILD_TESTING=ON
+```
+
+#### **3.2. Build Release (cho production)**
+
+```bash
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_STATIC_ANALYSIS=ON \
+    -DENABLE_LIDAR=ON \
+    -DENABLE_WIFI_AP=ON \
+    -DENABLE_WEBSOCKET=OFF \
+    -DENABLE_HTTPS=OFF
+```
+
+#### **3.3. Build Options**
+
+| **Option** | **Default** | **Description** |
+|------------|-------------|-----------------|
+| `CMAKE_BUILD_TYPE` | Debug | Debug/Release/RelWithDebInfo |
+| `BUILD_TESTING` | ON | Enable test suite |
+| `ENABLE_COVERAGE` | OFF | Code coverage analysis |
+| `ENABLE_SANITIZERS` | OFF | AddressSanitizer/UBSan |
+| `ENABLE_STATIC_ANALYSIS` | OFF | clang-tidy analysis |
+| `ENABLE_LIDAR` | ON | LiDAR support |
+| `ENABLE_WIFI_AP` | ON | WiFi Access Point |
+| `ENABLE_WEBSOCKET` | OFF | WebSocket support (DEPRECATED) |
+| `ENABLE_HTTPS` | OFF | HTTPS support |
+
+### **Bước 4: Build**
+
+```bash
+# Build với all CPU cores
+make -j$(nproc)
+
+# Hoặc build với verbose output
+make VERBOSE=1
+```
+
+### **Bước 5: Verify Build**
+
+```bash
+# Check executable đã được tạo
+ls -lh oht50_main
+
+# Check file size (khoảng 2-5 MB)
+du -h oht50_main
+
+# Check dependencies
+ldd oht50_main
+```
+
+---
+
+## ⚙️ **CẤU HÌNH HARDWARE**
+
+### **Bước 1: Cấu Hình UART1 cho RS485**
+
+#### **1.1. Device Tree Overlay**
+
+```bash
+# Copy device tree overlay
+sudo cp ../overlays/uart1_correct.dtbo /boot/dtb/rockchip/overlay/
+
+# Edit /boot/armbianEnv.txt
+sudo nano /boot/armbianEnv.txt
+
+# Thêm dòng:
+overlays=uart1_correct
+
+# Reboot
+sudo reboot
+```
+
+#### **1.2. Tạo udev rule cho /dev/ttyOHT485**
+
+```bash
+# Tạo udev rule
+sudo nano /etc/udev/rules.d/99-oht-rs485.rules
+
+# Thêm nội dung:
+KERNEL=="ttyS1", SYMLINK+="ttyOHT485", MODE="0666", GROUP="dialout"
+
+# Reload udev rules
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+
+# Verify
+ls -l /dev/ttyOHT485
+```
+
+### **Bước 2: Cấu Hình GPIO cho Relays**
+
+```bash
+# Export GPIO (nếu cần)
+echo 59 > /sys/class/gpio/export  # GPIO1_D3 (Relay1)
+echo 58 > /sys/class/gpio/export  # GPIO1_D2 (Relay2)
+
+# Set direction
+echo out > /sys/class/gpio/gpio59/direction
+echo out > /sys/class/gpio/gpio58/direction
+
+# Test relay
+echo 1 > /sys/class/gpio/gpio59/value  # Turn ON
+echo 0 > /sys/class/gpio/gpio59/value  # Turn OFF
+```
+
+### **Bước 3: Cấu Hình Permissions**
+
+```bash
+# Thêm user vào dialout group (cho RS485)
+sudo usermod -a -G dialout $USER
+
+# Thêm user vào gpio group
+sudo usermod -a -G gpio $USER
+
+# Logout và login lại để apply
+exit
+```
+
+---
+
+## 🚀 **TRIỂN KHAI LÊN THIẾT BỊ**
+
+### **Bước 1: Copy Executable**
+
+```bash
+# Copy từ build machine sang Orange Pi
+scp build/oht50_main oht50@orangepi5b:/home/oht50/
+
+# Hoặc nếu build trực tiếp trên Orange Pi
+sudo cp build/oht50_main /usr/local/bin/
+sudo chmod +x /usr/local/bin/oht50_main
+```
+
+### **Bước 2: Tạo Configuration Directory**
+
+```bash
+# Tạo config directory
+sudo mkdir -p /etc/oht50
+sudo chown oht50:oht50 /etc/oht50
+
+# Copy config files
+sudo cp config/modules.yaml /etc/oht50/
+sudo cp config/safety_config.yaml /etc/oht50/
+```
+
+### **Bước 3: Tạo Systemd Service (Tùy chọn)**
+
+```bash
+# Tạo service file
+sudo nano /etc/systemd/system/oht50.service
+```
+
+**Nội dung file:**
+
+```ini
+[Unit]
+Description=OHT-50 Master Module Firmware
+After=network.target
+
+[Service]
+Type=simple
+User=oht50
+Group=oht50
+WorkingDirectory=/home/oht50
+ExecStart=/usr/local/bin/oht50_main
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+# Enable và start service
+sudo systemctl daemon-reload
+sudo systemctl enable oht50.service
+sudo systemctl start oht50.service
+
+# Check status
+sudo systemctl status oht50.service
+```
+
+---
+
+## ✅ **XÁC MINH CÀI ĐẶT**
+
+### **Bước 1: Test Run**
+
+```bash
+# Chạy firmware (dry-run mode)
+./oht50_main --dry-run
+
+# Chạy firmware với debug
+./oht50_main --debug
+
+# Chạy firmware bình thường
+./oht50_main
+```
+
+### **Bước 2: Kiểm Tra Hardware**
+
+```bash
+# Kiểm tra UART1
+ls -l /dev/ttyOHT485
+
+# Kiểm tra GPIO
+gpioinfo | grep -i "gpio1"
+
+# Kiểm tra network
+ip addr show
+
+# Kiểm tra LiDAR (nếu có)
+ls -l /dev/ttyUSB0
+```
+
+### **Bước 3: Test API**
+
+```bash
+# Test HTTP API (port 8080)
+curl http://localhost:8080/api/v1/robot/status
+
+# Test module discovery
+curl http://localhost:8080/api/v1/modules
+
+# Test telemetry
+curl http://localhost:8080/api/v1/telemetry/current
+```
+
+### **Bước 4: Kiểm Tra Logs**
+
+```bash
+# Real-time logs
+journalctl -u oht50.service -f
+
+# Recent logs
+journalctl -u oht50.service -n 100
+
+# Errors only
+journalctl -u oht50.service -p err
+```
+
+---
+
+## 🔥 **TROUBLESHOOTING**
+
+### **Vấn Đề 1: Build Failed - Missing Dependencies**
+
+**Triệu chứng:**
+```
+CMake Error: Could not find OpenSSL
+```
+
+**Giải pháp:**
+```bash
+# Cài đặt lại OpenSSL
+sudo apt install -y libssl-dev libcrypto++-dev
+rm -rf build && mkdir build && cd build
+cmake ..
+```
+
+---
+
+### **Vấn Đề 2: /dev/ttyOHT485 Not Found**
+
+**Triệu chứng:**
+```
+[OHT-50] hal_rs485_init failed: Device not found
+```
+
+**Giải pháp:**
+```bash
+# Kiểm tra UART1
+ls -l /dev/ttyS1
+
+# Nếu không có, check device tree
+dmesg | grep ttyS1
+
+# Tạo lại udev rule
+sudo nano /etc/udev/rules.d/99-oht-rs485.rules
+# Thêm: KERNEL=="ttyS1", SYMLINK+="ttyOHT485", MODE="0666"
+sudo udevadm control --reload-rules
+sudo reboot
+```
+
+---
+
+### **Vấn Đề 3: Permission Denied khi chạy**
+
+**Triệu chứng:**
+```
+Error: Permission denied opening /dev/ttyOHT485
+```
+
+**Giải pháp:**
+```bash
+# Thêm user vào dialout group
+sudo usermod -a -G dialout $USER
+
+# Hoặc chạy với sudo (không khuyến nghị)
+sudo ./oht50_main
+```
+
+---
+
+### **Vấn Đề 4: Port 8080 Already in Use**
+
+**Triệu chứng:**
+```
+[OHT-50] API Manager init failed: Address already in use
+```
+
+**Giải pháp:**
+```bash
+# Tìm process đang dùng port 8080
+sudo lsof -i :8080
+
+# Kill process
+sudo kill -9 <PID>
+
+# Hoặc dùng auto cleanup (firmware tự động làm)
+./oht50_main  # Auto cleanup enabled
+```
+
+---
+
+## 📚 **TÀI LIỆU THAM KHẢO**
+
+- [BUILD_GUIDE.md](BUILD_GUIDE.md) - Hướng dẫn build chi tiết
+- [USAGE.md](USAGE.md) - Hướng dẫn sử dụng
+- [DEVELOPMENT.md](DEVELOPMENT.md) - Hướng dẫn phát triển
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Khắc phục sự cố
+- [API_REFERENCE.md](API_REFERENCE.md) - Tài liệu API
+
+---
+
+## 🆘 **HỖ TRỢ**
+
+Nếu gặp vấn đề khi cài đặt:
+
+1. 📖 Đọc [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
+2. 🐛 Tạo issue trên GitHub
+3. 📧 Email: support@oht50.com
+4. 💬 Slack channel: #oht50-support
+
+---
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07  
+**Maintained By:** OHT-50 Firmware Team
+

--- a/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-002_Usage_Guide.md
+++ b/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-002_Usage_Guide.md
@@ -1,0 +1,543 @@
+# 📖 Hướng Dẫn Sử Dụng OHT-50 Firmware
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07  
+**Platform:** Orange Pi 5B (RK3588)
+
+---
+
+## 📋 **MỤC LỤC**
+
+1. [Khởi Động Firmware](#khởi-động-firmware)
+2. [Chế Độ Chạy](#chế-độ-chạy)
+3. [Cấu Hình Hệ Thống](#cấu-hình-hệ-thống)
+4. [Sử Dụng API](#sử-dụng-api)
+5. [Quản Lý Module](#quản-lý-module)
+6. [Giám Sát Hệ Thống](#giám-sát-hệ-thống)
+7. [Emergency Stop](#emergency-stop)
+8. [Xử Lý Lỗi](#xử-lý-lỗi)
+
+---
+
+## 🚀 **KHỞI ĐỘNG FIRMWARE**
+
+### **1. Khởi động cơ bản**
+
+```bash
+# Chạy firmware
+./oht50_main
+
+# Output mẫu:
+[OHT-50] 🧹 Starting auto cleanup system...
+[CLEANUP] ✅ Process cleanup completed
+[CLEANUP] ✅ Ports 8080 and 8081 are now free
+[OHT-50] Starting main application...
+[OHT-50] System starting in BOOT state...
+[OHT-50] BOOT -> INIT transition
+[OHT-50] INIT -> IDLE transition
+[OHT-50] Boot sequence completed, system ready in < 20ms
+[OHT-50] ✅ Communication manager started successfully (HTTP API)
+[OHT-50] ✅ API Manager started on port 8080 (HTTP)
+[OHT-50] Entering main loop. Press Ctrl+C to exit.
+```
+
+### **2. Khởi động với options**
+
+```bash
+# Dry-run mode (không chạm hardware)
+./oht50_main --dry-run
+
+# Debug mode (verbose logging)
+./oht50_main --debug
+
+# Cả hai
+./oht50_main --dry-run --debug
+
+# Help
+./oht50_main --help
+```
+
+### **3. Khởi động như service**
+
+```bash
+# Start service
+sudo systemctl start oht50.service
+
+# Stop service
+sudo systemctl stop oht50.service
+
+# Restart service
+sudo systemctl restart oht50.service
+
+# Check status
+sudo systemctl status oht50.service
+
+# View logs
+journalctl -u oht50.service -f
+```
+
+---
+
+## 🎛️ **CHẾ ĐỘ CHẠY**
+
+### **Máy Trạng Thái Hệ Thống**
+
+Firmware hoạt động theo máy trạng thái với các trạng thái sau:
+
+```
+┌─────────┐     ┌──────┐     ┌──────┐     ┌───────┐     ┌─────────┐
+│  BOOT   │────▶│ INIT │────▶│ IDLE │────▶│ READY │────▶│ RUNNING │
+└─────────┘     └──────┘     └──────┘     └───────┘     └─────────┘
+                                                                │
+                                                                ▼
+┌──────────┐    ┌───────┐                              ┌───────────┐
+│ SHUTDOWN │◀───│ FAULT │◀─────────────────────────────│  E-STOP   │
+└──────────┘    └───────┘                              └───────────┘
+```
+
+| **Trạng thái** | **Mô tả** | **LED System** | **Có thể điều khiển?** |
+|----------------|-----------|----------------|------------------------|
+| 🔵 **BOOT** | Khởi động hệ thống | Blink fast | ❌ Không |
+| 🟡 **INIT** | Khởi tạo hardware | Blink slow | ❌ Không |
+| 🟢 **IDLE** | Chờ lệnh | ON solid | ⚠️ Một phần |
+| 🟢 **READY** | Sẵn sàng hoạt động | ON solid | ✅ Có |
+| 🟢 **RUNNING** | Đang hoạt động | Blink slow | ✅ Có |
+| 🔴 **FAULT** | Lỗi hệ thống | Blink fast | ❌ Không |
+| 🔴 **E-STOP** | Emergency stop | OFF | ❌ Không |
+| ⚫ **SHUTDOWN** | Đang tắt | OFF | ❌ Không |
+
+### **Chuyển trạng thái thủ công**
+
+```bash
+# Thông qua API
+curl -X POST http://localhost:8080/api/v1/robot/command \
+     -H "Content-Type: application/json" \
+     -d '{"command": "set_state", "state": "IDLE"}'
+```
+
+---
+
+## ⚙️ **CẤU HÌNH HỆ THỐNG**
+
+### **1. Cấu hình Module Registry**
+
+File: `/etc/oht50/modules.yaml`
+
+```yaml
+# Module Registry Configuration
+modules:
+  - address: 0x02
+    type: POWER
+    name: "Power Module"
+    enabled: true
+    polling_interval_ms: 1000
+    timeout_ms: 500
+
+  - address: 0x03
+    type: SAFETY
+    name: "Safety Module"
+    enabled: true
+    polling_interval_ms: 500
+    timeout_ms: 200
+
+  - address: 0x04
+    type: TRAVEL_MOTOR
+    name: "Travel Motor Module"
+    enabled: true
+    polling_interval_ms: 100
+    timeout_ms: 200
+
+  - address: 0x05
+    type: DOCK
+    name: "Dock Module"
+    enabled: true
+    polling_interval_ms: 1000
+    timeout_ms: 500
+```
+
+### **2. Cấu hình Safety**
+
+File: `/etc/oht50/safety_config.yaml`
+
+```yaml
+# Safety Configuration
+safety:
+  estop_pin: 27
+  response_time_ms: 100
+  debounce_time_ms: 10
+  safety_check_interval_ms: 50
+  fault_clear_timeout_ms: 5000
+  
+  # Safety zones (LiDAR)
+  zones:
+    emergency_stop_mm: 500
+    warning_mm: 1000
+    safe_mm: 2000
+```
+
+### **3. Áp dụng cấu hình**
+
+```bash
+# Reload configuration
+curl -X POST http://localhost:8080/api/v1/config/reload
+
+# Hoặc restart service
+sudo systemctl restart oht50.service
+```
+
+---
+
+## 🌐 **SỬ DỤNG API**
+
+### **1. Robot Status**
+
+```bash
+# Lấy trạng thái robot
+curl http://localhost:8080/api/v1/robot/status
+
+# Response:
+{
+  "success": true,
+  "data": {
+    "state": "IDLE",
+    "system_ready": true,
+    "safety_ok": true,
+    "communication_ok": true,
+    "modules_online": 4,
+    "uptime_seconds": 3600
+  }
+}
+```
+
+### **2. Robot Control**
+
+```bash
+# Gửi lệnh di chuyển
+curl -X POST http://localhost:8080/api/v1/robot/command \
+     -H "Content-Type: application/json" \
+     -d '{
+       "command": "move",
+       "parameters": {
+         "velocity": 1000,
+         "acceleration": 500,
+         "position": 5000
+       }
+     }'
+
+# Dừng robot
+curl -X POST http://localhost:8080/api/v1/robot/command \
+     -H "Content-Type: application/json" \
+     -d '{"command": "stop"}'
+
+# Emergency stop
+curl -X POST http://localhost:8080/api/v1/safety/emergency
+```
+
+### **3. Module Management**
+
+```bash
+# Danh sách modules
+curl http://localhost:8080/api/v1/modules
+
+# Chi tiết module
+curl http://localhost:8080/api/v1/modules/0x02
+
+# Scan modules mới
+curl -X POST http://localhost:8080/api/v1/modules/discover
+```
+
+### **4. Telemetry**
+
+```bash
+# Telemetry hiện tại
+curl http://localhost:8080/api/v1/telemetry/current
+
+# Response:
+{
+  "timestamp": 1696680000,
+  "robot": {
+    "position": 2500,
+    "velocity": 1000,
+    "battery_level": 87,
+    "temperature": 42.5
+  },
+  "modules": {
+    "0x02": {"voltage": 48.5, "current": 2.3},
+    "0x03": {"safety_status": "NORMAL"},
+    "0x04": {"motor_speed": 1500, "torque": 5.2},
+    "0x05": {"dock_status": "READY"}
+  }
+}
+```
+
+---
+
+## 📦 **QUẢN LÝ MODULE**
+
+### **1. Auto-Discovery**
+
+Firmware tự động tìm kiếm slave modules khi khởi động:
+
+```
+[OHT-50] Starting module discovery in background...
+[OHT-50] Initial module discovery completed
+[OHT-50] Adding discovered modules to polling manager...
+[OHT-50] All discovered modules added to polling manager
+```
+
+Modules được phát hiện:
+- **0x02**: Power Module
+- **0x03**: Safety Module
+- **0x04**: Travel Motor Module
+- **0x05**: Dock Module
+
+### **2. Module Polling**
+
+Firmware tự động poll các modules theo interval:
+
+| **Module** | **Interval** | **Purpose** |
+|------------|--------------|-------------|
+| Power (0x02) | 1000ms | Battery, voltage, current |
+| Safety (0x03) | 500ms | Safety status, faults |
+| Motor (0x04) | 100ms | Position, velocity, torque |
+| Dock (0x05) | 1000ms | Dock status, alignment |
+
+### **3. Module Health Check**
+
+```bash
+# Kiểm tra health của tất cả modules
+curl http://localhost:8080/api/v1/modules/health
+
+# Response:
+{
+  "modules": [
+    {
+      "address": "0x02",
+      "status": "ONLINE",
+      "last_seen_ms": 100,
+      "response_time_ms": 15,
+      "error_count": 0
+    },
+    {
+      "address": "0x03",
+      "status": "ONLINE",
+      "last_seen_ms": 50,
+      "response_time_ms": 12,
+      "error_count": 0
+    }
+  ]
+}
+```
+
+---
+
+## 📊 **GIÁM SÁT HỆ THỐNG**
+
+### **1. System Telemetry**
+
+Firmware broadcast telemetry mỗi 1 giây:
+
+```bash
+# View real-time telemetry
+curl http://localhost:8080/api/v1/telemetry/stream
+
+# Hoặc xem logs
+journalctl -u oht50.service -f | grep TELEMETRY
+```
+
+### **2. LED Status Indicators**
+
+| **LED** | **Trạng thái** | **Ý nghĩa** |
+|---------|---------------|-------------|
+| 🔴 **Power** | ON | Hệ thống có nguồn |
+| 🟢 **System** | Blink 500ms | Heartbeat (hệ thống hoạt động) |
+| 🔵 **Comm** | ON | Tất cả 4 modules online |
+| 🔵 **Comm** | Blink fast | Một số modules missing |
+| 🔵 **Comm** | OFF | Không có modules online |
+| 🟡 **Network** | ON | Network connected |
+| 🔴 **Error** | ON | Có lỗi hệ thống |
+
+### **3. Performance Monitoring**
+
+Firmware có performance monitoring tích hợp:
+
+```
+[PERF] Loops: 1000, Avg: 8.5 μs, Max: 25000 μs, Slow: 2 (0.2%)
+```
+
+Thông tin:
+- **Loops**: Số vòng lặp đã chạy
+- **Avg**: Thời gian trung bình mỗi vòng lặp
+- **Max**: Thời gian max
+- **Slow**: Số vòng lặp chậm (>20ms)
+
+---
+
+## 🛑 **EMERGENCY STOP**
+
+### **1. Hardware E-Stop**
+
+Nhấn nút **E-Stop** trên thiết bị:
+- ✅ Hệ thống chuyển sang trạng thái **E-STOP** ngay lập tức
+- ✅ Tất cả motor dừng
+- ✅ Relay tắt
+- ✅ LED Error ON
+
+### **2. Software E-Stop**
+
+```bash
+# Gửi E-Stop qua API
+curl -X POST http://localhost:8080/api/v1/safety/emergency
+
+# Response time: < 100ms
+```
+
+### **3. Recovery từ E-Stop**
+
+```bash
+# 1. Kiểm tra nguyên nhân
+curl http://localhost:8080/api/v1/safety/status
+
+# 2. Clear faults
+curl -X POST http://localhost:8080/api/v1/safety/clear_faults
+
+# 3. Reset E-Stop (nếu safe)
+curl -X POST http://localhost:8080/api/v1/safety/reset_estop
+
+# 4. Quay về IDLE
+curl -X POST http://localhost:8080/api/v1/robot/command \
+     -d '{"command": "set_state", "state": "IDLE"}'
+```
+
+---
+
+## ⚠️ **XỬ LÝ LỖI**
+
+### **Lỗi 1: Module Offline**
+
+**Hiện tượng:**
+- COMM LED blink fast
+- Log: `WARNING: Only X/4 mandatory slave modules online`
+
+**Xử lý:**
+```bash
+# 1. Kiểm tra modules
+curl http://localhost:8080/api/v1/modules
+
+# 2. Scan lại
+curl -X POST http://localhost:8080/api/v1/modules/discover
+
+# 3. Kiểm tra RS485 connection
+# - Check cáp RS485
+# - Check termination resistor
+# - Check power supply
+```
+
+---
+
+### **Lỗi 2: RS485 Communication Error**
+
+**Hiện tượng:**
+- Log: `[RS485] CRC error count: XX`
+- Log: `[RS485] Timeout count: XX`
+
+**Xử lý:**
+```bash
+# 1. Check RS485 stats
+curl http://localhost:8080/api/v1/communication/stats
+
+# 2. Test loopback
+cd scripts/rs485
+./rs485_loop_tester.py
+
+# 3. Check hardware
+# - Termination resistor 120Ω
+# - Bias resistors
+# - Cable quality
+```
+
+---
+
+### **Lỗi 3: LiDAR Not Responding**
+
+**Hiện tượng:**
+- Log: `[OHT-50] hal_lidar_init failed`
+
+**Xử lý:**
+```bash
+# 1. Check LiDAR device
+ls -l /dev/ttyUSB0
+
+# 2. Check permissions
+sudo chmod 666 /dev/ttyUSB0
+
+# 3. Test LiDAR
+cd scripts/lidar
+./lidar_test.sh
+```
+
+---
+
+## 📚 **TÀI LIỆU THAM KHẢO**
+
+- [API_REFERENCE.md](API_REFERENCE.md) - API documentation đầy đủ
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Khắc phục sự cố chi tiết
+- [DEVELOPMENT.md](DEVELOPMENT.md) - Hướng dẫn phát triển
+- [SECURITY.md](SECURITY.md) - Chính sách bảo mật
+
+---
+
+## 💡 **TIPS & TRICKS**
+
+### **1. Performance Tuning**
+
+```bash
+# Giảm CPU usage bằng cách tăng sleep time
+# Edit constants.h:
+#define MIN_LOOP_INTERVAL_MS 10  # Tăng từ 5 lên 10
+
+# Giảm telemetry frequency
+# Thay đổi từ 1s → 2s trong main.c
+```
+
+### **2. Debug Mode**
+
+```bash
+# Chạy với debug để xem chi tiết
+./oht50_main --debug
+
+# Lọc debug logs
+./oht50_main --debug 2>&1 | grep "DEBUG"
+
+# Performance logs
+./oht50_main --debug 2>&1 | grep "PERF"
+```
+
+### **3. Quick Commands**
+
+```bash
+# Alias hữu ích
+alias oht-start='sudo systemctl start oht50'
+alias oht-stop='sudo systemctl stop oht50'
+alias oht-status='sudo systemctl status oht50'
+alias oht-logs='journalctl -u oht50 -f'
+alias oht-api='curl http://localhost:8080/api/v1'
+```
+
+---
+
+## 🆘 **HỖ TRỢ**
+
+Nếu cần hỗ trợ:
+
+1. 📖 Đọc [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
+2. 🐛 Tạo issue trên GitHub với logs
+3. 📧 Email: support@oht50.com
+4. 💬 Slack: #oht50-support
+
+---
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07  
+**Maintained By:** OHT-50 Firmware Team
+

--- a/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-003_Development_Guide.md
+++ b/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-003_Development_Guide.md
@@ -1,0 +1,193 @@
+# 🛠️ Hướng Dẫn Phát Triển - OHT-50 Firmware
+
+**Version:** 1.0.1  
+**Last Updated:** 2025-10-07
+
+---
+
+## 📋 **MỤC LỤC**
+
+1. [Development Environment](#development-environment)
+2. [Architecture Overview](#architecture-overview)
+3. [Development Workflow](#development-workflow)
+4. [Debugging](#debugging)
+5. [Testing Strategy](#testing-strategy)
+6. [Performance Profiling](#performance-profiling)
+7. [Best Practices](#best-practices)
+
+---
+
+## 💻 **DEVELOPMENT ENVIRONMENT**
+
+### **1. IDE Setup**
+
+#### **VS Code (Khuyến nghị)**
+
+```bash
+# Install VS Code
+# Extensions cần thiết:
+code --install-extension ms-vscode.cpptools
+code --install-extension ms-vscode.cmake-tools
+code --install-extension llvm-vs-code-extensions.vscode-clangd
+code --install-extension twxs.cmake
+code --install-extension ms-vscode.makefile-tools
+```
+
+**.vscode/settings.json:**
+
+```json
+{
+  "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+  "cmake.configureOnOpen": true,
+  "clang-format.executable": "/usr/bin/clang-format",
+  "clang-format.style": "file",
+  "editor.formatOnSave": true,
+  "files.associations": {
+    "*.h": "c",
+    "*.c": "c"
+  }
+}
+```
+
+---
+
+## 🏗️ **ARCHITECTURE OVERVIEW**
+
+### **Layer Architecture**
+
+```
+Application (Orchestration)
+     ↓
+Domain (Business Logic)
+     ↓
+Infrastructure (Technical Services)
+     ↓
+Core (Business Core - Independent)
+     ↓
+HAL (Hardware Abstraction)
+```
+
+**Dependency Rules:**
+- ✅ Lower layers CAN'T depend on upper layers
+- ✅ Upper layers CAN depend on lower layers
+- ✅ Same layer: minimize coupling
+
+---
+
+## 🔄 **DEVELOPMENT WORKFLOW**
+
+### **1. Feature Development**
+
+```bash
+# 1. Create feature branch
+git checkout -b feature/my-feature
+
+# 2. Implement feature
+# Edit files...
+
+# 3. Build và test
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+make -j$(nproc)
+make test
+
+# 4. Commit và push
+git add .
+git commit -m "feat: add my feature"
+git push origin feature/my-feature
+
+# 5. Create Pull Request
+```
+
+---
+
+## 🐛 **DEBUGGING**
+
+### **GDB Debugging**
+
+```bash
+# Build với debug symbols
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+make
+
+# Run với GDB
+gdb ./oht50_main
+
+# GDB commands:
+(gdb) break main
+(gdb) run --debug
+(gdb) next
+(gdb) print variable
+(gdb) backtrace
+```
+
+### **Valgrind (Memory Leaks)**
+
+```bash
+# Check memory leaks
+valgrind --leak-check=full \
+         --show-leak-kinds=all \
+         ./oht50_main --dry-run
+```
+
+---
+
+## 🧪 **TESTING STRATEGY**
+
+### **Unit Tests**
+
+```bash
+# Run all tests
+make test
+
+# Run specific test
+./tests/unit/test_hal_rs485
+
+# With verbose
+ctest -V
+```
+
+### **Integration Tests**
+
+```bash
+cd tests/integration
+./test_module_discovery.sh
+```
+
+---
+
+## ⚡ **PERFORMANCE PROFILING**
+
+### **Using perf**
+
+```bash
+# Profile CPU
+perf record -g ./oht50_main
+perf report
+
+# Analyze hotspots
+perf top
+```
+
+---
+
+## ✅ **BEST PRACTICES**
+
+### **Code Quality**
+
+```bash
+# Format code
+clang-format -i src/**/*.c
+
+# Static analysis
+clang-tidy src/**/*.c -- -I include/
+
+# Build warnings
+cmake -DCMAKE_C_FLAGS="-Wall -Wextra -Werror" ..
+```
+
+---
+
+**Version:** 1.0.1  
+**Maintained By:** OHT-50 Dev Team
+

--- a/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-005_LiDAR_Debug_Guide.md
+++ b/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-005_LiDAR_Debug_Guide.md
@@ -1,0 +1,94 @@
+# LiDAR Debug Guide
+
+## Tổng quan
+Hệ thống LiDAR có debug system linh hoạt để hỗ trợ development và troubleshooting mà không làm spam log trong production.
+
+## Debug Configuration
+
+### 1. Enable Debug Mode
+Để bật debug mode, uncomment dòng sau trong `hal_lidar.h`:
+```c
+#define DEBUG_LIDAR_SAFETY
+```
+
+### 2. Debug Messages
+
+#### Normal Mode (Production)
+- **Safety Alerts:** Chỉ hiển thị khi có vấn đề an toàn
+```
+[SAFETY] Emergency distance detected: 450 mm (threshold: 500 mm)
+```
+
+#### Debug Mode (Development)
+- **Input Inspection:** Kiểm tra dữ liệu đầu vào
+```
+DEBUG: calc_min - point_count=360, scan_complete=1
+DEBUG: calc_min - first distances: 1200 1150 1100 1050 1000
+DEBUG: calc_min - result=1000
+```
+
+## Safety Thresholds
+
+| Threshold | Distance | Purpose |
+|-----------|----------|---------|
+| `LIDAR_EMERGENCY_STOP_MM` | 500mm | Emergency stop trigger |
+| `LIDAR_WARNING_MM` | 1000mm | Warning alert |
+| `LIDAR_SAFE_MM` | 2000mm | Safe zone boundary |
+
+## Debug Scenarios
+
+### 1. LiDAR Not Scanning
+```
+DEBUG: calc_min - point_count=0, scan_complete=0
+```
+**Nguyên nhân:** LiDAR chưa khởi động hoặc lỗi kết nối
+
+### 2. Invalid Distance Data
+```
+DEBUG: calc_min - first distances: 0 0 0 0 0
+```
+**Nguyên nhân:** LiDAR không nhận được tín hiệu phản hồi
+
+### 3. Emergency Stop Triggered
+```
+[SAFETY] Emergency distance detected: 300 mm (threshold: 500 mm)
+```
+**Nguyên nhân:** Vật cản quá gần, cần dừng khẩn cấp
+
+## Performance Impact
+
+### Normal Mode
+- ✅ Không có performance impact
+- ✅ Chỉ log khi cần thiết
+- ✅ Phù hợp cho production
+
+### Debug Mode
+- ⚠️ Có thể làm chậm hệ thống
+- ⚠️ Spam log liên tục
+- ⚠️ Chỉ dùng cho development
+
+## Best Practices
+
+1. **Development:** Bật `DEBUG_LIDAR_SAFETY` để debug
+2. **Testing:** Tắt debug để test performance
+3. **Production:** Luôn tắt debug mode
+4. **Troubleshooting:** Bật debug khi có vấn đề
+
+## Example Usage
+
+```c
+// Development
+#ifdef DEBUG_LIDAR_SAFETY
+    printf("DEBUG: LiDAR scan data received\n");
+#endif
+
+// Production - chỉ log khi có vấn đề
+if (min_distance < LIDAR_EMERGENCY_STOP_MM) {
+    printf("[SAFETY] Emergency stop triggered: %u mm\n", min_distance);
+}
+```
+
+## Changelog
+- v1.0: Initial debug system implementation
+- v1.1: Added conditional compilation for performance
+- v1.2: Added safety alert system

--- a/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-006_Network_Deployment.md
+++ b/firmware_new/docs/04-WORK_INSTRUCTIONS/WI-006_Network_Deployment.md
@@ -1,0 +1,601 @@
+# 🏭 OHT-50 Network Management - Plant Implementation Guide
+
+**Version:** 1.0.0  
+**Date:** 2025-01-28  
+**Team:** Plant Engineering & Network Integration  
+**Status:** 📋 Implementation Planning  
+**Priority:** 🔴 High - Critical for Plant Operations
+
+---
+
+## 🎯 **OVERVIEW**
+
+This document provides comprehensive guidance for implementing OHT-50 Network Management system in industrial plant environments. It covers network infrastructure requirements, deployment procedures, configuration management, and operational procedures.
+
+---
+
+## 🏭 **PLANT NETWORK ARCHITECTURE**
+
+### **Industrial Network Topology:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    PLANT NETWORK INFRASTRUCTURE                │
+│                                                                 │
+│  ┌─────────────────┐    ┌─────────────────┐                   │
+│  │   Production    │    │   Management    │                   │
+│  │   Network       │    │   Network       │                   │
+│  │   (VLAN 100)    │    │   (VLAN 200)    │                   │
+│  │                 │    │                 │                   │
+│  │ • OHT-50 Units  │    │ • SCADA System  │                   │
+│  │ • PLCs          │    │ • HMI Stations  │                   │
+│  │ • Sensors       │    │ • Database      │                   │
+│  │ • Actuators     │    │ • Historian     │                   │
+│  └─────────────────┘    └─────────────────┘                   │
+│           │                       │                           │
+│           └───────────┬───────────┘                           │
+│                       │                                       │
+│  ┌─────────────────┐  │  ┌─────────────────┐                 │
+│  │   Safety        │  │  │   Mobile        │                 │
+│  │   Network       │  │  │   Network       │                 │
+│  │   (VLAN 300)    │  │  │   (VLAN 400)    │                 │
+│  │                 │  │  │                 │                 │
+│  │ • E-Stop        │  │  │ • Tablets       │                 │
+│  │ • Safety PLCs   │  │  │ • Smartphones   │                 │
+│  │ • Emergency     │  │  │ • Maintenance   │                 │
+│  │   Systems       │  │  │   Tools         │                 │
+│  └─────────────────┘  │  └─────────────────┘                 │
+│                       │                                       │
+│  ┌─────────────────┐  │  ┌─────────────────┐                 │
+│  │   Corporate     │  │  │   Internet      │                 │
+│  │   Network       │  │  │   Gateway       │                 │
+│  │   (VLAN 500)    │  │  │   (DMZ)         │                 │
+│  │                 │  │  │                 │                 │
+│  │ • ERP System    │  │  │ • Remote Access │                 │
+│  │ • MES System    │  │  │ • Cloud Services│                 │
+│  │ • IT Services   │  │  │ • Updates       │                 │
+│  └─────────────────┘  │  └─────────────────┘                 │
+│                       │                                       │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │              CORE SWITCHING INFRASTRUCTURE              │  │
+│  │  ┌─────────────────┐  ┌─────────────────┐              │  │
+│  │  │   Core Switch   │  │   Distribution  │              │  │
+│  │  │   (Layer 3)     │  │   Switches      │              │  │
+│  │  │                 │  │   (Layer 2)     │              │  │
+│  │  │ • VLAN Routing  │  │ • Access Ports  │              │  │
+│  │  │ • Inter-VLAN    │  │ • Port Security │              │  │
+│  │  │   Communication │  │ • PoE Support   │              │  │
+│  │  │ • QoS Policies  │  │ • Link Aggregation│            │  │
+│  │  └─────────────────┘  └─────────────────┘              │  │
+│  └─────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### **OHT-50 Network Integration:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    OHT-50 NETWORK INTEGRATION                  │
+│                                                                 │
+│  ┌─────────────────┐    ┌─────────────────┐                   │
+│  │   OHT-50 Unit   │    │   Network       │                   │
+│  │   (Production)  │    │   Infrastructure│                   │
+│  │                 │    │                 │                   │
+│  │ ┌─────────────┐ │    │ ┌─────────────┐ │                   │
+│  │ │   Ethernet  │ │◄──►│ │   Production│ │                   │
+│  │ │   Port      │ │    │ │   Switch    │ │                   │
+│  │ │   (Primary) │ │    │ │   Port      │ │                   │
+│  │ └─────────────┘ │    │ └─────────────┘ │                   │
+│  │                 │    │                 │                   │
+│  │ ┌─────────────┐ │    │ ┌─────────────┐ │                   │
+│  │ │   WiFi      │ │◄──►│ │   WiFi      │ │                   │
+│  │ │   Antenna   │ │    │ │   Access    │ │                   │
+│  │ │   (Backup)  │ │    │ │   Point     │ │                   │
+│  │ └─────────────┘ │    │ └─────────────┘ │                   │
+│  │                 │    │                 │                   │
+│  │ ┌─────────────┐ │    │ ┌─────────────┐ │                   │
+│  │ │   Mobile    │ │◄──►│ │   Mobile    │ │                   │
+│  │ │   WiFi      │ │    │ │   Network   │ │                   │
+│  │ │   (Mobile)  │ │    │ │   (VLAN 400)│ │                   │
+│  │ └─────────────┘ │    │ └─────────────┘ │                   │
+│  └─────────────────┘    └─────────────────┘                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 🔧 **HARDWARE REQUIREMENTS**
+
+### **Network Infrastructure:**
+- **Core Switch:** Layer 3 managed switch with VLAN support
+- **Distribution Switches:** Layer 2 managed switches with PoE
+- **WiFi Access Points:** Industrial-grade 802.11ac access points
+- **Network Cables:** Cat6/Cat6a Ethernet cables
+- **Fiber Optic:** Single-mode fiber for backbone connections
+- **UPS Systems:** Uninterruptible power supply for network equipment
+
+### **OHT-50 Network Components:**
+- **Ethernet Port:** Gigabit Ethernet (RJ45)
+- **WiFi Module:** 802.11ac dual-band (2.4GHz + 5GHz)
+- **Antenna:** External WiFi antenna with IP65 rating
+- **Network LEDs:** Status indicators for network connectivity
+- **Power Management:** Network interface power control
+
+### **Environmental Considerations:**
+- **Temperature:** -20°C to +60°C operating range
+- **Humidity:** 5% to 95% non-condensing
+- **EMI/EMC:** Industrial electromagnetic compatibility
+- **Vibration:** IEC 60068-2-6 vibration resistance
+- **Shock:** IEC 60068-2-27 shock resistance
+
+---
+
+## 📋 **DEPLOYMENT PROCEDURES**
+
+### **Phase 1: Network Infrastructure Setup**
+
+#### **1.1 Core Network Configuration:**
+```bash
+# Core switch configuration
+configure terminal
+vlan 100
+  name PRODUCTION
+  exit
+vlan 200
+  name MANAGEMENT
+  exit
+vlan 300
+  name SAFETY
+  exit
+vlan 400
+  name MOBILE
+  exit
+
+# Inter-VLAN routing
+interface vlan 100
+  ip address 192.168.100.1 255.255.255.0
+  exit
+interface vlan 200
+  ip address 192.168.200.1 255.255.255.0
+  exit
+interface vlan 300
+  ip address 192.168.300.1 255.255.255.0
+  exit
+interface vlan 400
+  ip address 192.168.400.1 255.255.255.0
+  exit
+
+# QoS policies
+class-map match-any CRITICAL
+  match dscp 46
+  exit
+class-map match-any HIGH
+  match dscp 34
+  exit
+class-map match-any NORMAL
+  match dscp 0
+  exit
+
+policy-map NETWORK-QOS
+  class CRITICAL
+    priority percent 30
+    exit
+  class HIGH
+    bandwidth percent 50
+    exit
+  class NORMAL
+    bandwidth percent 20
+    exit
+  exit
+```
+
+#### **1.2 WiFi Access Point Configuration:**
+```bash
+# Production WiFi network
+interface dot11Radio0
+  ssid PRODUCTION-WIFI
+  authentication open
+  wpa-psk ascii production-wifi-password
+  channel 6
+  power local 20
+  exit
+
+# Mobile WiFi network
+interface dot11Radio1
+  ssid MOBILE-WIFI
+  authentication open
+  wpa-psk ascii mobile-wifi-password
+  channel 11
+  power local 15
+  exit
+
+# VLAN assignment
+interface dot11Radio0
+  encapsulation dot1Q 100
+  exit
+interface dot11Radio1
+  encapsulation dot1Q 400
+  exit
+```
+
+### **Phase 2: OHT-50 Network Configuration**
+
+#### **2.1 Ethernet Configuration:**
+```bash
+# OHT-50 Ethernet setup
+# File: /etc/network/interfaces
+auto eth0
+iface eth0 inet dhcp
+    # Primary connection to production network
+    # VLAN 100 (Production)
+    # IP range: 192.168.100.10-192.168.100.50
+```
+
+#### **2.2 WiFi Configuration:**
+```bash
+# OHT-50 WiFi setup
+# File: /etc/wpa_supplicant/wpa_supplicant.conf
+network={
+    ssid="PRODUCTION-WIFI"
+    psk="production-wifi-password"
+    priority=1
+    key_mgmt=WPA-PSK
+}
+
+network={
+    ssid="MOBILE-WIFI"
+    psk="mobile-wifi-password"
+    priority=2
+    key_mgmt=WPA-PSK
+}
+```
+
+#### **2.3 Network Manager Configuration:**
+```json
+{
+  "ethernet": {
+    "enabled": true,
+    "dhcp_enabled": true,
+    "static_ip": "192.168.100.10",
+    "gateway": "192.168.100.1",
+    "dns": "192.168.200.10",
+    "netmask": "255.255.255.0"
+  },
+  "wifi": {
+    "enabled": true,
+    "ssid": "PRODUCTION-WIFI",
+    "password": "production-wifi-password",
+    "security_type": "WPA2",
+    "channel": 6,
+    "hidden": false
+  },
+  "policies": {
+    "connection_priority": 1,
+    "auto_failover_enabled": true,
+    "failover_timeout_ms": 5000,
+    "mobile_app_access": true,
+    "mobile_app_port": 8080
+  },
+  "advanced": {
+    "network_monitoring_enabled": true,
+    "monitoring_interval_ms": 1000,
+    "traffic_logging_enabled": true,
+    "max_retry_attempts": 3
+  }
+}
+```
+
+---
+
+## 🔒 **SECURITY IMPLEMENTATION**
+
+### **Network Security Policies:**
+
+#### **3.1 Access Control Lists (ACLs):**
+```bash
+# Production network ACL
+access-list 100 permit ip 192.168.100.0 0.0.0.255 192.168.200.0 0.0.0.255
+access-list 100 permit ip 192.168.100.0 0.0.0.255 192.168.300.0 0.0.0.255
+access-list 100 deny ip any any
+
+# Management network ACL
+access-list 200 permit ip 192.168.200.0 0.0.0.255 any
+access-list 200 deny ip any any
+
+# Safety network ACL
+access-list 300 permit ip 192.168.300.0 0.0.0.255 192.168.100.0 0.0.0.255
+access-list 300 permit ip 192.168.300.0 0.0.0.255 192.168.200.0 0.0.0.255
+access-list 300 deny ip any any
+
+# Mobile network ACL
+access-list 400 permit ip 192.168.400.0 0.0.0.255 192.168.200.0 0.0.0.255
+access-list 400 deny ip any any
+```
+
+#### **3.2 Port Security:**
+```bash
+# Port security configuration
+interface GigabitEthernet0/1
+  switchport mode access
+  switchport access vlan 100
+  switchport port-security
+  switchport port-security maximum 1
+  switchport port-security violation restrict
+  switchport port-security mac-address sticky
+  exit
+```
+
+#### **3.3 WiFi Security:**
+```bash
+# WiFi security configuration
+interface dot11Radio0
+  encryption wpa2 aes
+  wpa-psk ascii strong-production-password
+  wpa-group 2
+  wpa-pairwise 4
+  exit
+```
+
+---
+
+## 📊 **MONITORING & MAINTENANCE**
+
+### **Network Monitoring Setup:**
+
+#### **4.1 SNMP Configuration:**
+```bash
+# SNMP configuration for network monitoring
+snmp-server community public RO
+snmp-server community private RW
+snmp-server location "Plant Network Infrastructure"
+snmp-server contact "Network Administrator"
+snmp-server enable traps
+snmp-server host 192.168.200.10 public
+```
+
+#### **4.2 Network Monitoring Scripts:**
+```bash
+#!/bin/bash
+# Network health monitoring script
+# File: /usr/local/bin/network-monitor.sh
+
+# Check network connectivity
+check_connectivity() {
+    local host=$1
+    local timeout=5
+    
+    if ping -c 1 -W $timeout $host > /dev/null 2>&1; then
+        echo "OK: $host is reachable"
+        return 0
+    else
+        echo "ERROR: $host is not reachable"
+        return 1
+    fi
+}
+
+# Check network interfaces
+check_interfaces() {
+    local interfaces=("eth0" "wlan0")
+    
+    for interface in "${interfaces[@]}"; do
+        if ip link show $interface | grep -q "state UP"; then
+            echo "OK: $interface is up"
+        else
+            echo "ERROR: $interface is down"
+        fi
+    done
+}
+
+# Check network performance
+check_performance() {
+    local target="192.168.100.1"
+    local latency=$(ping -c 5 $target | grep "avg" | cut -d'/' -f5)
+    
+    if (( $(echo "$latency < 10" | bc -l) )); then
+        echo "OK: Network latency is good ($latency ms)"
+    else
+        echo "WARNING: Network latency is high ($latency ms)"
+    fi
+}
+
+# Main monitoring function
+main() {
+    echo "=== Network Health Check ==="
+    echo "Timestamp: $(date)"
+    
+    check_connectivity "192.168.100.1"
+    check_connectivity "192.168.200.1"
+    check_interfaces
+    check_performance
+    
+    echo "=== End of Check ==="
+}
+
+main
+```
+
+#### **4.3 Log Management:**
+```bash
+# Log rotation configuration
+# File: /etc/logrotate.d/network-logs
+/var/log/network/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    delaycompress
+    notifempty
+    create 644 root root
+    postrotate
+        /usr/bin/systemctl reload rsyslog
+    endscript
+}
+```
+
+---
+
+## 🚨 **TROUBLESHOOTING GUIDE**
+
+### **Common Network Issues:**
+
+#### **5.1 Ethernet Connection Issues:**
+```bash
+# Check Ethernet interface status
+ip link show eth0
+
+# Check Ethernet configuration
+ip addr show eth0
+
+# Check Ethernet statistics
+cat /proc/net/dev
+
+# Test Ethernet connectivity
+ping -c 5 192.168.100.1
+
+# Check Ethernet cable
+ethtool eth0
+```
+
+#### **5.2 WiFi Connection Issues:**
+```bash
+# Check WiFi interface status
+ip link show wlan0
+
+# Check WiFi configuration
+iwconfig wlan0
+
+# Scan for available networks
+iwlist wlan0 scan
+
+# Check WiFi connection status
+wpa_cli -i wlan0 status
+
+# Restart WiFi interface
+sudo systemctl restart wpa_supplicant
+```
+
+#### **5.3 Network Performance Issues:**
+```bash
+# Check network throughput
+iperf3 -c 192.168.100.1 -t 30
+
+# Check network latency
+ping -c 100 192.168.100.1
+
+# Check network errors
+cat /proc/net/dev | grep -E "(errors|dropped)"
+
+# Check network buffer usage
+cat /proc/net/sockstat
+```
+
+---
+
+## 📋 **OPERATIONAL PROCEDURES**
+
+### **Daily Operations:**
+
+#### **6.1 Network Health Check:**
+- [ ] Check network connectivity status
+- [ ] Verify network performance metrics
+- [ ] Review network error logs
+- [ ] Check network security status
+- [ ] Verify backup connections
+
+#### **6.2 Network Maintenance:**
+- [ ] Update network firmware
+- [ ] Review network configuration
+- [ ] Check network security policies
+- [ ] Verify network monitoring
+- [ ] Test network failover
+
+### **Weekly Operations:**
+
+#### **6.3 Network Performance Review:**
+- [ ] Analyze network performance trends
+- [ ] Review network capacity utilization
+- [ ] Check network security incidents
+- [ ] Verify network backup procedures
+- [ ] Update network documentation
+
+### **Monthly Operations:**
+
+#### **6.4 Network Security Audit:**
+- [ ] Review network access logs
+- [ ] Check network security policies
+- [ ] Verify network encryption
+- [ ] Test network security measures
+- [ ] Update network security procedures
+
+---
+
+## 📊 **PERFORMANCE BENCHMARKS**
+
+### **Network Performance Targets:**
+- **Ethernet Latency:** < 1ms (local network)
+- **WiFi Latency:** < 5ms (local network)
+- **Network Throughput:** > 100Mbps (sustained)
+- **Connection Time:** < 5 seconds
+- **Failover Time:** < 2 seconds
+- **Uptime:** > 99.9%
+
+### **Network Capacity Planning:**
+- **Ethernet Bandwidth:** 1Gbps per OHT-50 unit
+- **WiFi Bandwidth:** 100Mbps per OHT-50 unit
+- **Network Latency:** < 10ms (end-to-end)
+- **Packet Loss:** < 0.1%
+- **Jitter:** < 2ms
+
+---
+
+## 📝 **IMPLEMENTATION CHECKLIST**
+
+### **Pre-Implementation:**
+- [ ] Network infrastructure assessment
+- [ ] Network security audit
+- [ ] Network capacity planning
+- [ ] Network monitoring setup
+- [ ] Network documentation review
+
+### **Implementation:**
+- [ ] Core network configuration
+- [ ] WiFi access point setup
+- [ ] OHT-50 network configuration
+- [ ] Network security implementation
+- [ ] Network monitoring configuration
+
+### **Post-Implementation:**
+- [ ] Network performance testing
+- [ ] Network security testing
+- [ ] Network failover testing
+- [ ] Network monitoring validation
+- [ ] Network documentation update
+
+---
+
+## 🔗 **RELATED DOCUMENTS**
+
+- **Technical Documentation:** `NETWORK_MANAGEMENT_TECHNICAL.md`
+- **Tracking Plant:** `NETWORK_MANAGEMENT_TRACKING_PLANT.md`
+- **API Documentation:** `API_DOCUMENTATION.md`
+- **Security Guidelines:** `SECURITY_IMPLEMENTATION.md`
+- **Troubleshooting Guide:** `NETWORK_TROUBLESHOOTING.md`
+
+---
+
+## 📝 **CHANGELOG**
+
+### **v1.0.0 (2025-01-28) - Initial Implementation Guide**
+- ✅ Plant network architecture design
+- ✅ Hardware requirements specification
+- ✅ Deployment procedures documentation
+- ✅ Security implementation guidelines
+- ✅ Monitoring and maintenance procedures
+- ✅ Troubleshooting guide
+- ✅ Operational procedures
+- ✅ Performance benchmarks
+
+---
+
+**📋 Generated by Plant Engineering Team - OHT-50 Project**  
+**🕒 Date: 2025-01-28**  
+**✅ Status: v1.0 IMPLEMENTATION GUIDE COMPLETE**  
+**🎯 Next: Plant Deployment Phase**

--- a/firmware_new/docs/05-FORMS_RECORDS/README.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/README.md
@@ -1,0 +1,87 @@
+# 📋 05-FORMS_RECORDS (Biểu Mẫu và Hồ Sơ)
+
+**Theo ISO 9001:2015 Section 7.5.3 - Control of Documented Information**
+
+---
+
+## 🎯 **MỤC ĐÍCH**
+
+Thư mục này chứa **biểu mẫu và hồ sơ** - records của các thay đổi, migrations, và audit trails.
+
+---
+
+## 📄 **DANH SÁCH TÀI LIỆU**
+
+| **Mã** | **Tên tài liệu** | **Mô tả** | **Version** | **Date** |
+|--------|------------------|-----------|-------------|----------|
+| **REC-001** | Change_Log.md | Lịch sử thay đổi (v0.1.0 → v1.0.1) | 1.0.1 | 2025-10-07 |
+| **REC-002** | Migration_Log_v1.0.1.md | Migration log: Core Architecture | 1.0.1 | 2025-10-07 |
+| **REC-003** | Domain_Driven_Migration_Summary.md | DDD migration summary (4 layers) | 1.0.1 | 2025-10-07 |
+| **REC-004** | Cleanup_Summary.md | Code cleanup report | 1.0.0 | 2025-10-07 |
+| **REC-005** | Final_Cleanup_Report.md | Executive cleanup summary | 1.0.0 | 2025-10-07 |
+| **REC-006** | Documentation_Update_Summary.md | Documentation update report | 1.0.1 | 2025-10-07 |
+| **REC-007** | LiDAR_HAL_Implementation.md | LiDAR HAL v2.3.0 implementation | 2.3.0 | 2025-01-28 |
+| **REC-008** | CTO_Refactor_Order.md | CTO refactor priority order | 1.0 | 2025-01-28 |
+| **REC-009** | Network_Tracking.md | Network management tracking | 1.0 | 2025-01-28 |
+
+---
+
+## 📊 **RECORDS CATEGORIES**
+
+### **1️⃣ Change Management**
+
+| **Record** | **Purpose** | **Frequency** |
+|------------|-------------|---------------|
+| REC-001 | Track all changes by version | Every release |
+
+### **2️⃣ Migration Records**
+
+| **Record** | **Purpose** | **Event** |
+|------------|-------------|-----------|
+| REC-002 | Core architecture migration | v1.0.1 |
+| REC-003 | Domain-Driven migration | v1.0.1 |
+
+### **3️⃣ Quality Records**
+
+| **Record** | **Purpose** | **Event** |
+|------------|-------------|-----------|
+| REC-004 | Cleanup actions detail | v1.0.0 |
+| REC-005 | Executive cleanup summary | v1.0.0 |
+| REC-006 | Documentation updates | v1.0.1 |
+
+---
+
+## ✅ **RECORD RETENTION**
+
+**Retention Policy:**
+- **Change Logs:** Permanent (all versions)
+- **Migration Records:** 3 years minimum
+- **Quality Records:** 2 years minimum
+- **Cleanup Reports:** 1 year minimum
+
+---
+
+## 📝 **KHI NÀO TẠO RECORD MỚI**
+
+Tạo record mới khi:
+- ✅ Release version mới → Update REC-001
+- ✅ Major architecture change → Tạo migration log mới
+- ✅ Quality audit → Tạo audit report
+- ✅ Cleanup major → Tạo cleanup report
+
+---
+
+## 🔍 **TRUY VẾT (Traceability)**
+
+Tất cả records phải có:
+- ✅ Version number
+- ✅ Date created/updated
+- ✅ Author/Maintainer
+- ✅ Related documents references
+
+---
+
+**Version:** 1.0  
+**Last Updated:** 2025-10-07  
+**Maintained By:** QA Team
+

--- a/firmware_new/docs/05-FORMS_RECORDS/REC-001_Change_Log.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/REC-001_Change_Log.md
@@ -1,0 +1,210 @@
+# 📅 Changelog - OHT-50 Firmware
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### 🔮 Planned Features
+- [ ] WebSocket support (optional re-enable)
+- [ ] HTTPS/TLS support
+- [ ] Multi-language support
+- [ ] Advanced telemetry analytics
+- [ ] Predictive maintenance
+- [ ] Cloud integration
+
+---
+
+## [1.0.1] - 2025-10-07
+
+### ✨ Added
+- **Domain-Driven Architecture**: Restructured codebase into 4 layers (Core, Infrastructure, Domain, Application)
+- **Modular CMake**: Separated build configuration into modular files
+- **Performance Monitoring**: Real-time loop performance tracking with adaptive timing
+- **Auto Cleanup**: Automatic process and port cleanup on startup
+- **Module Polling Manager**: Dynamic polling for slave modules
+- **Module Data Storage**: Persistent storage for module configurations
+- **Network HAL**: WiFi and LAN management with failover
+- **LiDAR Integration**: 360° obstacle detection and safety zones
+- **API Documentation**: Comprehensive API reference
+- **Code Quality Tools**: clang-format, clang-tidy, editorconfig
+
+### 🔄 Changed
+- **Boot Sequence**: Optimized to < 20ms (was ~200ms)
+- **State Machine**: Improved transition logic BOOT → INIT → IDLE
+- **Module Discovery**: Moved to background to avoid blocking boot
+- **Communication Manager**: Refactored for better error handling
+- **Safety System**: Enhanced multi-level graduated response
+- **Telemetry**: Separated RS485 telemetry (2s) and system telemetry (1s)
+- **LED Indicators**: Updated COMM LED logic for 4 mandatory modules
+
+### 🐛 Fixed
+- **Issue #135**: Fast boot sequence (< 10s to READY state)
+- **Issue #90**: RS485 telemetry broadcasting
+- **Issue #168**: Network API initialization
+- **Port Conflicts**: Auto cleanup for port 8080/8081
+- **Process Conflicts**: Kill old processes before start
+- **Memory Leaks**: Fixed several memory leaks in communication layer
+- **Race Conditions**: Fixed state machine race conditions
+- **RS485 Timeouts**: Improved retry and timeout handling
+
+### 🚫 Removed
+- **WebSocket Support**: Removed per CTO decision (firmware only uses HTTP/REST)
+- **Old Module Handlers**: Deprecated managers/ and modules/ folders (compatibility shim remains)
+- **Duplicate Code**: Removed redundant implementations
+- **Empty Directories**: Cleaned up empty src/drivers/, src/tests/
+
+### 📚 Documentation
+- Added `INSTALLATION.md` - Complete installation guide
+- Added `USAGE.md` - Comprehensive usage guide
+- Added `CONTRIBUTING.md` - Contribution guidelines
+- Added `CHANGELOG.md` - This file
+- Added `LICENSE.md` - Project license
+- Added `DEVELOPMENT.md` - Development guide
+- Added `API_REFERENCE.md` - API documentation
+- Added `TROUBLESHOOTING.md` - Troubleshooting guide
+- Added `SECURITY.md` - Security policy
+- Updated `README.md` - Refreshed with new architecture
+- Updated `BUILD_GUIDE.md` - Enhanced build instructions
+- Added `ARCHITECTURE_QUICK_REFERENCE.md` - Quick reference card
+- Added `DOMAIN_DRIVEN_MIGRATION_SUMMARY.md` - Migration details
+
+### 🏗️ Architecture
+- **CORE LAYER**: State Management, Safety System, Control System
+- **INFRASTRUCTURE LAYER**: Communication, Network, Telemetry
+- **DOMAIN LAYER**: Module Management, Power, Motion, Safety Module, Dock
+- **APPLICATION LAYER**: Safety Orchestrator, System Orchestrator
+- **Dependency Flow**: Application → Domain → Infrastructure → Core → HAL
+
+### ⚡ Performance
+- **Boot Time**: < 20ms (target met)
+- **Loop Time**: Average 8-15μs, Max 25ms
+- **API Response**: < 50ms (HTTP)
+- **Safety Response**: < 100ms (E-Stop)
+- **CPU Usage**: Target 70%, adaptive sleep 5-50ms
+
+### 🧪 Testing
+- 47 test files across 8 categories
+- Unit tests for all core components
+- Integration tests for system workflows
+- Performance benchmarks
+- Safety validation tests
+- Network communication tests
+
+---
+
+## [1.0.0] - 2025-10-05
+
+### ✨ Added
+- **Initial Release**: Production-ready firmware for OHT-50 Master Module
+- **Multi-protocol Communication**: RS485, Ethernet, WiFi
+- **Safety System**: E-Stop hardware integration, safety monitoring
+- **Module Management**: Auto-discovery and control of slave modules
+- **HTTP API**: RESTful API on port 8080
+- **State Machine**: System lifecycle management
+- **HAL Layer**: Hardware abstraction for Orange Pi 5B
+- **RS485 HAL**: Modbus RTU communication
+- **GPIO HAL**: Relay control (GPIO1_D3, GPIO1_D2)
+- **LED HAL**: 5x status indicators
+- **Module Registry**: YAML-based module configuration
+- **Safety Monitor**: Real-time safety monitoring
+- **Communication Manager**: RS485/Modbus management
+- **Telemetry Manager**: Data collection and streaming
+
+### 🏗️ Initial Architecture
+- Application Layer (app/)
+- HAL Layer (hal/)
+- Managers (communication, telemetry, module)
+- Module Handlers (power, motor, dock, safety)
+
+### 📚 Initial Documentation
+- README.md
+- BUILD_GUIDE.md
+- CODE_STRUCTURE.md
+- CODE_QUALITY.md
+
+---
+
+## [0.9.0] - 2025-09-20 (Beta)
+
+### ✨ Added
+- **Beta Release**: Initial beta testing
+- **Core Features**: State machine, safety, communication
+- **Hardware Integration**: Orange Pi 5B bring-up
+- **RS485 Communication**: Basic Modbus RTU support
+- **Module Discovery**: Auto-scan for slave modules
+
+### 🐛 Fixed
+- UART1 configuration issues
+- GPIO permission problems
+- RS485 CRC validation
+- State machine deadlocks
+
+### 🧪 Testing
+- Basic unit tests
+- Hardware-in-the-loop tests
+- Manual testing procedures
+
+---
+
+## [0.1.0] - 2025-08-15 (Alpha)
+
+### ✨ Added
+- **Alpha Release**: Initial development version
+- **Project Setup**: CMake build system
+- **Basic HAL**: UART, GPIO stubs
+- **Proof of Concept**: Basic communication test
+
+### 📝 Notes
+- Internal development only
+- Not production-ready
+- Experimental features
+
+---
+
+## 📋 **Version Naming Convention**
+
+- **Major** (X.0.0): Breaking changes, major architecture changes
+- **Minor** (1.X.0): New features, backward-compatible changes
+- **Patch** (1.0.X): Bug fixes, minor improvements
+
+---
+
+## 🏷️ **Change Types**
+
+- **✨ Added**: New features
+- **🔄 Changed**: Changes in existing functionality
+- **🚫 Deprecated**: Soon-to-be removed features
+- **🗑️ Removed**: Removed features
+- **🐛 Fixed**: Bug fixes
+- **🔒 Security**: Security fixes
+- **📚 Documentation**: Documentation changes
+- **⚡ Performance**: Performance improvements
+- **🧪 Testing**: Testing additions/changes
+
+---
+
+## 🔗 **Links**
+
+- [GitHub Repository](https://github.com/your-org/OHT-50-firmware)
+- [Issue Tracker](https://github.com/your-org/OHT-50-firmware/issues)
+- [Releases](https://github.com/your-org/OHT-50-firmware/releases)
+- [Documentation](https://docs.oht50.com)
+
+---
+
+## 📞 **Contact**
+
+- **Email:** support@oht50.com
+- **Slack:** #oht50-firmware
+- **Website:** https://oht50.com
+
+---
+
+**Maintained By:** OHT-50 Firmware Team  
+**Last Updated:** 2025-10-07
+

--- a/firmware_new/docs/05-FORMS_RECORDS/REC-002_Migration_Log_v1.0.1.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/REC-002_Migration_Log_v1.0.1.md
@@ -1,0 +1,564 @@
+# 🏗️ MIGRATION LOG - Core Architecture Restructure
+
+**Phiên bản:** v1.0.1  
+**Ngày thực hiện:** 2025-10-07  
+**Loại thay đổi:** Major - Architecture Refactoring  
+**Breaking Changes:** KHÔNG (Backward compatible)
+
+---
+
+## 📊 EXECUTIVE SUMMARY
+
+**Migration Type:** Domain-Driven Architecture Restructure  
+**Scope:** `src/app/core/` directory  
+**Files Affected:** 18 files migrated + 7 files updated  
+**Build Status:** ✅ SUCCESS (100% pass)  
+**Test Status:** ✅ ALL TESTS PASS
+
+---
+
+## 🎯 MỤC TIÊU
+
+### Goals:
+1. ✅ **Better Organization** - Phân tách code theo domain (State, Safety, Control)
+2. ✅ **Modularity** - Mỗi domain có library riêng
+3. ✅ **Scalability** - Dễ thêm module mới vào domain tương ứng
+4. ✅ **Maintainability** - Dễ maintain và debug
+5. ✅ **Team Collaboration** - Mỗi team có thể own 1 domain
+
+### Non-Goals:
+- ❌ KHÔNG thay đổi functionality
+- ❌ KHÔNG phá vỡ existing code
+- ❌ KHÔNG thêm features mới
+
+---
+
+## 📋 MIGRATION DETAILS
+
+### Phase 1: Backup (COMPLETED ✅)
+```bash
+✅ Created backup: core_backup_20251007_*
+✅ Verified backup integrity
+```
+
+### Phase 2: Structure Creation (COMPLETED ✅)
+```bash
+✅ Created: src/app/core/state_management/
+✅ Created: src/app/core/safety/
+✅ Created: src/app/core/control/
+✅ Created: src/app/core/_backup/
+```
+
+### Phase 3: File Migration (COMPLETED ✅)
+
+#### 3.1 State Management (4 files)
+```
+✅ system_state_machine.c/h → state_management/
+✅ system_controller.c/h    → state_management/
+```
+
+#### 3.2 Safety System (8 files)
+```
+✅ safety_monitor.c/h                      → safety/
+✅ critical_module_detector.c/h            → safety/
+✅ graduated_response_system.c/h           → safety/
+✅ safety_rs485_integration.c/h            → safety/
+```
+
+#### 3.3 Control System (4 files)
+```
+✅ control_loop.c/h   → control/
+✅ estimator_1d.c/h   → control/
+```
+
+#### 3.4 Backup Files (2 files)
+```
+✅ safety_monitor.c.phase2.2.backup.20250919_161056 → _backup/
+✅ safety_monitor.c.pre-phase2.20250919_160344      → _backup/
+```
+
+#### 3.5 Cleanup
+```
+✅ Removed empty: safety_integration/ folder
+```
+
+### Phase 4: Build System Update (COMPLETED ✅)
+
+#### 4.1 Created CMakeLists.txt (3 files)
+```
+✅ state_management/CMakeLists.txt
+✅ safety/CMakeLists.txt
+✅ control/CMakeLists.txt
+```
+
+#### 4.2 Updated Existing CMakeLists.txt (3 files)
+```
+✅ src/app/core/CMakeLists.txt        - INTERFACE library
+✅ src/app/managers/CMakeLists.txt    - Added core subfolders includes
+✅ src/app/api/CMakeLists.txt         - Added core subfolders includes
+```
+
+### Phase 5: Code Updates (COMPLETED ✅)
+
+#### 5.1 Updated Includes (6 files)
+```c
+✅ state_management/system_state_machine.c
+   - #include "safety_monitor.h" → "../safety/safety_monitor.h"
+
+✅ state_management/system_controller.h
+   - #include "safety_monitor.h" → "../safety/safety_monitor.h"
+   - #include "control_loop.h" → "../control/control_loop.h"
+
+✅ control/control_loop.c
+   - #include "safety_monitor.h" → "../safety/safety_monitor.h"
+
+✅ control/control_loop.h
+   - #include "system_state_machine.h" → "../state_management/system_state_machine.h"
+
+✅ safety/safety_monitor.c
+   - #include "system_state_machine.h" → "../state_management/system_state_machine.h"
+   - #include "safety_integration/critical_module_detector.h" → "critical_module_detector.h"
+
+✅ safety/safety_monitor.h
+   - #include "system_state_machine.h" → "../state_management/system_state_machine.h"
+```
+
+#### 5.2 Fixed Bugs (2 issues)
+```c
+✅ graduated_response_system.c
+   - Fixed: HAL_OK → HAL_STATUS_OK (17 occurrences)
+   - Fixed: HAL_ERROR → HAL_STATUS_ERROR (12 occurrences)
+   - Added: (void) casts cho unused parameters
+
+✅ telemetry_manager.c
+   - Fixed: #include "../core/estimator_1d.h" inside function
+   - Moved: #include to top of file
+```
+
+### Phase 6: Testing & Verification (COMPLETED ✅)
+```
+✅ Clean build: rm -rf build
+✅ Reconfigure: cmake -B build
+✅ Full rebuild: cmake --build build
+✅ Result: EXIT CODE 0 (SUCCESS)
+✅ All tests: PASS
+✅ Executable: build/oht50_main (469KB)
+```
+
+---
+
+## 🏗️ NEW ARCHITECTURE
+
+### Domain Structure:
+
+```
+┌─────────────────────────────────────────────┐
+│          Application Core (app_core)        │
+│                                             │
+│  ┌─────────────────────────────────────┐   │
+│  │  State Management Domain            │   │
+│  │  - system_state_machine.c/h         │   │
+│  │  - system_controller.c/h            │   │
+│  │  Library: app_core_state_management │   │
+│  └─────────────────┬───────────────────┘   │
+│                    │ (no dependencies)      │
+│                    ↓                        │
+│  ┌─────────────────────────────────────┐   │
+│  │  Safety System Domain               │   │
+│  │  - safety_monitor.c/h               │   │
+│  │  - critical_module_detector.c/h     │   │
+│  │  - graduated_response_system.c/h    │   │
+│  │  - safety_rs485_integration.c/h     │   │
+│  │  Library: app_core_safety           │   │
+│  └─────────────────┬───────────────────┘   │
+│                    │ depends on state mgmt  │
+│                    ↓                        │
+│  ┌─────────────────────────────────────┐   │
+│  │  Control System Domain              │   │
+│  │  - control_loop.c/h                 │   │
+│  │  - estimator_1d.c/h                 │   │
+│  │  Library: app_core_control          │   │
+│  └─────────────────────────────────────┘   │
+│                    depends on safety       │
+└─────────────────────────────────────────────┘
+```
+
+### Build Artifacts:
+
+```
+Before:
+  - app_core.a (monolithic)
+
+After:
+  - app_core_state_management.a
+  - app_core_safety.a
+  - app_core_control.a
+  - app_core (INTERFACE - tổng hợp 3 libs)
+```
+
+---
+
+## 📊 IMPACT ANALYSIS
+
+### Build System Impact:
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| CMakeLists files | 1 | 4 | +300% |
+| Library targets | 1 | 4 | +300% |
+| Build time | ~45s | ~46s | +2% ⚠️ |
+| Executable size | 469KB | 469KB | 0% ✅ |
+
+### Code Impact:
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| Files changed | 0 | 6 | Internal only |
+| Include paths | Flat | Relative | Better organization |
+| Bugs fixed | 0 | 2 | Improvement ✅ |
+| Lines changed | 0 | ~30 | Minimal |
+
+### Developer Impact:
+| Aspect | Before | After | Impact |
+|--------|--------|-------|--------|
+| Finding files | OK | Better | ✅ Positive |
+| Understanding code | OK | Better | ✅ Positive |
+| Adding features | OK | Easier | ✅ Positive |
+| Build complexity | Simple | Slightly complex | ⚠️ Minor |
+| Learning curve | Low | Medium | ⚠️ Acceptable |
+
+---
+
+## 🔧 TECHNICAL CHANGES
+
+### CMake Changes:
+
+#### Before (Monolithic):
+```cmake
+add_library(app_core STATIC
+    system_state_machine.c
+    control_loop.c
+    safety_monitor.c
+    estimator_1d.c
+    system_controller.c
+    safety_integration/critical_module_detector.c
+    safety_integration/safety_rs485_integration.c
+)
+```
+
+#### After (Modular):
+```cmake
+# Main CMakeLists.txt
+add_subdirectory(state_management)
+add_subdirectory(safety)
+add_subdirectory(control)
+
+add_library(app_core INTERFACE)
+target_link_libraries(app_core INTERFACE
+    app_core_state_management
+    app_core_safety
+    app_core_control
+)
+```
+
+### Include Path Strategy:
+
+**Backward Compatibility Maintained:**
+```cmake
+# External code can still use:
+#include "safety_monitor.h"  
+
+# Because we added to include path:
+target_include_directories(app_core INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/state_management
+    ${CMAKE_CURRENT_SOURCE_DIR}/safety
+    ${CMAKE_CURRENT_SOURCE_DIR}/control
+)
+```
+
+---
+
+## 🐛 BUGS FIXED
+
+### Bug #1: Wrong HAL Constants (graduated_response_system.c)
+**Severity:** 🔴 High (Build Error)  
+**Impact:** File couldn't compile
+
+**Before:**
+```c
+return HAL_OK;        // ❌ Undefined
+return HAL_ERROR;     // ❌ Undefined
+```
+
+**After:**
+```c
+return HAL_STATUS_OK;     // ✅ Correct
+return HAL_STATUS_ERROR;  // ✅ Correct
+```
+
+**Occurrences Fixed:** 29 total (17 HAL_OK + 12 HAL_ERROR)
+
+---
+
+### Bug #2: Include Inside Function (telemetry_manager.c)
+**Severity:** 🟡 Medium (Bad Practice)  
+**Impact:** Confusing code structure
+
+**Before:**
+```c
+static void collect_control_data(telemetry_data_t *data) {
+    control_status_t cs;
+    if (control_loop_get_status(&cs) == HAL_STATUS_OK) {
+        #include "../core/estimator_1d.h"  // ❌ Inside function!
+        est1d_state_t est = {0};
+```
+
+**After:**
+```c
+// At top of file
+#include "estimator_1d.h"
+
+static void collect_control_data(telemetry_data_t *data) {
+    control_status_t cs;
+    if (control_loop_get_status(&cs) == HAL_STATUS_OK) {
+        est1d_state_t est = {0};  // ✅ Clean
+```
+
+---
+
+## ✅ VERIFICATION CHECKLIST
+
+### Pre-Migration:
+- [x] Backup created
+- [x] Dependencies analyzed
+- [x] Migration plan approved
+- [x] Team notified
+
+### Migration:
+- [x] Folders created
+- [x] Files moved correctly
+- [x] CMakeLists.txt created
+- [x] Include paths updated
+- [x] External files checked
+
+### Post-Migration:
+- [x] Build successful (exit code 0)
+- [x] All tests pass
+- [x] Executable created (469KB)
+- [x] No functionality regression
+- [x] Documentation updated
+- [x] Migration script cleaned up
+
+---
+
+## 📚 DOCUMENTATION UPDATES
+
+### Files Created:
+1. ✅ `src/app/core/state_management/README.md` - State management docs
+2. ✅ `src/app/core/safety/README.md` - Safety system docs
+3. ✅ `src/app/core/control/README.md` - Control system docs
+4. ✅ `MIGRATION_LOG_v1.0.1.md` - This file
+
+### Files Updated:
+1. ✅ `README.md` - Added Core Architecture section
+2. ✅ `README.md` - Updated changelog
+3. ✅ `CODE_STRUCTURE.md` - Updated directory structure
+4. ✅ `CODE_STRUCTURE.md` - Added migration info
+
+---
+
+## 🎯 SUCCESS METRICS
+
+### Migration Success:
+- ✅ **100% files migrated** - Không có file nào bị mất
+- ✅ **100% build pass** - Không có build errors
+- ✅ **100% tests pass** - Không có test failures
+- ✅ **0% functionality loss** - Tất cả features hoạt động bình thường
+
+### Code Quality:
+- ✅ **2 bugs found & fixed** - Improvement trong quá trình migration
+- ✅ **0 new warnings** - Không tạo thêm warnings
+- ✅ **0 new errors** - Clean migration
+- ✅ **Consistent formatting** - Code style giữ nguyên
+
+### Performance:
+- ✅ **Binary size:** 469KB (unchanged)
+- ✅ **Build time:** +2% (acceptable)
+- ✅ **Runtime performance:** Unchanged
+- ✅ **Memory footprint:** Unchanged
+
+---
+
+## 🔄 ROLLBACK PLAN
+
+### If Issues Occur:
+
+#### Option 1: Git Revert
+```bash
+git revert <commit-hash>
+```
+
+#### Option 2: Manual Restore (if not committed)
+```bash
+# Restore từ backup
+rm -rf src/app/core
+cp -r ../core_backup_20251007_*/core src/app/
+
+# Restore old CMakeLists.txt
+git checkout src/app/core/CMakeLists.txt
+git checkout src/app/managers/CMakeLists.txt
+git checkout src/app/api/CMakeLists.txt
+
+# Rebuild
+rm -rf build
+cmake -B build && cmake --build build
+```
+
+#### Option 3: Script Rollback
+```python
+# Use inverse migration script
+python3 scripts/rollback_core_migration.py
+```
+
+---
+
+## 📝 LESSONS LEARNED
+
+### What Went Well:
+1. ✅ **Migration script** - Python script làm việc rất tốt
+2. ✅ **Backward compatibility** - INTERFACE library strategy hiệu quả
+3. ✅ **Bug discovery** - Tìm được 2 bugs ẩn trong code cũ
+4. ✅ **Testing** - Full rebuild test catch issues sớm
+
+### What Could Be Improved:
+1. ⚠️ **Build time** - Tăng nhẹ do có thêm libraries
+2. ⚠️ **CMake complexity** - Nhiều CMakeLists.txt hơn
+3. ⚠️ **Learning curve** - Team cần familiar với structure mới
+
+### Recommendations:
+1. 💡 **Documentation** - Cần training session cho team về structure mới
+2. 💡 **IDE Setup** - Update IDE project files để reflect structure
+3. 💡 **CI/CD** - Có thể optimize build parallelization
+4. 💡 **Monitoring** - Watch build times trong future commits
+
+---
+
+## 🚀 NEXT STEPS
+
+### Immediate:
+- [x] Verify build on target hardware (Orange Pi 5B)
+- [x] Run full test suite
+- [x] Update documentation
+- [x] Commit changes
+
+### Short-term (This week):
+- [ ] Team training session về new structure
+- [ ] Update development guide
+- [ ] Monitor build times
+- [ ] Collect team feedback
+
+### Long-term (This month):
+- [ ] Consider further modularization nếu cần
+- [ ] Evaluate build performance optimization
+- [ ] Review và refine domain boundaries
+- [ ] Document best practices
+
+---
+
+## 📊 STATISTICS
+
+### File Operations:
+```
+Total Files Migrated:     18 files
+Total Files Created:      7 files (CMakeLists + READMEs)
+Total Files Updated:      6 files (source code)
+Total Files Deleted:      1 folder (safety_integration)
+Total Bugs Fixed:         2 bugs
+Total Lines Changed:      ~50 lines (includes + HAL constants)
+```
+
+### Build System:
+```
+CMakeLists.txt files:     4 (was 1)
+Library targets:          4 (was 1)
+Include directories:      +9 paths
+Link dependencies:        Reorganized
+```
+
+### Time Spent:
+```
+Planning:                 ~5 minutes
+Script Development:       ~10 minutes
+Migration Execution:      ~2 minutes (automated)
+Build System Update:      ~15 minutes
+Testing & Verification:   ~10 minutes
+Documentation:            ~20 minutes
+─────────────────────────────────────
+Total:                    ~62 minutes
+```
+
+---
+
+## 👥 TEAM COMMUNICATION
+
+### Announcement:
+```
+🎉 Core Architecture Migration Complete!
+
+We've successfully migrated src/app/core/ to Domain-Driven Architecture.
+
+What changed:
+- ✅ 3 domains: State Management, Safety, Control
+- ✅ Modular build system
+- ✅ Better organization
+
+What DIDN'T change:
+- ✅ Functionality (100% same)
+- ✅ API compatibility
+- ✅ Performance
+
+Next steps:
+- Review new structure trong src/app/core/
+- Read domain READMEs
+- Update your IDE project settings if needed
+
+Questions? Contact FW Team Lead.
+```
+
+---
+
+## 📞 CONTACT
+
+**Migration Performed By:** AI Assistant (Firmware Team)  
+**Reviewed By:** PM  
+**Approved By:** CTO  
+**Date:** 2025-10-07
+
+---
+
+**Migration Status:** ✅ COMPLETED SUCCESSFULLY  
+**Production Impact:** 🟢 NONE (Backward compatible)  
+**Rollback Required:** ❌ NO
+
+---
+
+## 📝 UPDATE (2025-10-07 Evening)
+
+### Follow-up Migration: Complete Domain-Driven Architecture
+
+**What:** Extended migration để cover `managers/` và `modules/` folders  
+**Status:** ✅ COMPLETED  
+**Files Migrated:** Additional 27 files across 3 new layers
+
+**New Layers Created:**
+- 🔌 **Infrastructure Layer** - Communication, Network, Telemetry
+- 🏭 **Domain Layer** - Module Management, Power, Motion, Safety Module, Dock
+- 🔐 **Application Layer** - Safety Orchestrator
+
+**Documentation:**
+- See [DOMAIN_DRIVEN_MIGRATION_SUMMARY.md](DOMAIN_DRIVEN_MIGRATION_SUMMARY.md) for complete details
+- See [src/app/ARCHITECTURE_v1.0.1.md](src/app/ARCHITECTURE_v1.0.1.md) for architecture guide
+
+**Result:** 
+- Complete 4-layer Domain-Driven Architecture (Core + Infrastructure + Domain + Application)
+- 100% backward compatible
+- Build successful (oht50_main: 473KB)
+

--- a/firmware_new/docs/05-FORMS_RECORDS/REC-003_Domain_Driven_Migration_Summary.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/REC-003_Domain_Driven_Migration_Summary.md
@@ -1,0 +1,458 @@
+# 🏗️ DOMAIN-DRIVEN ARCHITECTURE MIGRATION - SUMMARY
+
+**Phiên bản:** v1.0.1  
+**Ngày thực hiện:** 2025-10-07  
+**Loại thay đổi:** Major - Architecture Refactoring (4-Layer DDD)  
+**Breaking Changes:** NONE (100% Backward Compatible)  
+**Build Status:** ✅ SUCCESS  
+**Migration Time:** ~85 phút
+
+---
+
+## 📊 EXECUTIVE SUMMARY
+
+### Migration Type:
+**Domain-Driven Architecture** - Complete 4-layer restructure
+
+### Scope:
+- `src/app/managers/` → `infrastructure/` + `application/`
+- `src/app/modules/` → `domain/`
+- Legacy folders kept as compatibility shims
+
+### Impact:
+- **50 files changed** (27 files migrated + 17 CMakeLists + 6 updates)
+- **14 new libraries** generated
+- **0 functionality changes** (pure refactoring)
+- **0 breaking changes** (old code still works)
+
+---
+
+## 🎯 MIGRATION GOALS
+
+### ✅ Achieved:
+1. **Better Organization** - 4 clear layers với boundaries rõ ràng
+2. **Modularity** - 14 independent libraries có thể build riêng
+3. **Scalability** - Dễ thêm domain/service mới
+4. **Maintainability** - Mỗi layer có responsibility rõ ràng
+5. **Team Collaboration** - Mỗi team own 1 layer/domain
+6. **Backward Compatibility** - Legacy code vẫn hoạt động
+
+### ❌ Non-Goals (As Expected):
+- Không thay đổi functionality
+- Không phá vỡ existing APIs
+- Không thêm features mới
+- Không thay đổi performance
+
+---
+
+## 📋 MIGRATION PHASES
+
+### ✅ Phase 1: Preparation (5 phút)
+```
+✅ Created folder structure (10 folders)
+✅ Verified git repository state
+✅ Prepared migration plan
+```
+
+### ✅ Phase 2: Infrastructure Layer (10 phút)
+```
+✅ Migrated communication_manager (2 files)
+✅ Migrated telemetry_manager (2 files)
+✅ Migrated network managers (8 files)
+✅ Created 3 CMakeLists.txt
+```
+
+**Files Moved:**
+- `managers/communication_manager.*` → `infrastructure/communication/`
+- `managers/telemetry_manager.*` → `infrastructure/telemetry/`
+- `managers/network/*` → `infrastructure/network/`
+
+### ✅ Phase 3: Domain Layer (15 phút)
+```
+✅ Migrated module_management (6 files)
+✅ Migrated power handler (2 files)
+✅ Migrated motion handler (2 files)
+✅ Migrated safety_module handler (2 files)
+✅ Migrated dock handler (2 files)
+✅ Created 6 CMakeLists.txt
+```
+
+**Files Moved:**
+- `managers/module_manager.*` → `domain/module_management/`
+- `managers/module_polling_manager.*` → `domain/module_management/`
+- `modules/module_registry.c` → `domain/module_management/`
+- `modules/power_module_handler.*` → `domain/power/`
+- `modules/travel_motor_module_handler.*` → `domain/motion/`
+- `modules/safety_module_handler.*` → `domain/safety_module/`
+- `modules/dock_module_handler.*` → `domain/dock/`
+
+### ✅ Phase 4: Application Layer (5 phút)
+```
+✅ Migrated safety_manager (2 files)
+✅ Created application/safety_orchestrator/
+✅ Created 2 CMakeLists.txt
+```
+
+**Files Moved:**
+- `managers/safety_manager.*` → `application/safety_orchestrator/`
+
+### ✅ Phase 5: Build System (30 phút)
+```
+✅ Created infrastructure CMakeLists (4 files)
+✅ Created domain CMakeLists (6 files)
+✅ Created application CMakeLists (2 files)
+✅ Updated main app CMakeLists
+✅ Created legacy compatibility shims (2 files)
+✅ Updated core/safety CMakeLists
+```
+
+### ✅ Phase 6: Validation & Documentation (20 phút)
+```
+✅ Fixed include paths (6 files)
+✅ Fixed CMake dependencies
+✅ Build successful (oht50_main: 473KB)
+✅ Created ARCHITECTURE_v1.0.1.md
+✅ Updated README.md
+✅ Created migration summary
+```
+
+---
+
+## 📊 MIGRATION STATISTICS
+
+### Files Migrated by Layer:
+
+| Layer | Files | CMakeLists | Total |
+|-------|-------|------------|-------|
+| 🔌 Infrastructure | 12 | 4 | 16 |
+| 🏭 Domain | 13 | 6 | 19 |
+| 🔐 Application | 2 | 2 | 4 |
+| 📚 Documentation | 3 | 0 | 3 |
+| 🔧 Build System | 0 | 3 | 3 |
+| **TOTAL** | **30** | **15** | **45** |
+
+### Git Operations:
+
+```
+R  = Rename (27 files)
+M  = Modified (6 files)
+A  = Added (17 files)
+───────────────────────
+Total: 50 files changed
+```
+
+### Libraries Created:
+
+**Infrastructure Layer (3):**
+- `app_infrastructure_communication.a`
+- `app_infrastructure_network.a`
+- `app_infrastructure_telemetry.a`
+
+**Domain Layer (5):**
+- `app_domain_module_management.a`
+- `app_domain_power.a`
+- `app_domain_motion.a`
+- `app_domain_safety_module.a`
+- `app_domain_dock.a`
+
+**Application Layer (1):**
+- `app_application_safety_orchestrator.a`
+
+**Unified Interfaces (3):**
+- `app_infrastructure` (INTERFACE)
+- `app_domain` (INTERFACE)
+- `app_application` (INTERFACE)
+
+**Legacy Compatibility (2):**
+- `app_managers` (INTERFACE → infrastructure + application)
+- `app_modules` (INTERFACE → domain)
+
+**Total:** 14 libraries
+
+---
+
+## 🏗️ ARCHITECTURE OVERVIEW
+
+### Before (Monolithic):
+```
+src/app/
+├── core/
+├── managers/       # Mixed responsibilities
+│   ├── communication_manager.*
+│   ├── network/*
+│   ├── telemetry_manager.*
+│   ├── module_manager.*
+│   ├── module_polling_manager.*
+│   └── safety_manager.*
+└── modules/        # Mixed domain logic
+    ├── module_registry.c
+    ├── power_module_handler.*
+    ├── travel_motor_module_handler.*
+    ├── safety_module_handler.*
+    └── dock_module_handler.*
+```
+
+### After (Domain-Driven):
+```
+src/app/
+├── core/                    # 🎛️ CORE (unchanged)
+├── infrastructure/          # 🔌 NEW
+│   ├── communication/
+│   ├── network/
+│   └── telemetry/
+├── domain/                  # 🏭 NEW
+│   ├── module_management/
+│   ├── power/
+│   ├── motion/
+│   ├── safety_module/
+│   └── dock/
+├── application/             # 🔐 NEW
+│   └── safety_orchestrator/
+├── managers/                # ⚠️ DEPRECATED (compatibility)
+└── modules/                 # ⚠️ DEPRECATED (compatibility)
+```
+
+---
+
+## 🔗 DEPENDENCY GRAPH
+
+```
+┌─────────────────────────────────────────────┐
+│         APPLICATION LAYER                   │
+│  ┌─────────────────────────────────┐        │
+│  │  Safety Orchestrator            │        │
+│  └─────────────────────────────────┘        │
+└────────────────┬────────────────────────────┘
+                 │
+┌────────────────▼────────────────────────────┐
+│         DOMAIN LAYER                        │
+│  ┌────────────┐ ┌─────────┐ ┌─────────┐    │
+│  │ Module Mgmt│ │ Power   │ │ Motion  │    │
+│  └────────────┘ └─────────┘ └─────────┘    │
+│  ┌────────────┐ ┌─────────┐                │
+│  │ Safety Mod │ │ Dock    │                │
+│  └────────────┘ └─────────┘                │
+└────────────────┬────────────────────────────┘
+                 │
+┌────────────────▼────────────────────────────┐
+│         INFRASTRUCTURE LAYER                │
+│  ┌──────────────┐ ┌─────────┐ ┌──────────┐ │
+│  │ Communication│ │ Network │ │Telemetry │ │
+│  └──────────────┘ └─────────┘ └──────────┘ │
+└────────────────┬────────────────────────────┘
+                 │
+┌────────────────▼────────────────────────────┐
+│         CORE LAYER                          │
+│  ┌──────────────┐ ┌─────────┐ ┌──────────┐ │
+│  │    State     │ │ Safety  │ │ Control  │ │
+│  └──────────────┘ └─────────┘ └──────────┘ │
+└────────────────┬────────────────────────────┘
+                 │
+┌────────────────▼────────────────────────────┐
+│         HAL LAYER                           │
+└─────────────────────────────────────────────┘
+```
+
+---
+
+## 🔧 TECHNICAL CHANGES
+
+### Include Path Updates:
+
+**Files Updated (6):**
+1. `core/safety/safety_rs485_integration.h`
+2. `core/safety/critical_module_detector.h`
+3. `core/safety/critical_module_detector.c`
+4. `domain/module_management/module_manager.c`
+5. `domain/module_management/module_manager.h`
+6. `domain/module_management/module_polling_manager.c`
+
+**Pattern:**
+```c
+// OLD
+#include "../../managers/communication_manager.h"
+
+// NEW
+#include "../../infrastructure/communication/communication_manager.h"
+```
+
+### CMake Changes:
+
+**New CMakeLists.txt (17):**
+- Infrastructure: 4 (communication, network, telemetry, main)
+- Domain: 6 (module_management, power, motion, safety_module, dock, main)
+- Application: 2 (safety_orchestrator, main)
+- App: 1 (updated main app)
+- Core: 1 (updated safety)
+- Legacy: 2 (managers, modules compatibility)
+
+---
+
+## ✅ VALIDATION RESULTS
+
+### Build Status:
+```bash
+✅ CMake configuration: SUCCESS
+✅ Make compilation: SUCCESS (warnings only)
+✅ Main executable: oht50_main (473KB)
+✅ All libraries: 14/14 built
+```
+
+### Warnings:
+```
+⚠️ ~50 conversion warnings (non-critical)
+⚠️ Some unused function warnings (acceptable)
+```
+
+### Errors:
+```
+❌ 0 errors
+```
+
+### Backward Compatibility:
+```c
+// OLD CODE - Still works!
+#include "communication_manager.h"
+#include "module_manager.h"
+
+target_link_libraries(my_app
+    app_managers    // ✅ Redirects to new libs
+    app_modules     // ✅ Redirects to new libs
+)
+```
+
+---
+
+## 🚨 KNOWN ISSUES
+
+### Issue #1: Circular Dependency (Accepted)
+**Status:** Temporary accepted for quick migration  
+**Location:** `infrastructure/communication` ↔ `domain/module_management`  
+**Root Cause:** `communication_manager` calls `registry_*` functions  
+**Impact:** None (compiles và runs correctly)  
+**Solution:** Refactor to callback pattern trong v1.1.0
+
+### Issue #2: Some Test Failures
+**Status:** Non-blocking  
+**Impact:** Build succeeds, main executable works  
+**Solution:** Fix tests trong follow-up PRs
+
+---
+
+## 📈 BENEFITS ACHIEVED
+
+### Organization:
+✅ **4 clear layers** với well-defined boundaries  
+✅ **14 modular libraries** có thể build/test riêng  
+✅ **Domain isolation** - mỗi domain độc lập  
+
+### Maintainability:
+✅ **Easier to locate code** - biết file ở layer nào  
+✅ **Clear responsibilities** - mỗi layer có role rõ ràng  
+✅ **Reduced coupling** - dependencies một chiều  
+
+### Scalability:
+✅ **Easy to add new domains** - copy folder pattern  
+✅ **Easy to add new services** - add to appropriate layer  
+✅ **Independent testing** - test từng domain riêng  
+
+### Team Collaboration:
+✅ **Clear ownership** - team own layer/domain  
+✅ **Parallel development** - ít conflict  
+✅ **Better code reviews** - review by domain  
+
+---
+
+## 🎯 NEXT STEPS
+
+### Immediate (v1.0.2):
+- [ ] Add README.md cho mỗi domain
+- [ ] Update API documentation
+- [ ] Add migration guide cho developers
+- [ ] Fix remaining test failures
+
+### Short-term (v1.1.0):
+- [ ] Resolve circular dependency
+- [ ] Remove compatibility shims (breaking change)
+- [ ] Add domain-specific tests
+- [ ] Performance benchmarking
+
+### Long-term (v2.0.0):
+- [ ] Extract domains to separate repos (optional)
+- [ ] Microservices architecture (optional)
+- [ ] Plugin system (optional)
+
+---
+
+## 📚 DOCUMENTATION
+
+### New Documents:
+- ✅ `src/app/ARCHITECTURE_v1.0.1.md` - Architecture guide
+- ✅ `DOMAIN_DRIVEN_MIGRATION_SUMMARY.md` - This file
+- ✅ Updated `README.md` - Main documentation
+- ✅ Updated `MIGRATION_LOG_v1.0.1.md` - Core migration log
+
+### Existing Documents:
+- ✅ `src/app/core/README.md` - Core layer guide (unchanged)
+- ✅ `BUILD_GUIDE.md` - Build instructions (still valid)
+
+---
+
+## 🏆 SUCCESS METRICS
+
+| Metric | Target | Actual | Status |
+|--------|--------|--------|--------|
+| **Build Success** | ✅ | ✅ | PASS |
+| **Binary Size** | < 500KB | 473KB | PASS |
+| **Migration Time** | < 6h | ~1.5h | PASS |
+| **Files Migrated** | 100% | 100% | PASS |
+| **Backward Compat** | Yes | Yes | PASS |
+| **Documentation** | Complete | Complete | PASS |
+| **Breaking Changes** | 0 | 0 | PASS |
+| **Functionality** | Unchanged | Unchanged | PASS |
+
+---
+
+## 🎊 CONCLUSION
+
+**Migration thành công!** OHT-50 Firmware đã được tái cấu trúc thành **Domain-Driven Architecture v1.0.1** với:
+
+✨ **4 layers** rõ ràng và modular  
+✨ **14 libraries** độc lập  
+✨ **100% backward compatible**  
+✨ **Build successful** (473KB)  
+✨ **Documentation đầy đủ**  
+
+Firmware giờ đã **ready để scale, maintain, và extend** trong tương lai! 🚀
+
+---
+
+## 📞 CONTACT & SUPPORT
+
+| Question Type | Contact |
+|--------------|---------|
+| Architecture | FW Team Lead / CTO |
+| Infrastructure | EMBED Team |
+| Domain Logic | FW Domain Team |
+| Application | FW Application Team |
+| Build System | DevOps Team |
+
+---
+
+**Maintained By:** Firmware Team  
+**Migration By:** AI Assistant + Human Review  
+**Reviewed By:** PENDING - CTO Approval Required  
+**Date:** 2025-10-07  
+
+---
+
+## Changelog
+
+### v1.0 (2025-10-07)
+- ✅ Initial migration summary document
+- ✅ Documented all 6 migration phases
+- ✅ Included statistics và metrics
+- ✅ Added architecture diagrams
+- ✅ Documented known issues và next steps
+
+

--- a/firmware_new/docs/05-FORMS_RECORDS/REC-004_Cleanup_Summary.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/REC-004_Cleanup_Summary.md
@@ -1,0 +1,415 @@
+# OHT-50 Firmware Deep Cleanup Summary
+
+**Date:** 2025-10-07  
+**Version:** 1.0.0  
+**Status:** ✅ Completed
+
+## Overview
+
+Comprehensive deep cleanup and reorganization of the OHT-50 firmware codebase. This cleanup focused on code organization, documentation, build system optimization, and professional project structure.
+
+## Cleanup Actions
+
+### 1. ✅ Source Code Organization (src/)
+
+**Actions Taken:**
+- Moved test files from `src/tests/` to `tests/` directory
+- Removed duplicate header file `include/http_server.h`
+- Consolidated test files into proper categories
+- Analyzed code structure and documented components
+
+**Files Affected:**
+- Moved 7 test files from `src/tests/network/` → `tests/network/`
+- Moved `src/tests/test_register_info.c` → `tests/unit/`
+- Removed `src/tests/` directory
+- Deleted duplicate `include/http_server.h`
+
+**Results:**
+- Clear separation between source and tests
+- No duplicate headers
+- Proper file organization
+- 58,265 total lines of code organized
+
+### 2. ✅ Test Suite Restructuring (tests/)
+
+**Actions Taken:**
+- Organized test files by category
+- Created issue-specific test directory
+- Moved Python API tests to dedicated folder
+- Created comprehensive test documentation
+
+**Structure Created:**
+```
+tests/
+├── unit/              # Unit tests
+├── integration/       # Integration tests
+│   └── issues/        # Issue-specific tests (issue_135_*.c)
+├── performance/       # Performance tests
+├── network/           # Network tests (6 test files)
+├── safety/            # Safety tests
+├── smoke/             # Smoke tests
+├── hal/               # HAL tests
+└── api/               # API tests (3 Python scripts)
+```
+
+**Documentation Created:**
+- `tests/README.md` - Comprehensive test suite guide
+
+### 3. ✅ Header Files Organization (include/)
+
+**Actions Taken:**
+- Identified unused header files
+- Documented header structure
+- Created header organization guide
+
+**Analysis Results:**
+- 4 active headers: `constants.h`, `register_map.h`, `safety_types.h`, `version.h`
+- 1 unused header: `module_registry.h` (flagged for removal)
+- Total header size: ~43 KB
+- Largest: `register_map.h` (30 KB)
+
+**Documentation Created:**
+- `include/README.md` - Header organization guide
+
+### 4. ✅ Documentation Structure (docs/)
+
+**Actions Taken:**
+- Created documentation index
+- Linked to main documentation (symlink)
+- Documented structure and navigation
+
+**Documentation Files:**
+- `DOCUMENTATION.md` - Complete documentation index
+- Links to main docs at `/home/orangepi/Desktop/OHT_V2/docs/05-IMPLEMENTATION/FIRMWARE/`
+
+### 5. ✅ CMake Build System Optimization
+
+**Actions Taken:**
+- Modularized CMake configuration
+- Created separate module files
+- Added comprehensive build options
+- Improved dependency management
+- Added build summary
+
+**New CMake Structure:**
+```
+cmake/
+├── CompilerOptions.cmake   # Compiler flags and standards
+├── BuildOptions.cmake      # Build configuration options
+├── Dependencies.cmake      # External dependencies
+└── README.md              # CMake documentation
+```
+
+**Features Added:**
+- Build type selection (Debug/Release/etc.)
+- Code coverage support (`ENABLE_COVERAGE`)
+- Sanitizer support (`ENABLE_SANITIZERS`)
+- Static analysis support (`ENABLE_STATIC_ANALYSIS`)
+- Feature toggles (LiDAR, WiFi, WebSocket, HTTPS)
+- Build summary output
+
+**Documentation Created:**
+- `cmake/README.md` - CMake configuration guide
+
+### 6. ✅ Scripts Organization
+
+**Actions Taken:**
+- Organized scripts by function
+- Created subdirectories for each category
+- Added README for each category
+
+**Structure Created:**
+```
+scripts/
+├── build/      # Build scripts (6 scripts)
+├── deploy/     # Deploy scripts (8 scripts)
+├── test/       # Test scripts (13 scripts)
+├── rs485/      # RS485 utilities (2 scripts)
+├── lidar/      # LiDAR utilities (1 file)
+└── safety/     # Safety tests (1 script)
+```
+
+**Documentation Created:**
+- `scripts/*/README.md` - Documentation for each category
+
+### 7. ✅ Build Artifacts Cleanup
+
+**Actions Taken:**
+- Cleaned `build/` directory
+- Removed object files (`*.o`)
+- Removed old test executables
+- Created `.gitignore`
+
+**Files Removed:**
+- All files in `build/`
+- `tests/*.o`
+- `tests/issue_135_simple_test` (executable)
+- `tests/Makefile`
+
+**.gitignore Created:**
+- Build artifacts
+- Temporary files
+- OS-generated files
+- IDE files
+- Runtime data
+
+### 8. ✅ Comprehensive Documentation
+
+**New Documentation Files:**
+
+1. **README.md** (Updated)
+   - Professional project overview
+   - Feature highlights
+   - Quick start guide
+   - Complete documentation links
+
+2. **CODE_STRUCTURE.md** (New)
+   - Complete code structure analysis
+   - Component statistics
+   - Architecture layers
+   - Naming conventions
+
+3. **DOCUMENTATION.md** (New)
+   - Documentation index
+   - Navigation guide
+   - Standards and best practices
+
+4. **BUILD_GUIDE.md** (New)
+   - Complete build instructions
+   - Build configurations
+   - Troubleshooting guide
+   - Advanced topics
+
+5. **CLEANUP_SUMMARY.md** (This file)
+   - Cleanup actions summary
+   - Before/after comparison
+   - Maintenance guidelines
+
+## Statistics
+
+### Before Cleanup
+```
+- Build artifacts: Present
+- Test organization: Mixed (src/tests + tests/)
+- Duplicate headers: 1 (http_server.h)
+- Scripts organization: Flat structure
+- Documentation: Basic
+- CMake: Monolithic
+- .gitignore: None
+```
+
+### After Cleanup
+```
+- Build artifacts: Cleaned
+- Test organization: Categorized (7 categories)
+- Duplicate headers: 0
+- Scripts organization: 6 functional categories
+- Documentation: Comprehensive (9 main docs)
+- CMake: Modularized (3 modules)
+- .gitignore: Complete
+```
+
+### Code Statistics
+- **Total Lines:** 58,265
+- **Source Files:** 35 (C/H)
+- **Test Files:** 43
+- **Documentation Files:** 14 (including READMEs)
+
+### File Changes
+- **Files Moved:** 10
+- **Files Deleted:** 5
+- **Files Created:** 14
+- **Directories Created:** 10
+- **README Files Created:** 9
+
+## Project Structure (Final)
+
+```
+firmware_new/
+├── README.md                    # ✅ Updated - Professional overview
+├── BUILD_GUIDE.md               # ✅ New - Complete build guide
+├── CODE_STRUCTURE.md            # ✅ New - Code analysis
+├── DOCUMENTATION.md             # ✅ New - Doc index
+├── CLEANUP_SUMMARY.md           # ✅ New - This file
+├── .gitignore                   # ✅ New - Git ignore rules
+├── CMakeLists.txt               # ✅ Updated - Optimized
+├── modules.yaml                 # ✅ Cleaned - Reset state
+│
+├── build/                       # ✅ Cleaned - Empty
+├── cmake/                       # ✅ New - CMake modules
+│   ├── CompilerOptions.cmake
+│   ├── BuildOptions.cmake
+│   ├── Dependencies.cmake
+│   └── README.md
+│
+├── config/                      # Configuration files
+├── docs/                        # Symlink to main docs
+├── include/                     # ✅ Analyzed - Headers
+│   └── README.md               # ✅ New - Header guide
+│
+├── scripts/                     # ✅ Reorganized - By function
+│   ├── build/README.md
+│   ├── deploy/README.md
+│   ├── test/README.md
+│   ├── rs485/README.md
+│   ├── lidar/README.md
+│   └── safety/README.md
+│
+├── src/                         # ✅ Cleaned - Source only
+│   ├── app/                    # Application layer
+│   ├── hal/                    # Hardware abstraction
+│   ├── drivers/                # Platform drivers
+│   ├── utils/                  # Utilities
+│   └── main.c                  # Main entry
+│
+├── tests/                       # ✅ Reorganized - By category
+│   ├── README.md               # ✅ New - Test guide
+│   ├── unit/
+│   ├── integration/
+│   │   └── issues/             # Issue-specific tests
+│   ├── performance/
+│   ├── network/                # Network tests moved here
+│   ├── safety/
+│   ├── smoke/
+│   ├── hal/
+│   └── api/                    # Python API tests
+│
+└── third_party/                 # External libraries
+    └── unity/                  # Test framework
+```
+
+## Quality Improvements
+
+### Code Organization
+- ✅ Clear separation of concerns
+- ✅ Proper directory structure
+- ✅ No duplicate files
+- ✅ Logical component grouping
+
+### Documentation
+- ✅ Comprehensive README files
+- ✅ Build and test guides
+- ✅ Code structure documentation
+- ✅ Navigation guides
+
+### Build System
+- ✅ Modular CMake configuration
+- ✅ Multiple build options
+- ✅ Feature toggles
+- ✅ Dependency management
+- ✅ Build summary
+
+### Testing
+- ✅ Organized by category
+- ✅ Clear test documentation
+- ✅ API test suite
+- ✅ Integration tests
+
+### Maintenance
+- ✅ .gitignore for artifacts
+- ✅ Clean repository
+- ✅ Professional structure
+- ✅ Easy navigation
+
+## Maintenance Guidelines
+
+### Regular Cleanup
+```bash
+# Clean build artifacts
+rm -rf build/*
+
+# Remove temporary files
+find . -name "*.tmp" -delete
+find . -name "*~" -delete
+
+# Check for large files
+find . -size +1M -ls
+```
+
+### Documentation Updates
+- Update README when adding features
+- Keep CODE_STRUCTURE.md current
+- Update test documentation
+- Maintain changelog
+
+### Code Quality
+- Run static analysis: `cmake -DENABLE_STATIC_ANALYSIS=ON`
+- Check coverage: `cmake -DENABLE_COVERAGE=ON`
+- Test on target hardware
+- Review warnings
+
+### Git Best Practices
+```bash
+# Before commit
+git status
+git diff
+
+# Check .gitignore effectiveness
+git ls-files --others --exclude-standard
+
+# Ensure no build artifacts
+git clean -xdn  # Dry run
+```
+
+## Benefits Achieved
+
+### Development
+- ✅ Easier navigation
+- ✅ Faster builds
+- ✅ Better organization
+- ✅ Clear structure
+
+### Maintenance
+- ✅ Easier to maintain
+- ✅ Clear documentation
+- ✅ Organized tests
+- ✅ Professional appearance
+
+### Collaboration
+- ✅ Clear onboarding
+- ✅ Self-documenting structure
+- ✅ Easy contribution
+- ✅ Professional standards
+
+### Production
+- ✅ Clean codebase
+- ✅ Optimized builds
+- ✅ Comprehensive testing
+- ✅ Release ready
+
+## Next Steps
+
+### Recommended Actions
+1. ✅ Review all documentation
+2. ✅ Test build system
+3. ✅ Run full test suite
+4. ⏳ Deploy to target hardware
+5. ⏳ Gather team feedback
+
+### Future Improvements
+- [ ] Add API documentation (Doxygen)
+- [ ] Implement continuous integration
+- [ ] Add performance benchmarks
+- [ ] Expand test coverage to 95%
+- [ ] Add deployment automation
+
+## Conclusion
+
+The OHT-50 firmware codebase has been successfully cleaned, organized, and documented. The project now features:
+
+- **Professional Structure:** Clear organization and separation of concerns
+- **Comprehensive Documentation:** Complete guides for building, testing, and development
+- **Optimized Build System:** Modular CMake with multiple options
+- **Clean Repository:** No artifacts, proper .gitignore
+- **Quality Standards:** Ready for production deployment
+
+The codebase is now **production-ready** and follows industry best practices for embedded firmware development.
+
+---
+
+**Cleanup Performed By:** AI Assistant  
+**Date:** 2025-10-07  
+**Status:** ✅ Complete  
+**Next Review:** As needed for new features
+
+

--- a/firmware_new/docs/05-FORMS_RECORDS/REC-005_Final_Cleanup_Report.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/REC-005_Final_Cleanup_Report.md
@@ -1,0 +1,409 @@
+# OHT-50 Firmware - Final Cleanup Report
+
+**Date:** 2025-10-07  
+**Version:** 1.0.0  
+**Status:** ✅ COMPLETED & PRODUCTION READY
+
+## Executive Summary
+
+The OHT-50 firmware codebase has undergone a comprehensive professional cleanup and reorganization. The project now features industry-standard structure, complete documentation, optimized build system, and professional code quality tools.
+
+## What Was Done
+
+### 1. Code Organization ✅
+- Moved test files to proper location
+- Removed duplicate headers
+- Organized by architectural layers
+- Clean separation of concerns
+
+### 2. Documentation ✅
+Created **7 comprehensive documentation files**:
+1. `INDEX.md` - Quick navigation index
+2. `README.md` - Professional project overview
+3. `BUILD_GUIDE.md` - Complete build instructions
+4. `CODE_STRUCTURE.md` - Code architecture analysis
+5. `CODE_QUALITY.md` - Code quality tools & practices
+6. `DOCUMENTATION.md` - Documentation navigation
+7. `CLEANUP_SUMMARY.md` - Detailed cleanup report
+
+Plus **12 README files** throughout subdirectories!
+
+### 3. Build System ✅
+- Modularized CMake configuration (3 modules)
+- Added build options (Coverage, Sanitizers, Static Analysis)
+- Feature toggles (LiDAR, WiFi, WebSocket, HTTPS)
+- Build summary output
+- Installation rules
+
+### 4. Code Quality Tools ✅
+Created professional development environment:
+- `.clang-format` - Code formatting (LLVM-based)
+- `.clang-tidy` - Static analysis configuration
+- `.editorconfig` - Editor consistency
+- `.clang-format-ignore` - Exclude third-party code
+- `.gitignore` - Comprehensive ignore rules
+
+### 5. Test Organization ✅
+Organized tests into **8 categories**:
+- `unit/` - Unit tests
+- `integration/` - Integration tests (with issues/ subfolder)
+- `performance/` - Performance benchmarks
+- `network/` - Network communication tests
+- `safety/` - Safety system tests
+- `smoke/` - Quick sanity tests
+- `hal/` - HAL layer tests
+- `api/` - Python API tests
+
+### 6. Scripts Organization ✅
+Organized scripts into **6 functional categories**:
+- `build/` - Build scripts
+- `deploy/` - Deployment scripts
+- `test/` - Testing scripts
+- `rs485/` - RS485 utilities
+- `lidar/` - LiDAR utilities
+- `safety/` - Safety tests
+
+## Final File Structure
+
+```
+firmware_new/
+├── 📄 Configuration Files (5)
+│   ├── .clang-format          # Code formatting
+│   ├── .clang-format-ignore   # Formatting exclusions
+│   ├── .clang-tidy            # Static analysis
+│   ├── .editorconfig          # Editor config
+│   └── .gitignore             # Git ignore rules
+│
+├── 📚 Documentation (7 + 12 READMEs)
+│   ├── INDEX.md               # Quick navigation
+│   ├── README.md              # Project overview
+│   ├── BUILD_GUIDE.md         # Build instructions
+│   ├── CODE_STRUCTURE.md      # Code analysis
+│   ├── CODE_QUALITY.md        # Quality tools
+│   ├── DOCUMENTATION.md       # Doc navigation
+│   └── CLEANUP_SUMMARY.md     # Cleanup details
+│
+├── 🔧 Build System
+│   ├── CMakeLists.txt         # Main CMake
+│   ├── cmake/                 # CMake modules (3)
+│   ├── config/                # Build config
+│   └── modules.yaml           # Module registry
+│
+├── 💻 Source Code
+│   ├── src/                   # Source files
+│   │   ├── app/               # Application layer
+│   │   ├── hal/               # HAL layer
+│   │   ├── drivers/           # Platform drivers
+│   │   └── utils/             # Utilities
+│   └── include/               # Headers
+│
+├── 🧪 Testing
+│   └── tests/                 # Test suite (8 categories)
+│
+├── 🔨 Utilities
+│   └── scripts/               # Scripts (6 categories)
+│
+└── 📦 Dependencies
+    └── third_party/           # External libraries
+```
+
+## Key Achievements
+
+### ✅ Professional Quality
+- Industry-standard structure
+- Comprehensive documentation
+- Complete code quality tools
+- Production-ready codebase
+
+### ✅ Developer Experience
+- Easy navigation (INDEX.md)
+- Clear build instructions
+- Code quality guidelines
+- Self-documenting structure
+
+### ✅ Build System
+- Modular CMake
+- Multiple build configurations
+- Feature toggles
+- Automated quality checks
+
+### ✅ Code Quality
+- Formatting: clang-format
+- Static Analysis: clang-tidy
+- Coverage: gcov/lcov
+- Sanitizers: ASan/UBSan
+- Consistency: editorconfig
+
+## Statistics
+
+### Documentation
+- **Main Docs:** 7 files
+- **Component READMEs:** 12 files
+- **Total Documentation:** 19 files
+
+### Code
+- **Total Lines:** 58,265
+- **Source Files:** 70 (C/H)
+- **Test Files:** 47 (C/Python)
+
+### Configuration
+- **Quality Tools:** 5 config files
+- **CMake Modules:** 3 files
+- **Build Options:** 10+ options
+
+### Organization
+- **Main Directories:** 9
+- **Test Categories:** 8
+- **Script Categories:** 6
+
+## Quality Metrics
+
+### Code Coverage
+- **Target:** > 90%
+- **Safety-critical:** 100%
+- **HAL layer:** > 95%
+
+### Static Analysis
+- **Enabled Checks:** 5 categories
+- **Disabled Noisy Checks:** 3
+- **Zero tolerance for:** Critical issues
+
+### Compiler Warnings
+- **Flags:** 15+ warning flags enabled
+- **Errors:** Treat key warnings as errors
+- **Goal:** Zero warnings in production
+
+## Tools & Practices
+
+### Development Tools
+```bash
+# Format code
+clang-format -i src/**/*.{c,h}
+
+# Static analysis
+cmake -DENABLE_STATIC_ANALYSIS=ON ..
+
+# Code coverage
+cmake -DENABLE_COVERAGE=ON ..
+
+# Sanitizers
+cmake -DENABLE_SANITIZERS=ON ..
+```
+
+### Pre-commit Checks
+- Code formatting verification
+- Static analysis (optional)
+- Build verification
+- Test execution
+
+### CI/CD Ready
+- Build verification
+- Format checking
+- Static analysis
+- Test execution
+- Coverage reporting
+
+## Benefits
+
+### For Developers
+✅ Clear project structure  
+✅ Comprehensive guides  
+✅ Code quality tools  
+✅ Easy onboarding  
+
+### For Team
+✅ Professional standards  
+✅ Consistent workflow  
+✅ Quality assurance  
+✅ Documentation complete  
+
+### For Production
+✅ Production-ready  
+✅ Well-tested  
+✅ Maintainable  
+✅ Industry-standard  
+
+## Next Steps
+
+### Immediate
+- [x] Review all documentation
+- [x] Test build system
+- [x] Verify quality tools
+- [ ] Deploy to hardware
+- [ ] Team training
+
+### Short-term
+- [ ] Add Doxygen API docs
+- [ ] Setup CI/CD pipeline
+- [ ] Expand test coverage to 95%
+- [ ] Create performance benchmarks
+- [ ] Add deployment automation
+
+### Long-term
+- [ ] Continuous monitoring
+- [ ] Regular security audits
+- [ ] Performance optimization
+- [ ] Feature enhancements
+- [ ] Documentation updates
+
+## Quick Start Guide
+
+### For New Developers
+
+1. **Start Here:**
+   ```bash
+   cat INDEX.md
+   ```
+
+2. **Understand the Project:**
+   ```bash
+   cat README.md
+   cat CODE_STRUCTURE.md
+   ```
+
+3. **Setup Development:**
+   ```bash
+   cat CODE_QUALITY.md
+   # Install tools: clang-format, clang-tidy
+   ```
+
+4. **Build:**
+   ```bash
+   cat BUILD_GUIDE.md
+   mkdir build && cd build
+   cmake ..
+   make -j$(nproc)
+   ```
+
+5. **Run Tests:**
+   ```bash
+   ctest -V
+   ```
+
+### For Contributors
+
+1. **Before Coding:**
+   - Read CODE_QUALITY.md
+   - Setup .editorconfig in your editor
+   - Install clang-format and clang-tidy
+
+2. **While Coding:**
+   - Follow naming conventions
+   - Write tests for new features
+   - Document public APIs
+   - Format code: `clang-format -i file.c`
+
+3. **Before Committing:**
+   - Run formatter: `clang-format -i **/*.{c,h}`
+   - Run tests: `make test`
+   - Check coverage: `lcov ...`
+   - Run static analysis: `clang-tidy ...`
+
+4. **Commit:**
+   - Clear commit message
+   - Reference issues
+   - Update documentation
+   - Pass CI checks
+
+## Quality Checklist
+
+### Code Quality ✅
+- [x] Code formatting configured
+- [x] Static analysis enabled
+- [x] Coverage tools integrated
+- [x] Sanitizers available
+- [x] Editor configuration provided
+
+### Documentation ✅
+- [x] Project overview complete
+- [x] Build guide comprehensive
+- [x] Code structure documented
+- [x] Quality practices defined
+- [x] Navigation index created
+
+### Build System ✅
+- [x] CMake modularized
+- [x] Build options added
+- [x] Feature toggles implemented
+- [x] Installation rules defined
+- [x] Summary output included
+
+### Testing ✅
+- [x] Tests organized by category
+- [x] Test documentation complete
+- [x] API tests included
+- [x] Performance tests available
+- [x] Safety tests implemented
+
+### Infrastructure ✅
+- [x] .gitignore comprehensive
+- [x] .editorconfig provided
+- [x] Format configuration included
+- [x] Static analysis configured
+- [x] CI/CD ready
+
+## Success Criteria Met
+
+### ✅ Professional Structure
+- Industry-standard organization
+- Clear separation of concerns
+- Modular architecture
+- Clean dependencies
+
+### ✅ Complete Documentation
+- Getting started guides
+- Build instructions
+- Code organization
+- Quality practices
+- Navigation tools
+
+### ✅ Quality Tools
+- Code formatting
+- Static analysis
+- Coverage reporting
+- Memory checking
+- Thread safety
+
+### ✅ Production Ready
+- Clean codebase
+- Optimized builds
+- Comprehensive tests
+- Professional standards
+
+## Conclusion
+
+The OHT-50 firmware project has been transformed into a **professional, production-ready codebase** with:
+
+- ✅ **58,265 lines** of well-organized code
+- ✅ **7 comprehensive** documentation files
+- ✅ **12 component** README files
+- ✅ **5 code quality** configuration files
+- ✅ **8 test** categories
+- ✅ **6 script** categories
+- ✅ **Industry-standard** structure and practices
+
+The project now follows **best practices** for embedded firmware development and is ready for **production deployment**.
+
+---
+
+**Cleanup Performed By:** AI Assistant  
+**Date:** 2025-10-07  
+**Time Invested:** Deep cleanup session  
+**Status:** ✅ COMPLETE & VERIFIED  
+**Next Review:** As needed for feature additions  
+
+**Project Status:** 🚀 PRODUCTION READY
+
+---
+
+## Acknowledgments
+
+This cleanup was performed with attention to:
+- Industry best practices
+- Embedded systems standards
+- Professional development workflows
+- Team collaboration needs
+- Production requirements
+
+The result is a **world-class firmware codebase** ready for deployment! 🎉
+

--- a/firmware_new/docs/05-FORMS_RECORDS/REC-006_Documentation_Update_Summary.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/REC-006_Documentation_Update_Summary.md
@@ -1,0 +1,299 @@
+# 📚 Tổng Hợp Cập Nhật Tài Liệu Firmware
+
+**Ngày cập nhật:** 2025-10-07  
+**Version:** 1.0.1  
+**Người thực hiện:** PM Team
+
+---
+
+## ✅ **ĐÃ HOÀN THÀNH**
+
+### **📄 CÁC FILE TÀI LIỆU MỚI (9 files)**
+
+| # | **File** | **Mô tả** | **Dung lượng** | **Trạng thái** |
+|---|----------|-----------|----------------|----------------|
+| 1 | `INSTALLATION.md` | Hướng dẫn cài đặt chi tiết (hardware + software) | ~15 KB | ✅ Hoàn thành |
+| 2 | `USAGE.md` | Hướng dẫn sử dụng đầy đủ (chạy, config, API, troubleshoot) | ~12 KB | ✅ Hoàn thành |
+| 3 | `CONTRIBUTING.md` | Quy tắc đóng góp (code style, workflow, PR process) | ~10 KB | ✅ Hoàn thành |
+| 4 | `CHANGELOG.md` | Lịch sử thay đổi (v0.1.0 → v1.0.1) | ~5 KB | ✅ Hoàn thành |
+| 5 | `LICENSE.md` | Giấy phép MIT + third-party licenses | ~4 KB | ✅ Hoàn thành |
+| 6 | `DEVELOPMENT.md` | Hướng dẫn phát triển (IDE, workflow, debugging) | ~6 KB | ✅ Hoàn thành |
+| 7 | `API_REFERENCE.md` | Tài liệu API REST (endpoints, requests, responses) | ~5 KB | ✅ Hoàn thành |
+| 8 | `TROUBLESHOOTING.md` | Khắc phục 10+ sự cố phổ biến | ~7 KB | ✅ Hoàn thành |
+| 9 | `SECURITY.md` | Chính sách bảo mật + vulnerability reporting | ~5 KB | ✅ Hoàn thành |
+
+**Tổng dung lượng:** ~69 KB tài liệu mới
+
+---
+
+## 📊 **THỐNG KÊ CHI TIẾT**
+
+### **1. INSTALLATION.md (Hướng dẫn cài đặt)**
+
+**Nội dung bao gồm:**
+- ✅ Yêu cầu hệ thống (hardware + software)
+- ✅ Chuẩn bị môi trường (OS installation, SSH setup)
+- ✅ Cài đặt phụ thuộc (build tools, libraries, dev tools)
+- ✅ Build firmware (Debug/Release, CMake options)
+- ✅ Cấu hình hardware (UART1, GPIO, udev rules)
+- ✅ Triển khai lên thiết bị (systemd service)
+- ✅ Xác minh cài đặt (test run, hardware check, API test)
+- ✅ Troubleshooting (4 vấn đề phổ biến + giải pháp)
+
+**Highlights:**
+- 🎯 **Step-by-step guide** rất chi tiết
+- 🔧 **Hardware configuration** với device tree, udev rules
+- 🚀 **Deployment options**: Manual run hoặc systemd service
+- 🧪 **Verification steps** để đảm bảo cài đặt thành công
+
+---
+
+### **2. USAGE.md (Hướng dẫn sử dụng)**
+
+**Nội dung bao gồm:**
+- ✅ Khởi động firmware (basic, with options, as service)
+- ✅ Chế độ chạy (State machine: 8 states với LED indicators)
+- ✅ Cấu hình hệ thống (modules.yaml, safety_config.yaml)
+- ✅ Sử dụng API (Robot status, control, modules, telemetry)
+- ✅ Quản lý module (auto-discovery, polling, health check)
+- ✅ Giám sát hệ thống (telemetry, LED status, performance)
+- ✅ Emergency stop (hardware + software + recovery)
+- ✅ Xử lý lỗi (8 lỗi phổ biến + solutions)
+
+**Highlights:**
+- 🎛️ **State machine diagram** với 8 states
+- 📡 **API examples** cho tất cả endpoints
+- 🚨 **Emergency procedures** rõ ràng
+- 💡 **Tips & Tricks** cho performance tuning
+
+---
+
+### **3. CONTRIBUTING.md (Quy tắc đóng góp)**
+
+**Nội dung bao gồm:**
+- ✅ Quy tắc chung (Code of Conduct)
+- ✅ Code style (C naming, formatting, comments)
+- ✅ Quy trình phát triển (Fork, branch, commit, push)
+- ✅ Pull Request process (template, review, approval)
+- ✅ Báo cáo lỗi (Bug report template)
+- ✅ Đề xuất tính năng (Feature request template)
+- ✅ Testing requirements (Unit, integration, coverage)
+- ✅ Documentation standards (Code comments, API docs)
+
+**Highlights:**
+- 🎨 **LLVM code style** với auto-formatting
+- 📝 **Commit message convention** (type, scope, subject)
+- 🔄 **Git workflow** chi tiết
+- 🧪 **80% test coverage** target
+
+---
+
+### **4. CHANGELOG.md (Lịch sử thay đổi)**
+
+**Nội dung bao gồm:**
+- ✅ Version history: 0.1.0 (Alpha) → 0.9.0 (Beta) → 1.0.0 → 1.0.1
+- ✅ v1.0.1 changes:
+  - Added: Domain-Driven Architecture, Performance Monitoring, Auto Cleanup
+  - Changed: Boot sequence < 20ms, Module discovery non-blocking
+  - Fixed: Issue #135, #90, #168 + port/process conflicts
+  - Removed: WebSocket support, deprecated code
+  - Documentation: 9 new files
+- ✅ Semantic versioning (Major.Minor.Patch)
+- ✅ Change types (Added, Changed, Fixed, Removed, Security)
+
+**Highlights:**
+- 📅 **Complete history** từ alpha đến production
+- 📊 **Detailed changelog** cho v1.0.1
+- 🔖 **Semantic versioning** tuân thủ chuẩn
+
+---
+
+### **5. LICENSE.md (Giấy phép)**
+
+**Nội dung bao gồm:**
+- ✅ MIT License full text
+- ✅ Third-party licenses (Unity, OpenSSL)
+- ✅ Open source attribution
+- ✅ Usage permissions (CAN, MUST, CANNOT)
+- ✅ Warranty disclaimer
+- ✅ Security & Safety warnings
+- ✅ Commercial support info
+
+**Highlights:**
+- 📜 **MIT License** - Permissive open source
+- ⚖️ **Clear permissions** - Biết được quyền gì, không được gì
+- ⚠️ **Safety warnings** - Cho safety-critical applications
+- 🏢 **Commercial support** available
+
+---
+
+### **6. DEVELOPMENT.md (Hướng dẫn phát triển)**
+
+**Nội dung bao gồm:**
+- ✅ Development environment (VS Code, extensions, settings)
+- ✅ Architecture overview (5 layers với dependency rules)
+- ✅ Development workflow (Feature development step-by-step)
+- ✅ Debugging (GDB, Valgrind)
+- ✅ Testing strategy (Unit, integration, performance)
+- ✅ Performance profiling (perf, top, htop)
+- ✅ Best practices (Code quality, static analysis)
+
+**Highlights:**
+- 💻 **VS Code setup** với extensions cần thiết
+- 🏗️ **Layer architecture** diagram
+- 🐛 **Debugging tools** (GDB commands, Valgrind)
+- ⚡ **Profiling tools** (perf record/report)
+
+---
+
+### **7. API_REFERENCE.md (Tài liệu API)**
+
+**Nội dung bao gồm:**
+- ✅ 5 main endpoints:
+  1. `GET /api/v1/robot/status` - Robot status
+  2. `POST /api/v1/robot/command` - Robot control (move, stop, pause, resume, home)
+  3. `GET /api/v1/modules` - Module management
+  4. `POST /api/v1/safety/emergency` - Emergency stop
+  5. `GET /api/v1/telemetry/current` - Real-time telemetry
+- ✅ Request/Response examples với JSON
+- ✅ Authentication (Bearer token)
+- ✅ Error codes (200, 400, 401, 404, 500, 503)
+
+**Highlights:**
+- 🌐 **RESTful API** chuẩn
+- 📡 **Real-time telemetry** with modules data
+- 🔐 **Authentication** ready (future OAuth2/JWT)
+- ⚠️ **Error handling** comprehensive
+
+---
+
+### **8. TROUBLESHOOTING.md (Khắc phục sự cố)**
+
+**Nội dung bao gồm:**
+- ✅ 10 vấn đề phổ biến:
+  1. Build failed - Missing dependencies
+  2. /dev/ttyOHT485 not found
+  3. Permission denied
+  4. Port 8080 already in use
+  5. Module not discovered
+  6. High CPU usage
+  7. RS485 communication errors
+  8. LiDAR not responding
+  9. State machine stuck
+  10. Memory leak
+- ✅ Mỗi vấn đề có: Triệu chứng, Nguyên nhân, Giải pháp
+- ✅ Diagnostic tools (top, htop, valgrind, journalctl)
+- ✅ Getting help (docs, GitHub issues, support)
+
+**Highlights:**
+- 🔧 **10+ common issues** với solutions chi tiết
+- 📊 **Diagnostic tools** guide
+- 🆘 **Support channels** rõ ràng
+
+---
+
+### **9. SECURITY.md (Chính sách bảo mật)**
+
+**Nội dung bao gồm:**
+- ✅ Supported versions (1.0.x supported)
+- ✅ Security features (Authentication, Validation, Audit logging)
+- ✅ Reporting vulnerabilities (Private email, 24h response)
+- ✅ Known security considerations (3 areas: Default config, Network exposure, Hardware access)
+- ✅ Security best practices (Deployment, Network, Access control)
+- ✅ Security audit checklist
+- ✅ Security Hall of Fame
+
+**Highlights:**
+- 🔐 **Responsible disclosure** process
+- ⚠️ **Known risks** được document rõ
+- 🛡️ **Best practices** cho production deployment
+- 🏆 **Hall of Fame** cho security researchers
+
+---
+
+## 📈 **METRICS**
+
+### **Tổng thống kê tài liệu:**
+
+| **Metric** | **Trước** | **Sau** | **Tăng** |
+|------------|----------|---------|----------|
+| **Số file .md** | 13 | 22 | +9 (+69%) |
+| **Dung lượng docs** | ~50 KB | ~120 KB | +70 KB (+140%) |
+| **Coverage** | 40% | 95% | +55% |
+
+### **Phân loại tài liệu:**
+
+| **Loại** | **Số file** | **Examples** |
+|----------|-------------|--------------|
+| 📘 **Getting Started** | 3 | README, INSTALLATION, USAGE |
+| 🏗️ **Architecture** | 4 | ARCHITECTURE_v1.0.1, ARCHITECTURE_QUICK_REFERENCE, CODE_STRUCTURE, BUILD_GUIDE |
+| 👥 **Contributing** | 2 | CONTRIBUTING, DEVELOPMENT |
+| 🔐 **Legal/Security** | 2 | LICENSE, SECURITY |
+| 📊 **Reference** | 3 | API_REFERENCE, CHANGELOG, TROUBLESHOOTING |
+| 🗂️ **Meta** | 3 | INDEX, DOCUMENTATION, CODE_QUALITY |
+
+---
+
+## 🎯 **COVERAGE ASSESSMENT**
+
+### **Documentation Completeness:**
+
+| **Category** | **Coverage** | **Status** |
+|--------------|-------------|------------|
+| 📦 **Installation** | 100% | ✅ Complete |
+| 📖 **Usage** | 95% | ✅ Complete |
+| 🔧 **Development** | 90% | ✅ Complete |
+| 🌐 **API** | 85% | ✅ Complete (có thể mở rộng) |
+| 🐛 **Troubleshooting** | 90% | ✅ Complete |
+| 🔐 **Security** | 85% | ✅ Complete |
+| ⚖️ **Legal** | 100% | ✅ Complete |
+| 📚 **Architecture** | 100% | ✅ Complete |
+
+**Overall Coverage:** **~95%** (Excellent!) 🌟
+
+---
+
+## 🚀 **NEXT STEPS**
+
+### **Khuyến nghị:**
+
+1. ✅ **Review tất cả files** - Đọc qua để đảm bảo accuracy
+2. ✅ **Test instructions** - Verify installation và usage guides
+3. ✅ **Add screenshots** (tùy chọn) - Visual guides cho UI/API
+4. ✅ **Translate** (tùy chọn) - Dịch sang tiếng Anh nếu cần
+5. ✅ **Version control** - Commit tất cả files vào Git
+
+### **Maintenance:**
+
+- 🔄 **Update CHANGELOG.md** khi có version mới
+- 🔄 **Update API_REFERENCE.md** khi thêm/sửa endpoints
+- 🔄 **Update TROUBLESHOOTING.md** khi phát hiện issues mới
+- 🔄 **Update SECURITY.md** khi có security updates
+
+---
+
+## 📞 **LIÊN HỆ**
+
+Có câu hỏi về tài liệu?
+
+- 💬 **Slack:** #oht50-docs
+- 📧 **Email:** docs@oht50.com
+- 🐛 **Issues:** GitHub Issues với tag `documentation`
+
+---
+
+## 🏆 **ACKNOWLEDGMENTS**
+
+**Người đóng góp:**
+- PM Team - Documentation lead
+- Firmware Team - Technical review
+- QA Team - Testing và validation
+
+---
+
+**Tổng kết:** Đã hoàn thành **100%** tài liệu cần thiết cho firmware OHT-50! 🎉
+
+**Ngày hoàn thành:** 2025-10-07  
+**Version:** 1.0.1  
+**Status:** ✅ **PRODUCTION READY**
+

--- a/firmware_new/docs/05-FORMS_RECORDS/REC-007_LiDAR_HAL_Implementation.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/REC-007_LiDAR_HAL_Implementation.md
@@ -1,0 +1,430 @@
+# 🚀 **LiDAR HAL Implementation Summary - Complete**
+
+**Phiên bản:** 2.3.0  
+**Ngày cập nhật:** 2025-01-28  
+**Team:** EMBED  
+**Mục tiêu:** Tổng hợp toàn bộ implementation LiDAR HAL enhancement
+
+---
+
+## 📋 **TỔNG QUAN IMPLEMENTATION**
+
+### **LiDAR HAL Enhancement Project**
+Dự án nâng cấp LiDAR HAL từ phiên bản cơ bản lên **v2.3.0** với 4 giai đoạn chính:
+
+1. **Week 1-2: Enhanced Resolution System** (v2.0.0)
+2. **Week 3-4: Advanced Multi-Sample & Calibration** (v2.1.0)
+3. **Week 5-6: Multi-Threading & Memory Pool** (v2.2.0)
+4. **Week 7-8: Adaptive Processing & Hardware Acceleration** (v2.3.0)
+
+### **Kết quả đạt được:**
+- ✅ **4 giai đoạn** hoàn thành 100%
+- ✅ **Tất cả features** implemented và tested
+- ✅ **Project structure** được chuẩn hóa
+- ✅ **Documentation** đầy đủ
+- ✅ **Performance targets** đạt được
+
+---
+
+## 🎯 **PERFORMANCE ACHIEVEMENTS**
+
+### **Overall Performance Improvement**
+| Metric | Baseline | Enhanced | Improvement |
+|--------|----------|----------|-------------|
+| **Resolution** | 0.72° | 0.18° | **+300%** |
+| **Accuracy** | ±30mm | ±15mm | **+100%** |
+| **Efficiency** | 60% | 95% | **+58%** |
+| **Throughput** | 1000 ops/s | 2079 ops/s | **+108%** |
+| **Latency** | 15ms | 6.72ms | **-55%** |
+| **Power** | 8000mW | 4600mW | **-43%** |
+| **Temperature** | 55°C | 43°C | **-22%** |
+
+### **Feature-Specific Improvements**
+| Feature | Improvement | Target | Achieved |
+|---------|-------------|--------|----------|
+| **Adaptive Processing** | 70% efficiency | >50% | ✅ **70%** |
+| **Hardware Acceleration** | 50% throughput | >30% | ✅ **50%** |
+| **Load Balancing** | 30% efficiency | >20% | ✅ **30%** |
+| **Performance Scaling** | 40% power reduction | >30% | ✅ **40%** |
+
+---
+
+## 📁 **PROJECT STRUCTURE**
+
+### **Final Project Organization**
+```bash
+firmware_new/
+├── src/hal/peripherals/              # ✅ Source code (clean)
+│   ├── hal_lidar.h                   # v2.3.0 - Complete API
+│   ├── hal_lidar.c                   # v2.3.0 - Complete implementation
+│   ├── hal_led.c/h                   # Existing
+│   └── hal_relay.c/h                 # Existing
+├── tests/hal/peripherals/            # ✅ Test files
+│   ├── test_lidar_enhanced.c         # Enhanced resolution test
+│   ├── test_lidar_advanced.c         # Advanced multi-sample test
+│   ├── test_lidar_multithreading.c   # Multi-threading test
+│   ├── test_lidar_adaptive.c         # Adaptive processing test
+│   └── Makefile.enhanced             # Build system
+├── build/hal/peripherals/            # ✅ Build artifacts
+│   ├── *.o files                     # Object files
+│   └── test executables              # Test programs
+└── docs/05-IMPLEMENTATION/FIRMWARE/02-HAL/
+    ├── LIDAR_ENHANCED_RESOLUTION_GUIDE.md
+    ├── LIDAR_ADVANCED_MULTI_SAMPLE_GUIDE.md
+    ├── LIDAR_MULTI_THREADING_GUIDE.md
+    ├── LIDAR_ADAPTIVE_PROCESSING_GUIDE.md
+    ├── LIDAR_HAL_API_REFERENCE.md
+    └── LIDAR_HAL_IMPLEMENTATION_SUMMARY.md
+```
+
+---
+
+## 🔧 **IMPLEMENTATION DETAILS**
+
+### **1. Enhanced Resolution System (v2.0.0)**
+
+#### **Features Implemented:**
+- ✅ **Adaptive Resolution** với base/focus resolution
+- ✅ **Focus Area Control** với angle range
+- ✅ **Dynamic Resolution** adjustment
+- ✅ **Configuration Management**
+
+#### **API Functions:**
+```c
+hal_lidar_set_adaptive_resolution()
+hal_lidar_set_focus_area()
+hal_lidar_get_adaptive_status()
+```
+
+#### **Data Structures:**
+```c
+lidar_adaptive_config_t
+```
+
+#### **Constants:**
+```c
+LIDAR_BASE_RESOLUTION_DEG = 0.72°
+LIDAR_FOCUS_RESOLUTION_DEG = 0.36°
+LIDAR_MIN_RESOLUTION_DEG = 0.18°
+LIDAR_MAX_RESOLUTION_DEG = 1.44°
+```
+
+### **2. Advanced Multi-Sample & Calibration (v2.1.0)**
+
+#### **Features Implemented:**
+- ✅ **Statistical Averaging** với confidence intervals
+- ✅ **Real-time Outlier Detection** với Z-score method
+- ✅ **Dynamic Calibration** với multiple reference points
+- ✅ **Temporal Filtering** across multiple scans
+- ✅ **Weighted Averaging** based on signal quality
+- ✅ **Calibration Drift Detection**
+
+#### **API Functions:**
+```c
+hal_lidar_configure_accuracy()
+hal_lidar_configure_advanced_accuracy()
+hal_lidar_enable_statistical_averaging()
+hal_lidar_calibrate_distance()
+hal_lidar_apply_calibration()
+hal_lidar_auto_calibrate()
+hal_lidar_calibrate_multiple_points()
+hal_lidar_detect_calibration_drift()
+```
+
+#### **Data Structures:**
+```c
+lidar_accuracy_config_t
+lidar_calibration_t
+lidar_calibration_point_t
+```
+
+#### **Constants:**
+```c
+LIDAR_MAX_SAMPLE_COUNT = 20
+LIDAR_DEFAULT_CONFIDENCE = 0.95
+LIDAR_MAX_CALIBRATION_POINTS = 10
+```
+
+### **3. Multi-Threading & Memory Pool (v2.2.0)**
+
+#### **Features Implemented:**
+- ✅ **Multi-threading Architecture** với 6 threads
+- ✅ **Memory Pool Management** với 1MB pool
+- ✅ **Thread Priority & CPU Affinity** control
+- ✅ **Memory Allocation/Deallocation** với statistics
+- ✅ **Thread Safety** với mutex protection
+- ✅ **Memory Compaction** và optimization
+
+#### **API Functions:**
+```c
+hal_lidar_configure_threading()
+hal_lidar_enable_parallel_processing()
+hal_lidar_set_thread_priority()
+hal_lidar_set_thread_affinity()
+hal_lidar_configure_memory_pool()
+hal_lidar_allocate_memory_block()
+hal_lidar_deallocate_memory_block()
+hal_lidar_compact_memory_pool()
+```
+
+#### **Data Structures:**
+```c
+lidar_threading_config_t
+lidar_memory_pool_t
+```
+
+#### **Constants:**
+```c
+LIDAR_MAX_THREADS = 6
+LIDAR_DEFAULT_THREAD_COUNT = 4
+LIDAR_THREAD_STACK_SIZE = 65536
+LIDAR_MEMORY_POOL_SIZE = 1048576
+LIDAR_MEMORY_BLOCK_SIZE = 4096
+LIDAR_MAX_MEMORY_BLOCKS = 256
+```
+
+### **4. Adaptive Processing & Hardware Acceleration (v2.3.0)**
+
+#### **Features Implemented:**
+- ✅ **Adaptive Processing System** với dynamic optimization
+- ✅ **Hardware Acceleration** support cho GPU/DSP/NEON
+- ✅ **Intelligent Load Balancing** với workload distribution
+- ✅ **Dynamic Performance Scaling** với adaptive algorithms
+- ✅ **Real-time Optimization** với continuous improvement
+- ✅ **Performance Metrics** và power/thermal monitoring
+
+#### **API Functions:**
+```c
+hal_lidar_configure_adaptive_processing()
+hal_lidar_enable_adaptive_processing()
+hal_lidar_get_adaptive_processing_status()
+hal_lidar_configure_hardware_acceleration()
+hal_lidar_enable_hardware_acceleration()
+hal_lidar_get_hardware_acceleration_status()
+hal_lidar_configure_load_balancing()
+hal_lidar_enable_load_balancing()
+hal_lidar_get_load_balancing_status()
+hal_lidar_configure_performance_scaling()
+hal_lidar_enable_performance_scaling()
+hal_lidar_get_performance_scaling_status()
+hal_lidar_optimize_performance()
+hal_lidar_scale_performance()
+hal_lidar_balance_workload()
+hal_lidar_get_performance_metrics()
+hal_lidar_get_power_consumption()
+hal_lidar_get_thermal_status()
+```
+
+#### **Data Structures:**
+```c
+lidar_adaptive_processing_config_t
+lidar_hardware_acceleration_config_t
+lidar_load_balancing_config_t
+lidar_performance_scaling_config_t
+```
+
+#### **Constants:**
+```c
+LIDAR_ADAPTIVE_MAX_ALGORITHMS = 6
+LIDAR_ADAPTIVE_UPDATE_INTERVAL = 100ms
+LIDAR_ADAPTIVE_LEARNING_RATE = 0.15
+LIDAR_HW_ACCEL_MAX_DEVICES = 3
+LIDAR_HW_ACCEL_BATCH_SIZE = 128
+LIDAR_LOAD_BALANCE_MAX_WORKLOADS = 8
+LIDAR_PERF_SCALE_MIN_FREQ = 200MHz
+LIDAR_PERF_SCALE_MAX_FREQ = 2400MHz
+```
+
+---
+
+## 🧪 **TESTING IMPLEMENTATION**
+
+### **Test Programs Created:**
+1. **`test_lidar_enhanced.c`** - Enhanced resolution system test
+2. **`test_lidar_advanced.c`** - Advanced multi-sample & calibration test
+3. **`test_lidar_multithreading.c`** - Multi-threading & memory pool test
+4. **`test_lidar_adaptive.c`** - Adaptive processing & hardware acceleration test
+
+### **Test Coverage:**
+- ✅ **All API functions** tested
+- ✅ **All data structures** validated
+- ✅ **All error conditions** handled
+- ✅ **All performance metrics** verified
+- ✅ **All configuration options** tested
+
+### **Build System:**
+- ✅ **Makefile.enhanced** với proper paths
+- ✅ **Build artifacts** trong `build/` directory
+- ✅ **Source directory** clean
+- ✅ **Test execution** automated
+
+---
+
+## 📊 **CODE METRICS**
+
+### **Source Code Statistics:**
+| File | Lines | Functions | Features |
+|------|-------|-----------|----------|
+| **hal_lidar.h** | 410 | 50+ | Complete API |
+| **hal_lidar.c** | 3260 | 100+ | Complete implementation |
+| **test_lidar_enhanced.c** | 231 | 10+ | Enhanced test |
+| **test_lidar_advanced.c** | 249 | 15+ | Advanced test |
+| **test_lidar_multithreading.c** | 311 | 20+ | Multi-threading test |
+| **test_lidar_adaptive.c** | 428 | 25+ | Adaptive test |
+| **Makefile.enhanced** | 144 | - | Build system |
+
+### **Total Implementation:**
+- **Source Code:** 4,670+ lines
+- **Test Code:** 1,219+ lines
+- **Documentation:** 2,000+ lines
+- **Total:** 7,889+ lines
+
+---
+
+## 🔍 **ERROR HANDLING**
+
+### **Error Codes Implemented:**
+```c
+HAL_OK = 0                      // Success
+HAL_ERROR = -1                  // General error
+HAL_ERROR_INVALID_PARAM = -2    // Invalid parameter
+HAL_ERROR_NOT_INITIALIZED = -3  // Not initialized
+HAL_ERROR_ALREADY_INITIALIZED = -4 // Already initialized
+HAL_ERROR_HARDWARE_FAILURE = -5 // Hardware failure
+HAL_ERROR_MEMORY_ALLOCATION = -6 // Memory allocation failure
+HAL_ERROR_THREAD_CREATION = -7  // Thread creation failure
+HAL_ERROR_TIMEOUT = -8          // Timeout
+HAL_ERROR_NOT_SUPPORTED = -9    // Not supported
+```
+
+### **Error Handling Features:**
+- ✅ **Parameter validation** cho tất cả functions
+- ✅ **State checking** trước khi execute
+- ✅ **Resource cleanup** khi error
+- ✅ **Error logging** với detailed messages
+- ✅ **Graceful degradation** khi features fail
+
+---
+
+## 🚀 **DEPLOYMENT READY**
+
+### **Production Readiness:**
+- ✅ **All features** implemented và tested
+- ✅ **Performance targets** achieved
+- ✅ **Error handling** comprehensive
+- ✅ **Documentation** complete
+- ✅ **Build system** automated
+- ✅ **Project structure** standardized
+
+### **Integration Points:**
+- ✅ **Backend API** integration ready
+- ✅ **Frontend UI** integration ready
+- ✅ **Firmware** integration ready
+- ✅ **Hardware** integration ready
+
+### **Maintenance:**
+- ✅ **Code organization** clear
+- ✅ **Documentation** up-to-date
+- ✅ **Test coverage** comprehensive
+- ✅ **Build system** automated
+
+---
+
+## 📚 **DOCUMENTATION COMPLETED**
+
+### **Documentation Files:**
+1. **`LIDAR_ENHANCED_RESOLUTION_GUIDE.md`** - Enhanced resolution system
+2. **`LIDAR_ADVANCED_MULTI_SAMPLE_GUIDE.md`** - Advanced multi-sample & calibration
+3. **`LIDAR_MULTI_THREADING_GUIDE.md`** - Multi-threading & memory pool
+4. **`LIDAR_ADAPTIVE_PROCESSING_GUIDE.md`** - Adaptive processing & hardware acceleration
+5. **`LIDAR_HAL_API_REFERENCE.md`** - Complete API reference
+6. **`LIDAR_HAL_IMPLEMENTATION_SUMMARY.md`** - This summary
+
+### **Documentation Features:**
+- ✅ **Complete API reference** với examples
+- ✅ **Usage examples** cho tất cả features
+- ✅ **Configuration guides** detailed
+- ✅ **Performance benchmarks** documented
+- ✅ **Troubleshooting guides** included
+- ✅ **Error handling** documented
+
+---
+
+## 🎯 **SUCCESS CRITERIA ACHIEVED**
+
+### **Technical Requirements:**
+- ✅ **Performance targets** exceeded
+- ✅ **Feature completeness** 100%
+- ✅ **Code quality** high
+- ✅ **Test coverage** comprehensive
+- ✅ **Documentation** complete
+
+### **Project Requirements:**
+- ✅ **Timeline** on schedule
+- ✅ **Quality** high
+- ✅ **Maintainability** excellent
+- ✅ **Scalability** future-ready
+- ✅ **Integration** ready
+
+### **Team Requirements:**
+- ✅ **Knowledge transfer** complete
+- ✅ **Training materials** available
+- ✅ **Support documentation** ready
+- ✅ **Troubleshooting guides** available
+
+---
+
+## 🔄 **NEXT STEPS**
+
+### **Immediate Actions:**
+1. **Integration testing** với backend/frontend
+2. **Performance validation** trong production environment
+3. **User acceptance testing** với real hardware
+4. **Documentation review** và finalization
+
+### **Future Enhancements:**
+1. **Machine learning** integration cho adaptive algorithms
+2. **Cloud connectivity** cho remote monitoring
+3. **Advanced analytics** cho performance optimization
+4. **Mobile app** integration cho remote control
+
+---
+
+## 🏆 **PROJECT SUCCESS**
+
+### **Achievements:**
+- ✅ **4 major features** implemented successfully
+- ✅ **Performance improvements** exceeded targets
+- ✅ **Code quality** maintained high standards
+- ✅ **Documentation** comprehensive và professional
+- ✅ **Project structure** standardized và maintainable
+
+### **Impact:**
+- 🚀 **LiDAR performance** improved by 300%+
+- 🚀 **System efficiency** improved by 58%
+- 🚀 **Power consumption** reduced by 43%
+- 🚀 **Development productivity** increased significantly
+- 🚀 **Maintenance effort** reduced substantially
+
+---
+
+## 📞 **SUPPORT & MAINTENANCE**
+
+### **Support Resources:**
+- **Documentation:** Complete guides available
+- **Test Programs:** Comprehensive test suite
+- **API Reference:** Detailed function documentation
+- **Troubleshooting:** Common issues và solutions
+- **Performance Monitoring:** Built-in metrics
+
+### **Maintenance Schedule:**
+- **Weekly:** Performance monitoring
+- **Monthly:** Documentation updates
+- **Quarterly:** Feature enhancements
+- **Annually:** Major version updates
+
+---
+
+**🎯 LiDAR HAL v2.3.0 Implementation - COMPLETE SUCCESS!**
+
+**Ready for production deployment với comprehensive features, excellent performance, và complete documentation.**

--- a/firmware_new/docs/05-FORMS_RECORDS/REC-008_CTO_Refactor_Order.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/REC-008_CTO_Refactor_Order.md
@@ -1,0 +1,622 @@
+# 🚨 **CTO REFACTOR ORDER - OHT-50 FIRMWARE**
+
+**Phiên bản:** 1.0  
+**Ngày ra lệnh:** 2025-01-28  
+**Người ra lệnh:** CTO Team  
+**Trạng thái:** ✅ IMMEDIATE EXECUTION REQUIRED  
+**Mục tiêu:** Tái cấu trúc firmware theo kiến trúc an toàn đã được phê duyệt
+
+---
+
+## 🎯 **LỆNH TÁI CẤU TRÚC FIRMWARE**
+
+### **📋 YÊU CẦU THỰC HIỆN NGAY LẬP TỨC:**
+
+**1. SAO LƯU DỮ LIỆU HIỆN TẠI**
+```bash
+# Tạo backup toàn bộ firmware hiện tại
+cd /home/orangepi/Desktop/OHT_V2
+cp -r firmware_new firmware_backup_$(date +%Y%m%d_%H%M%S)
+tar -czf firmware_backup_$(date +%Y%m%d_%H%M%S).tar.gz firmware_backup_*
+```
+
+**2. PHÂN TÍCH VÀ THIẾT KẾ LẠI KIẾN TRÚC**
+- ✅ **Kiến trúc 4-layer đã được phê duyệt**
+- ✅ **Safety-first approach đã được thiết kế**
+- ✅ **Real-time requirements đã được định nghĩa**
+- ✅ **Security framework đã được lập kế hoạch**
+
+**3. ÁP DỤNG TIÊU CHUẨN VÀ THỰC HÀNH TỐT NHẤT**
+- ✅ **Bảo mật:** TLS 1.3, Bearer token, Secure boot
+- ✅ **Modular hóa:** Kiến trúc 4-layer với clear separation
+- ✅ **Tuân thủ tiêu chuẩn:** ISO/IEC 12207, MISRA C:2012
+- ✅ **Safety compliance:** SIL 2, E-Stop < 100ms
+
+---
+
+## 🏗️ **KIẾN TRÚC TÁI CẤU TRÚC ĐÃ PHÊ DUYỆT**
+
+### **4-Layer Architecture:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OHT-50 FIRMWARE APP                     │
+├─────────────────────────────────────────────────────────────┤
+│  🎯 APPLICATION LAYER (App Logic & API)                    │
+│  ├─ State Machine, Module Handlers, API Endpoints          │
+│  ├─ Safety Monitor, Control Logic, Communication           │
+│  └─ Configuration, Logging, Diagnostics                    │
+├─────────────────────────────────────────────────────────────┤
+│  🛡️ SAFETY LAYER (Safety-Critical Systems)                 │
+│  ├─ E-Stop System, Safety Interlocks, Watchdog            │
+│  ├─ Emergency Procedures, Fault Detection                  │
+│  └─ Safety State Machine, Hazard Analysis                 │
+├─────────────────────────────────────────────────────────────┤
+│  ⚙️ HAL LAYER (Hardware Abstraction)                       │
+│  ├─ RS485 HAL, GPIO HAL, Network HAL                       │
+│  ├─ LED HAL, Relay HAL, Sensor HAL                         │
+│  └─ Platform Abstraction, Driver Interface                 │
+├─────────────────────────────────────────────────────────────┤
+│  🔧 DRIVER LAYER (Platform-Specific Drivers)               │
+│  ├─ UART Drivers, GPIO Drivers, Network Drivers             │
+│  ├─ Hardware Drivers, System Drivers                       │
+│  └─ Orange Pi 5B Specific, RK3588 Drivers                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 📋 **KẾ HOẠCH THỰC HIỆN 3 PHASE**
+
+### **🚀 PHASE 1: FOUNDATION & SAFETY (Weeks 1-4)**
+**Mục tiêu:** Xây dựng nền tảng an toàn và cấu trúc cơ bản
+
+#### **Week 1-2: Core Foundation**
+- [ ] **Project Structure Setup**
+  - [ ] Tạo cấu trúc thư mục theo kiến trúc 4-layer
+  - [ ] Setup CMake build system
+  - [ ] Configure development environment
+  - [ ] Setup version control và CI/CD
+
+- [ ] **Safety Layer Implementation**
+  - [ ] E-Stop system với response time < 100ms
+  - [ ] Safety interlock system
+  - [ ] Watchdog system với timeout 1s
+  - [ ] Emergency procedures
+  - [ ] Safety state machine
+
+#### **Week 3-4: HAL Layer**
+- [ ] **Hardware Abstraction Layer**
+  - [ ] RS485 HAL implementation
+  - [ ] GPIO HAL implementation
+  - [ ] Network HAL implementation
+  - [ ] LED HAL implementation
+  - [ ] Relay HAL implementation
+
+- [ ] **Driver Layer**
+  - [ ] Orange Pi 5B platform drivers
+  - [ ] RK3588 SoC drivers
+  - [ ] UART driver implementation
+  - [ ] GPIO driver implementation
+
+### **🚀 PHASE 2: APPLICATION LAYER (Weeks 5-8)**
+**Mục tiêu:** Triển khai logic ứng dụng và quản lý module
+
+#### **Week 5-6: Core Application**
+- [ ] **Application Controller**
+  - [ ] Main application controller
+  - [ ] System state machine
+  - [ ] Control loop implementation
+  - [ ] System coordination
+
+- [ ] **Module Management**
+  - [ ] Power module handler
+  - [ ] Safety module handler
+  - [ ] Motor module handler
+  - [ ] Dock module handler
+
+#### **Week 7-8: Communication & API**
+- [ ] **Communication Systems**
+  - [ ] HTTP API server implementation
+  - [ ] Modbus RTU handler
+  - [ ] Telemetry system
+  - [ ] Real-time communication
+
+- [ ] **Configuration Management**
+  - [ ] Configuration manager
+  - [ ] Configuration storage
+  - [ ] Configuration validation
+  - [ ] Dynamic configuration updates
+
+### **🚀 PHASE 3: INTEGRATION & TESTING (Weeks 9-12)**
+**Mục tiêu:** Tích hợp toàn bộ hệ thống và kiểm thử
+
+#### **Week 9-10: System Integration**
+- [ ] **End-to-End Integration**
+  - [ ] Application ↔ Safety layer integration
+  - [ ] Safety ↔ HAL layer integration
+  - [ ] HAL ↔ Driver layer integration
+  - [ ] Complete system integration
+
+- [ ] **Performance Optimization**
+  - [ ] Real-time performance tuning
+  - [ ] Memory optimization
+  - [ ] CPU usage optimization
+  - [ ] Network latency optimization
+
+#### **Week 11-12: Testing & Validation**
+- [ ] **Comprehensive Testing**
+  - [ ] Unit tests (90%+ coverage)
+  - [ ] Integration tests
+  - [ ] Safety tests
+  - [ ] Performance tests
+  - [ ] HIL (Hardware-in-the-Loop) tests
+
+- [ ] **Safety Validation**
+  - [ ] SIL 2 compliance validation
+  - [ ] E-Stop response time validation
+  - [ ] Safety interlock validation
+  - [ ] Emergency procedure validation
+
+---
+
+## 🛡️ **SAFETY REQUIREMENTS - CRITICAL**
+
+### **1. Safety Integrity Level (SIL)**
+- **SIL Level:** SIL 2 (Basic Safety)
+- **Safety Functions:** E-Stop, Safety Interlocks, Watchdog
+- **Failure Rate:** < 10^-6 failures/hour
+- **Response Time:** E-Stop < 100ms
+- **Safety Validation:** Hardware-in-the-Loop testing
+
+### **2. Safety Architecture Principles**
+```c
+// Safety-critical function example
+int safety_emergency_stop(void) {
+    // CRITICAL: Must complete within 100ms
+    uint32_t start_time = get_system_time_ms();
+    
+    // 1. Hardware E-Stop (highest priority)
+    if (hardware_estop_active()) {
+        gpio_hal_emergency_off_all();
+        relay_hal_emergency_off_all();
+        motor_hal_emergency_stop();
+        return SAFETY_ESTOP_HARDWARE;
+    }
+    
+    // 2. Software E-Stop
+    if (software_estop_triggered()) {
+        motor_hal_emergency_stop();
+        return SAFETY_ESTOP_SOFTWARE;
+    }
+    
+    // 3. Safety zone violation
+    if (safety_zone_violated()) {
+        motor_hal_emergency_stop();
+        return SAFETY_ESTOP_ZONE;
+    }
+    
+    // Validate response time
+    uint32_t response_time = get_system_time_ms() - start_time;
+    if (response_time > 100) {
+        // CRITICAL: Response time exceeded
+        log_critical_error("E-Stop response time exceeded: %dms", response_time);
+        return SAFETY_ERROR_TIMEOUT;
+    }
+    
+    return SAFETY_OK;
+}
+```
+
+---
+
+## ⚡ **REAL-TIME REQUIREMENTS**
+
+### **1. Real-time Constraints**
+- **Control Loop:** 10ms cycle time
+- **Safety Check:** 5ms cycle time
+- **Communication:** 50ms timeout
+- **E-Stop Response:** < 100ms
+- **Watchdog:** 1s timeout
+
+### **2. Real-time Implementation**
+```c
+// Real-time control loop
+void control_loop_task(void) {
+    static uint32_t last_cycle_time = 0;
+    uint32_t current_time = get_system_time_ms();
+    
+    // Ensure 10ms cycle time
+    if (current_time - last_cycle_time < 10) {
+        return; // Too early for next cycle
+    }
+    
+    // Update cycle time
+    last_cycle_time = current_time;
+    
+    // Execute control logic
+    control_loop_execute();
+    
+    // Update safety status
+    safety_monitor_check();
+    
+    // Send telemetry
+    telemetry_send_update();
+}
+```
+
+---
+
+## 🔒 **SECURITY REQUIREMENTS**
+
+### **1. Security Architecture**
+- **Authentication:** Bearer token validation
+- **Authorization:** Role-based access control
+- **Encryption:** TLS 1.3 for network communication
+- **Secure Boot:** Verified boot sequence
+- **Secure Storage:** Encrypted configuration storage
+
+### **2. Security Implementation**
+```c
+// Security functions
+int security_validate_token(const char *token);
+int security_check_permissions(uint8_t user_id, uint8_t operation);
+int security_encrypt_data(uint8_t *data, size_t len, uint8_t *encrypted);
+int security_decrypt_data(uint8_t *encrypted, size_t len, uint8_t *data);
+```
+
+---
+
+## 📊 **PERFORMANCE REQUIREMENTS**
+
+### **1. Performance Metrics**
+- **CPU Usage:** < 60% average
+- **Memory Usage:** < 512MB
+- **Response Time:** API < 50ms
+- **Throughput:** 1000+ requests/second
+- **Latency:** Network < 10ms
+
+### **2. Performance Monitoring**
+```c
+// Performance monitoring
+typedef struct {
+    uint32_t cpu_usage_percent;
+    uint32_t memory_usage_mb;
+    uint32_t response_time_ms;
+    uint32_t throughput_rps;
+    uint32_t error_count;
+} performance_metrics_t;
+
+int performance_monitor_init(void);
+int performance_monitor_update(performance_metrics_t *metrics);
+int performance_monitor_check_thresholds(void);
+```
+
+---
+
+## 🧪 **TESTING STRATEGY**
+
+### **1. Testing Levels**
+- **Unit Tests:** Individual function testing
+- **Integration Tests:** Module integration testing
+- **Safety Tests:** Safety-critical function testing
+- **Performance Tests:** Real-time performance testing
+- **HIL Tests:** Hardware-in-the-Loop testing
+
+### **2. Test Implementation**
+```c
+// Test framework
+int test_safety_estop_response_time(void) {
+    uint32_t start_time = get_system_time_ms();
+    int result = safety_emergency_stop();
+    uint32_t response_time = get_system_time_ms() - start_time;
+    
+    // Assert response time < 100ms
+    assert(response_time < 100);
+    assert(result == SAFETY_OK);
+    
+    return TEST_PASS;
+}
+```
+
+---
+
+## 🚀 **DEPLOYMENT STRATEGY**
+
+### **1. Build Configuration**
+```cmake
+# CMakeLists.txt
+cmake_minimum_required(VERSION 3.16)
+project(OHT50_Firmware)
+
+# Safety configuration
+set(SAFETY_LEVEL SIL2)
+set(RESPONSE_TIME_MS 100)
+set(WATCHDOG_TIMEOUT_MS 1000)
+
+# Platform configuration
+set(PLATFORM OrangePi5B)
+set(SOC RK3588)
+
+# Build targets
+add_executable(firmware_app src/main.c)
+target_link_libraries(firmware_app hal drivers common)
+```
+
+### **2. Deployment Process**
+```bash
+# Build script
+#!/bin/bash
+./scripts/build.sh Release
+./scripts/test.sh
+./scripts/safety_test.sh
+./scripts/deploy.sh
+```
+
+---
+
+## 📋 **IMPLEMENTATION CHECKLIST**
+
+### **Phase 1: Foundation & Safety**
+- [ ] Project structure setup
+- [ ] Safety layer implementation
+- [ ] HAL layer implementation
+- [ ] Driver layer implementation
+- [ ] Unit tests
+- [ ] Safety validation tests
+
+### **Phase 2: Application Layer**
+- [ ] Application controller
+- [ ] Module management
+- [ ] Communication systems
+- [ ] API server
+- [ ] Configuration management
+- [ ] Integration tests
+
+### **Phase 3: Integration & Testing**
+- [ ] End-to-end integration
+- [ ] Performance optimization
+- [ ] Comprehensive testing
+- [ ] Safety validation
+- [ ] Production readiness
+
+---
+
+## 🎯 **SUCCESS CRITERIA**
+
+### **Technical Criteria**
+- ✅ **Safety:** SIL 2 compliance, E-Stop < 100ms
+- ✅ **Performance:** Real-time constraints met
+- ✅ **Reliability:** 99.9% uptime target
+- ✅ **Security:** Authentication, encryption, secure boot
+- ✅ **Maintainability:** Modular architecture, comprehensive tests
+
+### **Quality Criteria**
+- ✅ **Code Quality:** MISRA C:2012 compliance
+- ✅ **Documentation:** Complete API and architecture docs
+- ✅ **Testing:** 90%+ code coverage
+- ✅ **Performance:** All performance targets met
+- ✅ **Safety:** All safety requirements validated
+
+---
+
+## 🔄 **MAINTENANCE & UPDATES**
+
+### **1. Update Strategy**
+- **OTA Updates:** Secure over-the-air updates
+- **Rollback Capability:** Safe rollback to previous version
+- **Version Control:** Semantic versioning
+- **Change Management:** Controlled change process
+
+### **2. Monitoring & Diagnostics**
+- **Health Monitoring:** System health checks
+- **Performance Monitoring:** Real-time performance metrics
+- **Error Logging:** Comprehensive error logging
+- **Diagnostic Tools:** Built-in diagnostic capabilities
+
+---
+
+## 🚨 **LỆNH THỰC HIỆN NGAY LẬP TỨC**
+
+### **1. BẮT ĐẦU PHASE 1 - FOUNDATION & SAFETY**
+```bash
+# Tạo cấu trúc thư mục mới
+cd /home/orangepi/Desktop/OHT_V2/firmware_new
+mkdir -p src/{app/{core,safety,modules,communication,configuration},hal,drivers/{orange_pi_5b,rk3588},common}
+mkdir -p include/{app,hal,drivers,common}
+mkdir -p tests/{unit,integration,safety,performance}
+mkdir -p scripts config docs/{architecture,api,safety,user_guide}
+```
+
+### **2. SETUP BUILD SYSTEM**
+```bash
+# Tạo CMakeLists.txt
+cat > CMakeLists.txt << 'EOF'
+cmake_minimum_required(VERSION 3.16)
+project(OHT50_Firmware)
+
+# Safety configuration
+set(SAFETY_LEVEL SIL2)
+set(ESTOP_RESPONSE_TIME_MS 100)
+set(WATCHDOG_TIMEOUT_MS 1000)
+
+# Platform configuration
+set(PLATFORM OrangePi5B)
+set(SOC RK3588)
+
+# Compiler flags
+set(CMAKE_C_FLAGS "-Wall -Wextra -Werror -std=c99")
+set(CMAKE_C_FLAGS_DEBUG "-g -O0 -DDEBUG")
+set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+
+# Include directories
+include_directories(include)
+include_directories(src)
+
+# Source files
+set(SOURCES
+    src/main.c
+    src/app/core/app_controller.c
+    src/app/safety/safety_monitor.c
+    src/hal/rs485_hal.c
+    src/drivers/orange_pi_5b/platform_driver.c
+)
+
+# Create executable
+add_executable(firmware_app ${SOURCES})
+
+# Link libraries
+target_link_libraries(firmware_app pthread rt)
+
+# Install
+install(TARGETS firmware_app DESTINATION /usr/local/bin)
+EOF
+```
+
+### **3. TẠO SCRIPT BUILD**
+```bash
+# Tạo build script
+cat > scripts/build.sh << 'EOF'
+#!/bin/bash
+set -e
+
+echo "🚀 Building OHT-50 Firmware..."
+
+# Create build directory
+mkdir -p build
+cd build
+
+# Configure CMake
+cmake .. -DCMAKE_BUILD_TYPE=Release
+
+# Build
+make -j$(nproc)
+
+echo "✅ Build completed successfully!"
+EOF
+
+chmod +x scripts/build.sh
+```
+
+### **4. TẠO SCRIPT TEST**
+```bash
+# Tạo test script
+cat > scripts/test.sh << 'EOF'
+#!/bin/bash
+set -e
+
+echo "🧪 Running OHT-50 Firmware Tests..."
+
+# Run unit tests
+echo "Running unit tests..."
+./build/tests/unit/unit_tests
+
+# Run integration tests
+echo "Running integration tests..."
+./build/tests/integration/integration_tests
+
+# Run safety tests
+echo "Running safety tests..."
+./build/tests/safety/safety_tests
+
+echo "✅ All tests passed!"
+EOF
+
+chmod +x scripts/test.sh
+```
+
+### **5. TẠO SCRIPT SAFETY TEST**
+```bash
+# Tạo safety test script
+cat > scripts/safety_test.sh << 'EOF'
+#!/bin/bash
+set -e
+
+echo "🛡️ Running OHT-50 Safety Tests..."
+
+# Test E-Stop response time
+echo "Testing E-Stop response time..."
+./build/tests/safety/test_estop_response_time
+
+# Test safety interlocks
+echo "Testing safety interlocks..."
+./build/tests/safety/test_safety_interlocks
+
+# Test watchdog system
+echo "Testing watchdog system..."
+./build/tests/safety/test_watchdog_system
+
+echo "✅ All safety tests passed!"
+EOF
+
+chmod +x scripts/safety_test.sh
+```
+
+---
+
+## 📋 **TIMELINE & MILESTONES**
+
+### **Week 1-2: Foundation Setup**
+- [ ] Project structure created
+- [ ] Build system configured
+- [ ] Development environment setup
+- [ ] Version control configured
+
+### **Week 3-4: Safety Implementation**
+- [ ] E-Stop system implemented
+- [ ] Safety interlocks implemented
+- [ ] Watchdog system implemented
+- [ ] Safety tests passing
+
+### **Week 5-6: HAL Implementation**
+- [ ] RS485 HAL implemented
+- [ ] GPIO HAL implemented
+- [ ] Network HAL implemented
+- [ ] Driver layer implemented
+
+### **Week 7-8: Application Layer**
+- [ ] Application controller implemented
+- [ ] Module management implemented
+- [ ] Communication systems implemented
+- [ ] API server implemented
+
+### **Week 9-10: Integration**
+- [ ] End-to-end integration completed
+- [ ] Performance optimization completed
+- [ ] Security implementation completed
+- [ ] Documentation updated
+
+### **Week 11-12: Testing & Validation**
+- [ ] Comprehensive testing completed
+- [ ] Safety validation completed
+- [ ] Performance validation completed
+- [ ] Production readiness achieved
+
+---
+
+## 🚨 **CTO DECISION: FIRMWARE REFACTOR ORDER**
+
+**Lệnh này yêu cầu firmware team thực hiện ngay lập tức:**
+
+1. **BẮT ĐẦU PHASE 1** - Foundation & Safety implementation
+2. **TUÂN THỦ KIẾN TRÚC** - 4-layer architecture đã được phê duyệt
+3. **ĐẢM BẢO AN TOÀN** - SIL 2 compliance, E-Stop < 100ms
+4. **THỰC HIỆN TESTING** - 90%+ code coverage, comprehensive safety tests
+5. **HOÀN THÀNH ĐÚNG HẠN** - 12 tuần theo timeline đã định
+
+**🚨 LƯU Ý: Đây là lệnh bắt buộc từ CTO. Firmware team phải thực hiện ngay lập tức và báo cáo tiến độ hàng tuần.**
+
+---
+
+**Changelog v1.0:**
+- ✅ Created CTO refactor order
+- ✅ Added 3-phase implementation roadmap
+- ✅ Added safety requirements
+- ✅ Added real-time requirements
+- ✅ Added security requirements
+- ✅ Added performance requirements
+- ✅ Added testing strategy
+- ✅ Added deployment strategy
+- ✅ Added success criteria
+- ✅ Added immediate execution commands
+
+**🚨 Lưu ý:** Lệnh này đảm bảo an toàn tối đa với SIL 2 compliance và response time < 100ms cho E-Stop system.

--- a/firmware_new/docs/05-FORMS_RECORDS/REC-009_Network_Tracking.md
+++ b/firmware_new/docs/05-FORMS_RECORDS/REC-009_Network_Tracking.md
@@ -1,0 +1,486 @@
+# 📊 OHT-50 Network Management - Tracking Plant Documentation
+
+**Version:** 1.0.0  
+**Date:** 2025-01-28  
+**Team:** Plant Operations & Network Monitoring  
+**Status:** 📋 Tracking & Monitoring Setup  
+**Priority:** 🔴 High - Critical for Plant Operations
+
+---
+
+## 🎯 **OVERVIEW**
+
+This document provides comprehensive tracking and monitoring procedures for OHT-50 Network Management system in industrial plant environments. It covers network performance monitoring, robot tracking, connectivity status, and operational metrics.
+
+---
+
+## 📊 **NETWORK TRACKING SYSTEM**
+
+### **OHT-50 Robot Tracking Architecture:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    PLANT NETWORK TRACKING                      │
+│                                                                 │
+│  ┌─────────────────┐    ┌─────────────────┐                   │
+│  │   OHT-50        │    │   Network       │                   │
+│  │   Tracking      │    │   Monitoring    │                   │
+│  │   System        │    │   System        │                   │
+│  │                 │    │                 │                   │
+│  │ • Robot Position│    │ • WiFi Signal   │                   │
+│  │ • Movement      │    │ • Connection    │                   │
+│  │ • Status        │    │ • Performance   │                   │
+│  │ • Telemetry     │    │ • Health        │                   │
+│  └─────────────────┘    └─────────────────┘                   │
+│           │                       │                           │
+│           └───────────┬───────────┘                           │
+│                       │                                       │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │              CENTRAL MONITORING SYSTEM                  │  │
+│  │  ┌─────────────────┐  ┌─────────────────┐              │  │
+│  │  │   Database      │  │   Dashboard     │              │  │
+│  │  │   (InfluxDB)    │  │   (Grafana)     │              │  │
+│  │  │                 │  │                 │              │  │
+│  │  │ • Time Series   │  │ • Real-time     │              │  │
+│  │  │ • Metrics       │  │   Monitoring    │              │  │
+│  │  │ • Alerts        │  │ • Charts        │              │  │
+│  │  │ • History       │  │ • Reports       │              │  │
+│  │  └─────────────────┘  └─────────────────┘              │  │
+│  └─────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### **Tracking Components:**
+- **Robot Position Tracking:** GPS/Encoder-based position monitoring
+- **Network Signal Monitoring:** WiFi signal strength and quality
+- **Connection Status:** Real-time connectivity status
+- **Performance Metrics:** Network throughput and latency
+- **Health Monitoring:** System health and diagnostics
+
+---
+
+## 📈 **TRACKING METRICS**
+
+### **Network Performance Metrics:**
+```json
+{
+  "network_metrics": {
+    "signal_strength": {
+      "current": -45,
+      "average": -50,
+      "min": -70,
+      "max": -30,
+      "unit": "dBm"
+    },
+    "connection_quality": {
+      "current": 95.5,
+      "average": 92.3,
+      "min": 75.0,
+      "max": 100.0,
+      "unit": "%"
+    },
+    "latency": {
+      "current": 5.2,
+      "average": 8.5,
+      "min": 2.1,
+      "max": 25.0,
+      "unit": "ms"
+    },
+    "throughput": {
+      "current": 85.2,
+      "average": 78.5,
+      "min": 45.0,
+      "max": 100.0,
+      "unit": "Mbps"
+    },
+    "packet_loss": {
+      "current": 0.1,
+      "average": 0.3,
+      "min": 0.0,
+      "max": 2.5,
+      "unit": "%"
+    }
+  }
+}
+```
+
+### **Robot Movement Metrics:**
+```json
+{
+  "robot_metrics": {
+    "position": {
+      "x": 1250.5,
+      "y": 850.3,
+      "z": 1200.0,
+      "unit": "mm"
+    },
+    "movement": {
+      "speed": 2.5,
+      "direction": "forward",
+      "acceleration": 0.8,
+      "unit": "m/s"
+    },
+    "status": {
+      "current": "moving",
+      "previous": "idle",
+      "duration": 45.2,
+      "unit": "seconds"
+    },
+    "battery": {
+      "level": 87.5,
+      "voltage": 24.1,
+      "current": 2.3,
+      "unit": "%"
+    }
+  }
+}
+```
+
+### **System Health Metrics:**
+```json
+{
+  "system_health": {
+    "overall_health": 95.5,
+    "network_health": 92.3,
+    "robot_health": 98.7,
+    "safety_health": 100.0,
+    "unit": "%"
+  },
+  "alerts": {
+    "critical": 0,
+    "warning": 2,
+    "info": 5,
+    "total": 7
+  },
+  "uptime": {
+    "system": 86400,
+    "network": 86350,
+    "robot": 86400,
+    "unit": "seconds"
+  }
+}
+```
+
+---
+
+## 🔍 **MONITORING DASHBOARD**
+
+### **Real-time Dashboard Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    OHT-50 MONITORING DASHBOARD                 │
+│                                                                 │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐ │
+│  │   Robot Status  │  │   Network       │  │   System        │ │
+│  │                 │  │   Status        │  │   Health        │ │
+│  │ • Position      │  │ • WiFi Signal   │  │ • Overall       │ │
+│  │ • Movement      │  │ • Connection    │  │ • Network       │ │
+│  │ • Battery       │  │ • Performance   │  │ • Robot         │ │
+│  │ • Status        │  │ • Latency       │  │ • Safety        │ │
+│  └─────────────────┘  └─────────────────┘  └─────────────────┘ │
+│                                                                 │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │              NETWORK PERFORMANCE CHART                  │   │
+│  │                                                         │   │
+│  │  Signal Strength: ████████████████████ 95%             │   │
+│  │  Connection:      ████████████████████ 98%             │   │
+│  │  Latency:         ████████████████████ 5ms             │   │
+│  │  Throughput:      ████████████████████ 85Mbps          │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │              ROBOT MOVEMENT TRACKING                    │   │
+│  │                                                         │   │
+│  │  Position: X=1250.5, Y=850.3, Z=1200.0                 │   │
+│  │  Speed: 2.5 m/s, Direction: Forward                     │   │
+│  │  Battery: 87.5%, Voltage: 24.1V                        │   │
+│  └─────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### **Dashboard Components:**
+- **Robot Status Panel:** Real-time robot position and status
+- **Network Status Panel:** WiFi signal and connection quality
+- **System Health Panel:** Overall system health indicators
+- **Performance Charts:** Network performance over time
+- **Movement Tracking:** Robot position and movement history
+- **Alert Panel:** Critical alerts and notifications
+
+---
+
+## 📊 **DATA COLLECTION**
+
+### **Data Collection Points:**
+```bash
+#!/bin/bash
+# Network data collection script
+# File: /usr/local/bin/collect-network-data.sh
+
+# Collect WiFi signal strength
+get_wifi_signal() {
+    iwconfig wlan0 | grep "Signal level" | awk '{print $4}' | cut -d'=' -f2
+}
+
+# Collect network latency
+get_network_latency() {
+    ping -c 5 192.168.100.1 | grep "avg" | cut -d'/' -f5
+}
+
+# Collect network throughput
+get_network_throughput() {
+    iperf3 -c 192.168.100.1 -t 10 | grep "sender" | awk '{print $7}'
+}
+
+# Collect robot position
+get_robot_position() {
+    # Read from encoder or GPS
+    echo "1250.5,850.3,1200.0"
+}
+
+# Collect robot status
+get_robot_status() {
+    # Read from robot control system
+    echo "moving"
+}
+
+# Main data collection function
+collect_data() {
+    local timestamp=$(date +%s)
+    local wifi_signal=$(get_wifi_signal)
+    local latency=$(get_network_latency)
+    local throughput=$(get_network_throughput)
+    local position=$(get_robot_position)
+    local status=$(get_robot_status)
+    
+    # Send to monitoring system
+    curl -X POST http://192.168.200.10:8086/write?db=oht50 \
+         -d "network,signal_strength=$wifi_signal,latency=$latency,throughput=$throughput,position=$position,status=$status timestamp=$timestamp"
+}
+
+# Run data collection every 5 seconds
+while true; do
+    collect_data
+    sleep 5
+done
+```
+
+### **Data Storage:**
+```json
+{
+  "database": {
+    "type": "InfluxDB",
+    "host": "192.168.200.10",
+    "port": 8086,
+    "database": "oht50",
+    "retention": "30d"
+  },
+  "measurements": {
+    "network_metrics": {
+      "fields": ["signal_strength", "latency", "throughput", "packet_loss"],
+      "tags": ["robot_id", "location", "ap_id"]
+    },
+    "robot_metrics": {
+      "fields": ["position_x", "position_y", "position_z", "speed", "battery"],
+      "tags": ["robot_id", "status", "zone"]
+    },
+    "system_health": {
+      "fields": ["overall_health", "network_health", "robot_health"],
+      "tags": ["robot_id", "alert_level"]
+    }
+  }
+}
+```
+
+---
+
+## 🚨 **ALERT SYSTEM**
+
+### **Alert Configuration:**
+```json
+{
+  "alerts": {
+    "critical": {
+      "network_disconnected": {
+        "condition": "signal_strength < -80",
+        "duration": "10s",
+        "action": "send_notification,log_event,escalate"
+      },
+      "robot_stopped": {
+        "condition": "speed == 0 AND status == 'error'",
+        "duration": "5s",
+        "action": "send_notification,log_event,escalate"
+      },
+      "battery_low": {
+        "condition": "battery_level < 20",
+        "duration": "30s",
+        "action": "send_notification,log_event"
+      }
+    },
+    "warning": {
+      "signal_weak": {
+        "condition": "signal_strength < -70",
+        "duration": "60s",
+        "action": "send_notification,log_event"
+      },
+      "latency_high": {
+        "condition": "latency > 50",
+        "duration": "30s",
+        "action": "send_notification,log_event"
+      }
+    },
+    "info": {
+      "connection_restored": {
+        "condition": "signal_strength > -60",
+        "duration": "10s",
+        "action": "send_notification,log_event"
+      }
+    }
+  }
+}
+```
+
+### **Alert Actions:**
+```bash
+#!/bin/bash
+# Alert action script
+# File: /usr/local/bin/alert-actions.sh
+
+# Send notification
+send_notification() {
+    local level=$1
+    local message=$2
+    local timestamp=$(date)
+    
+    # Send to monitoring system
+    curl -X POST http://192.168.200.10:8086/write?db=oht50 \
+         -d "alerts,level=$level message=\"$message\",timestamp=\"$timestamp\""
+    
+    # Send email notification
+    echo "$message" | mail -s "OHT-50 Alert: $level" admin@plant.com
+    
+    # Send SMS notification (if configured)
+    # echo "$message" | curl -X POST https://api.sms.com/send -d "message=$message"
+}
+
+# Log event
+log_event() {
+    local level=$1
+    local message=$2
+    local timestamp=$(date)
+    
+    echo "[$timestamp] [$level] $message" >> /var/log/oht50/alerts.log
+}
+
+# Escalate alert
+escalate() {
+    local level=$1
+    local message=$2
+    
+    # Send to higher level monitoring
+    curl -X POST http://192.168.200.10:8086/write?db=oht50 \
+         -d "escalated_alerts,level=$level message=\"$message\""
+    
+    # Notify plant manager
+    echo "$message" | mail -s "OHT-50 CRITICAL ALERT" plant.manager@plant.com
+}
+```
+
+---
+
+## 📋 **OPERATIONAL PROCEDURES**
+
+### **Daily Monitoring Tasks:**
+- [ ] Check network performance metrics
+- [ ] Review robot movement patterns
+- [ ] Verify system health status
+- [ ] Check alert notifications
+- [ ] Review network connectivity
+
+### **Weekly Monitoring Tasks:**
+- [ ] Analyze network performance trends
+- [ ] Review robot efficiency metrics
+- [ ] Check system health trends
+- [ ] Review alert patterns
+- [ ] Update monitoring configuration
+
+### **Monthly Monitoring Tasks:**
+- [ ] Generate performance reports
+- [ ] Analyze network capacity
+- [ ] Review robot utilization
+- [ ] Check system reliability
+- [ ] Update monitoring thresholds
+
+---
+
+## 📊 **REPORTING**
+
+### **Performance Reports:**
+```json
+{
+  "daily_report": {
+    "date": "2025-01-28",
+    "network_performance": {
+      "average_signal": -52.3,
+      "average_latency": 8.5,
+      "average_throughput": 78.2,
+      "connection_uptime": 99.8
+    },
+    "robot_performance": {
+      "total_distance": 12500.5,
+      "average_speed": 2.3,
+      "battery_efficiency": 94.5,
+      "operational_time": 22.5
+    },
+    "system_health": {
+      "overall_health": 96.2,
+      "network_health": 94.8,
+      "robot_health": 97.5,
+      "safety_health": 100.0
+    }
+  }
+}
+```
+
+### **Alert Summary:**
+```json
+{
+  "alert_summary": {
+    "date": "2025-01-28",
+    "critical_alerts": 0,
+    "warning_alerts": 3,
+    "info_alerts": 12,
+    "total_alerts": 15,
+    "resolved_alerts": 15,
+    "open_alerts": 0
+  }
+}
+```
+
+---
+
+## 🔗 **RELATED DOCUMENTS**
+
+- **Technical Documentation:** `NETWORK_MANAGEMENT_TECHNICAL.md`
+- **Plant Implementation:** `NETWORK_MANAGEMENT_PLANT_IMPLEMENTATION.md`
+- **API Documentation:** `API_DOCUMENTATION.md`
+- **Monitoring Setup:** `MONITORING_SETUP.md`
+- **Alert Configuration:** `ALERT_CONFIGURATION.md`
+
+---
+
+## 📝 **CHANGELOG**
+
+### **v1.0.0 (2025-01-28) - Initial Tracking Documentation**
+- ✅ Network tracking architecture design
+- ✅ Monitoring metrics definition
+- ✅ Dashboard layout specification
+- ✅ Data collection procedures
+- ✅ Alert system configuration
+- ✅ Operational procedures
+- ✅ Reporting framework
+
+---
+
+**📋 Generated by Plant Operations Team - OHT-50 Project**  
+**🕒 Date: 2025-01-28**  
+**✅ Status: v1.0 TRACKING DOCUMENTATION COMPLETE**  
+**🎯 Next: Monitoring System Implementation**

--- a/firmware_new/docs/06-REFERENCE/README.md
+++ b/firmware_new/docs/06-REFERENCE/README.md
@@ -1,0 +1,92 @@
+# 📚 06-REFERENCE (Tài Liệu Tham Khảo)
+
+**Theo ISO 9001:2015 Section 7.5 - External Documents**
+
+---
+
+## 🎯 **MỤC ĐÍCH**
+
+Thư mục này chứa **tài liệu tham khảo** - reference materials, quick guides, và technical documentation.
+
+---
+
+## 📄 **DANH SÁCH TÀI LIỆU**
+
+| **Mã** | **Tên tài liệu** | **Mô tả** | **Version** |
+|--------|------------------|-----------|-------------|
+| **REF-001** | Control_Loop_Guide.md | Control loop development guide | 1.1 |
+| **REF-002** | Architecture_Quick_Reference.md | Architecture cheat sheet | 1.0.1 |
+| **REF-003** | Documentation_Index.md | Quick navigation index | 1.0.0 |
+| **REF-004** | Documentation_Navigation.md | Full documentation map | 1.0 |
+| **REF-005** | API_Complete.md | Complete API docs (37 endpoints) | 2.6.0 |
+| **REF-006** | LiDAR_HAL_API.md | LiDAR HAL API reference | 2.3.0 |
+| **REF-007** | Safety_Architecture.md | Safety system architecture | 1.0 |
+| **REF-008** | Network_Technical.md | Network technical reference | 1.0 |
+
+---
+
+## 🌐 **REF-001: API Reference**
+
+**Nội dung:**
+- 5 HTTP REST endpoints
+- Request/Response examples
+- Authentication (Bearer token)
+- Error codes (200, 400, 401, 404, 500, 503)
+
+**Khi nào dùng:** Integration với backend, API testing
+
+---
+
+## 🏗️ **REF-002: Architecture Quick Reference**
+
+**Nội dung:**
+- Folder structure cheat sheet
+- 4 layers (Core, Infrastructure, Domain, Application)
+- Include path examples
+- Library linking guide
+- Dependency rules
+- Common mistakes
+
+**Khi nào dùng:** Khi code, architecture questions
+
+---
+
+## 📖 **REF-003: Documentation Index**
+
+**Nội dung:**
+- Quick start links
+- Main documentation (7 files)
+- Directory-specific docs
+- Common tasks
+- Find information by topic
+
+**Khi nào dùng:** Tìm tài liệu, navigation
+
+---
+
+## 🗺️ **REF-004: Documentation Navigation**
+
+**Nội dung:**
+- Documentation structure
+- External docs links
+- Search và navigation tips
+- Maintenance tasks
+
+**Khi nào dùng:** Full documentation mapping
+
+---
+
+## ✅ **SỬ DỤNG REFERENCE**
+
+Reference documents là:
+- ✅ Quick lookup resources
+- ✅ Always available
+- ✅ No mandatory reading
+- ✅ Use as needed
+
+---
+
+**Version:** 1.0  
+**Last Updated:** 2025-10-07  
+**Maintained By:** Documentation Team
+

--- a/firmware_new/docs/06-REFERENCE/REF-001_Control_Loop_Guide.md
+++ b/firmware_new/docs/06-REFERENCE/REF-001_Control_Loop_Guide.md
@@ -1,0 +1,69 @@
+# HƯỚNG DẪN CHO DEV – CONTROL LOOP CORE
+
+Phiên bản: 1.1  
+Ngày cập nhật: 2025-09-09
+
+---
+
+## 1) Kiến trúc nhanh
+- Chỉ giữ VELOCITY control tại Firmware.
+- Ước lượng vị trí 1D `x_est` bằng IMU + ZUPT + neo RFID; LiDAR dùng cho vùng an toàn/docking.
+- Backend là Planner: gửi segment/`v_target`, tính `remaining_distance` (nếu có map), bật/tắt docking.
+- Vòng FW: áp profile v/a/jerk → PID vận tốc → kiểm tra safety → cập nhật telemetry (x_est, v, safety/docking).
+
+## 2) Không dùng giả lập trong runtime
+- Mock chỉ cho unit test (`use_mock=true`) và phải log cảnh báo rõ ràng.
+- Runtime/staging/prod: luôn dùng dữ liệu thật (IMU/RFID/LiDAR/Motor IO).
+
+## 3) Nguồn dữ liệu thật (gợi ý nối)
+- IMU: gia tốc dọc trục → lọc → tích phân thành v → tích phân có ràng buộc thành x; dùng ZUPT reset trôi khi v≈0.
+- RFID: sự kiện thẻ (id, offset) → neo tuyệt đối x_est theo `rfid_anchor_trust`.
+- LiDAR: range‑gate cho vùng an toàn và docking; không dùng để đo vị trí tuyệt đối toàn tuyến.
+- Motor IO: kênh điều khiển thực thi tốc độ (không yêu cầu encoder).
+
+## 4) Mode vận hành
+- Velocity: đặt `v_target` → PID vận tốc, có hạn chế `amax/jmax` và chính sách WARNING/CRITICAL.
+- Emergency: E‑Stop/CRITICAL → zero output tức thì.
+- Ghi chú: Position/Homing/Torque đã loại khỏi Firmware. Position được lập kế hoạch ở Backend theo segment.
+
+## 5) Limits & Settings (khởi đầu an toàn)
+- v_max_mm_s, v_slow_mm_s, amax_mm_s2, jmax_mm_s3
+- warning_speed_factor (vd 0.5), slowdown_distance_m (=2.0)
+- zupt_threshold, rfid_anchor_trust, imu_bias_update_rate
+- docking_enabled, dock_crawl_speed_mm_s, lidar_gate_range_mm, dock_stability_time_ms
+
+## 6) PID khởi đầu an toàn (vận tốc)
+- Velocity: Kp=0.5, Ki=0.0, Kd=0.05, output ±1.0; integral ±0.2.
+
+## 7) Diagnostics
+- Dùng `control_loop_get_diagnostics(...)` để in nhanh state/mode/v_target/x_est/v/errors/output/safety/docking.
+
+## 8) Test thực địa (gợi ý kịch bản)
+- Segment dài (có map): quan sát tự giảm về v_slow khi còn 2 m.
+- WARNING → giảm tốc trong 1 chu kỳ; CRITICAL/E‑STOP → zero <100 ms.
+- RFID neo x_est: trước/sau thẻ sai số giảm; log cập nhật.
+- Docking: LiDAR range‑gate; dừng trong cửa sổ sai số + ổn định thời gian.
+
+---
+
+## 9) Truy vết mã nguồn
+- `src/app/core/control_loop.c/.h`
+- `src/app/core/safety_monitor.*`
+- `src/app/modules/travel_motor_module_handler.*`
+- `src/app/modules/*` (RFID/LiDAR events nếu có)
+
+---
+
+## 10) Data Sources & Fallback Matrix (hướng dẫn dev)
+- Providers
+  - IMU: lấy từ DOCK & Location module; đảm bảo `freshness_ms ≤ 100`
+  - RFID: sự kiện thẻ từ DOCK module; `event_stale_ms ≤ 2000`
+  - LiDAR: từ SAFETY module; `freshness_ms ≤ 150`
+  - MOTOR: Travel Motor module để thực thi tốc độ
+- Kiểm tra chất lượng trước khi dùng
+  - `health == ONLINE` và `fresh == true`; nếu `WARNING` → áp `warning_speed_factor`
+- Fallback
+  - IMU stale → hạ `v_target` về `v_slow`; quá timeout → STOP
+  - RFID thiếu → không neo x_est; giới hạn tốc độ/quãng đường
+  - LiDAR lỗi → cấm docking; limit speed/STOP
+  - MOTOR lỗi → STOP ngay, phát FAULT

--- a/firmware_new/docs/06-REFERENCE/REF-002_Architecture_Quick_Reference.md
+++ b/firmware_new/docs/06-REFERENCE/REF-002_Architecture_Quick_Reference.md
@@ -1,0 +1,319 @@
+# 🚀 OHT-50 Architecture Quick Reference Card
+
+**Version:** v1.0.1 (Domain-Driven Design)  
+**Last Updated:** 2025-10-07
+
+---
+
+## 📁 Folder Structure Cheat Sheet
+
+### 🎛️ CORE (`src/app/core/`)
+**Purpose:** Independent business logic  
+**Rule:** No external dependencies (chỉ HAL)
+
+```
+core/
+├── state_management/    # System lifecycle
+├── safety/              # Safety monitoring (CRITICAL)
+└── control/             # Motion control
+```
+
+### 🔌 INFRASTRUCTURE (`src/app/infrastructure/`)
+**Purpose:** Technical services (I/O, networking)  
+**Rule:** Depends only on Core
+
+```
+infrastructure/
+├── communication/       # RS485/Modbus
+├── network/             # WiFi/LAN
+└── telemetry/           # Data collection
+```
+
+### 🏭 DOMAIN (`src/app/domain/`)
+**Purpose:** Business domain logic  
+**Rule:** Depends on Infrastructure + Core
+
+```
+domain/
+├── module_management/   # Discovery & registry
+├── power/               # Module 0x02
+├── motion/              # Module 0x04
+├── safety_module/       # Module 0x03
+└── dock/                # Module 0x05
+```
+
+### 🔐 APPLICATION (`src/app/application/`)
+**Purpose:** Orchestration & coordination  
+**Rule:** Depends on all layers
+
+```
+application/
+├── safety_orchestrator/  # Multi-source safety
+└── system_orchestrator/  # System-wide (future)
+```
+
+---
+
+## 🔗 Include Path Examples
+
+### From Core:
+```c
+// Core chỉ include HAL và internal core files
+#include "hal_common.h"
+#include "system_state_machine.h"
+```
+
+### From Infrastructure:
+```c
+// Infrastructure include Core
+#include "../../core/state_management/system_state_machine.h"
+#include "hal_rs485.h"
+```
+
+### From Domain:
+```c
+// Domain include Infrastructure + Core
+#include "../../infrastructure/communication/communication_manager.h"
+#include "../../core/state_management/system_state_machine.h"
+#include "hal_common.h"
+```
+
+### From Application:
+```c
+// Application include all layers
+#include "../../domain/module_management/module_manager.h"
+#include "../../infrastructure/telemetry/telemetry_manager.h"
+#include "../../core/safety/safety_monitor.h"
+```
+
+---
+
+## 🏗️ Library Linking
+
+### Link New Libraries:
+```cmake
+target_link_libraries(your_target
+    # Unified interfaces (recommended)
+    app_core
+    app_infrastructure
+    app_domain
+    app_application
+    
+    # Or specific libraries
+    app_infrastructure_communication
+    app_domain_power
+)
+```
+
+### Link Legacy (Still Works):
+```cmake
+target_link_libraries(your_target
+    app_core
+    app_managers    # Redirects to new libs
+    app_modules     # Redirects to new libs
+)
+```
+
+---
+
+## 📊 Dependency Rules
+
+### ✅ ALLOWED:
+```
+Application → Domain → Infrastructure → Core → HAL
+```
+
+### ❌ FORBIDDEN:
+```
+Core → Infrastructure      ❌ NO!
+Infrastructure → Domain    ❌ NO!
+Domain → Application       ❌ NO!
+```
+
+---
+
+## 🔧 Adding New Code
+
+### Add New Infrastructure Service:
+```bash
+# 1. Create folder
+mkdir src/app/infrastructure/my_service
+
+# 2. Add files
+touch src/app/infrastructure/my_service/my_service_manager.c
+touch src/app/infrastructure/my_service/my_service_manager.h
+
+# 3. Create CMakeLists.txt
+cat > src/app/infrastructure/my_service/CMakeLists.txt << EOF
+add_library(app_infrastructure_my_service STATIC
+    my_service_manager.c
+)
+target_include_directories(app_infrastructure_my_service PUBLIC ...)
+target_link_libraries(app_infrastructure_my_service ...)
+EOF
+
+# 4. Add to infrastructure/CMakeLists.txt
+add_subdirectory(my_service)
+target_link_libraries(app_infrastructure INTERFACE
+    ...existing...
+    app_infrastructure_my_service
+)
+```
+
+### Add New Domain:
+```bash
+# Similar pattern but in domain/
+mkdir src/app/domain/my_domain
+# ... follow same steps
+```
+
+---
+
+## 🧪 Testing Layers
+
+### Test Specific Layer:
+```bash
+cd build
+
+# Test infrastructure
+make app_infrastructure
+
+# Test specific domain
+make app_domain_power
+
+# Test application
+make app_application
+```
+
+### Test Full Build:
+```bash
+make -j$(nproc)
+./oht50_main
+```
+
+---
+
+## 📚 Documentation Files
+
+| File | Purpose |
+|------|---------|
+| `README.md` | Main project documentation |
+| `ARCHITECTURE_v1.0.1.md` | Detailed architecture guide |
+| `DOMAIN_DRIVEN_MIGRATION_SUMMARY.md` | Migration details |
+| `MIGRATION_LOG_v1.0.1.md` | Core migration log |
+| `ARCHITECTURE_QUICK_REFERENCE.md` | This file |
+
+---
+
+## 🚨 Common Mistakes
+
+### ❌ DON'T:
+```c
+// DON'T add new files vào managers/ hoặc modules/
+src/app/managers/new_manager.c        // ❌ DEPRECATED!
+src/app/modules/new_module.c          // ❌ DEPRECATED!
+
+// DON'T violate dependency rules
+// In core/
+#include "../../infrastructure/..."   // ❌ Core can't depend on Infrastructure
+
+// DON'T create circular dependencies
+// Infrastructure → Domain → Infrastructure  ❌
+```
+
+### ✅ DO:
+```c
+// DO add to appropriate layer
+src/app/infrastructure/my_service/    // ✅ Good!
+src/app/domain/my_domain/             // ✅ Good!
+
+// DO follow dependency direction
+// In domain/
+#include "../../infrastructure/..."   // ✅ OK - Domain can use Infrastructure
+#include "../../core/..."             // ✅ OK - Domain can use Core
+
+// DO use INTERFACE libraries
+target_link_libraries(my_target app_infrastructure)  // ✅ Clean!
+```
+
+---
+
+## 🔍 Finding Code
+
+### "Where is...?"
+
+**Communication với RS485?**
+→ `infrastructure/communication/communication_manager.*`
+
+**Module discovery?**
+→ `domain/module_management/module_manager.*`
+
+**Power module handler?**
+→ `domain/power/power_module_handler.*`
+
+**Safety coordination?**
+→ `application/safety_orchestrator/safety_manager.*`
+
+**System state machine?**
+→ `core/state_management/system_state_machine.*`
+
+---
+
+## 🎯 Migration Status
+
+| Folder | Status | Note |
+|--------|--------|------|
+| `core/` | ✅ Migrated | v1.0.1 (earlier) |
+| `infrastructure/` | ✅ Migrated | v1.0.1 (now) |
+| `domain/` | ✅ Migrated | v1.0.1 (now) |
+| `application/` | ✅ Migrated | v1.0.1 (now) |
+| `managers/` | ⚠️ DEPRECATED | Compatibility shim |
+| `modules/` | ⚠️ DEPRECATED | Compatibility shim |
+
+---
+
+## 📞 Who to Ask?
+
+| Question | Team |
+|----------|------|
+| Core architecture | CTO / FW Team Lead |
+| Infrastructure | EMBED Team |
+| Domain logic | FW Domain Team |
+| Application orchestration | FW Application Team |
+| Build issues | DevOps Team |
+
+---
+
+## 🏆 Best Practices
+
+1. **Read the layer README** before modifying code
+2. **Follow dependency rules** strictly
+3. **Update tests** when changing code
+4. **Document API changes** in headers
+5. **Ask before** adding cross-layer dependencies
+6. **Use unified interfaces** (`app_infrastructure`) not specific libs
+
+---
+
+**Quick Help:**
+```bash
+# View architecture
+cat src/app/ARCHITECTURE_v1.0.1.md
+
+# View migration details
+cat DOMAIN_DRIVEN_MIGRATION_SUMMARY.md
+
+# Build specific layer
+cd build && make app_domain
+
+# Run main executable
+./build/oht50_main
+```
+
+---
+
+**Version:** v1.0.1  
+**Last Updated:** 2025-10-07  
+**Maintained By:** Firmware Team
+
+

--- a/firmware_new/docs/06-REFERENCE/REF-003_Documentation_Index.md
+++ b/firmware_new/docs/06-REFERENCE/REF-003_Documentation_Index.md
@@ -1,0 +1,288 @@
+# OHT-50 Firmware - Quick Navigation Index
+
+**Version:** 1.0.0 | **Last Updated:** 2025-10-07 | **Status:** ✅ Production Ready
+
+## 🚀 Quick Start
+
+1. **New to the project?** → Start with [README.md](README.md)
+2. **Want to build?** → See [BUILD_GUIDE.md](BUILD_GUIDE.md)
+3. **Understanding code?** → Read [CODE_STRUCTURE.md](CODE_STRUCTURE.md)
+4. **Finding documentation?** → Check [DOCUMENTATION.md](DOCUMENTATION.md)
+5. **What changed?** → Review [CLEANUP_SUMMARY.md](CLEANUP_SUMMARY.md)
+
+## 📚 Main Documentation
+
+| Document | Purpose | When to Read |
+|----------|---------|--------------|
+| **[README.md](README.md)** | Project overview, features, quick start | First time, project introduction |
+| **[BUILD_GUIDE.md](BUILD_GUIDE.md)** | Complete build instructions | Building the firmware |
+| **[CODE_STRUCTURE.md](CODE_STRUCTURE.md)** | Code organization and architecture | Understanding codebase |
+| **[CODE_QUALITY.md](CODE_QUALITY.md)** | Code quality tools and practices | Setting up development |
+| **[DOCUMENTATION.md](DOCUMENTATION.md)** | Documentation index and navigation | Finding specific docs |
+| **[CLEANUP_SUMMARY.md](CLEANUP_SUMMARY.md)** | Cleanup actions and improvements | Understanding recent changes |
+
+## 📁 Directory-Specific Documentation
+
+### Source Code
+- **[src/README.md](src/README.md)** - Source code structure (TBD)
+- **[include/README.md](include/README.md)** - Header files organization
+- **[tests/README.md](tests/README.md)** - Test suite guide
+- **[cmake/README.md](cmake/README.md)** - CMake configuration
+
+### Scripts
+- **[scripts/build/README.md](scripts/build/README.md)** - Build scripts
+- **[scripts/deploy/README.md](scripts/deploy/README.md)** - Deploy scripts
+- **[scripts/test/README.md](scripts/test/README.md)** - Test scripts
+- **[scripts/rs485/README.md](scripts/rs485/README.md)** - RS485 utilities
+- **[scripts/lidar/README.md](scripts/lidar/README.md)** - LiDAR utilities
+- **[scripts/safety/README.md](scripts/safety/README.md)** - Safety tests
+
+## 🎯 Common Tasks
+
+### Building
+```bash
+# Quick build
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+
+# More info: BUILD_GUIDE.md
+```
+
+### Testing
+```bash
+# Run all tests
+cd build
+ctest -V
+
+# More info: tests/README.md
+```
+
+### Running
+```bash
+# Start firmware
+./build/oht50_main
+
+# More info: README.md
+```
+
+## 🔍 Find Information By Topic
+
+### Architecture & Design
+- Architecture overview → [CODE_STRUCTURE.md](CODE_STRUCTURE.md)
+- System layers → [CODE_STRUCTURE.md](CODE_STRUCTURE.md)
+- Component design → [docs/01-ARCHITECTURE/](docs/01-ARCHITECTURE/)
+
+### Implementation
+- Source structure → [CODE_STRUCTURE.md](CODE_STRUCTURE.md)
+- Header files → [include/README.md](include/README.md)
+- Implementation guides → [docs/02-IMPLEMENTATION/](docs/02-IMPLEMENTATION/)
+
+### Building & Configuration
+- Build instructions → [BUILD_GUIDE.md](BUILD_GUIDE.md)
+- CMake options → [cmake/README.md](cmake/README.md)
+- Build scripts → [scripts/build/README.md](scripts/build/README.md)
+
+### Testing
+- Test suite → [tests/README.md](tests/README.md)
+- Test scripts → [scripts/test/README.md](scripts/test/README.md)
+- API tests → [tests/api/](tests/api/)
+
+### Deployment
+- Deploy guide → [docs/03-DEPLOYMENT/](docs/03-DEPLOYMENT/)
+- Deploy scripts → [scripts/deploy/README.md](scripts/deploy/README.md)
+
+### Operations
+- Operations guide → [docs/04-OPERATIONS/](docs/04-OPERATIONS/)
+- User guide → [docs/user_guide/](docs/user_guide/)
+
+### Hardware & Interfaces
+- RS485 → [scripts/rs485/README.md](scripts/rs485/README.md)
+- LiDAR → [scripts/lidar/README.md](scripts/lidar/README.md)
+- Safety → [scripts/safety/README.md](scripts/safety/README.md)
+
+## 📊 Project Statistics
+
+- **Documentation Files:** 5 (root level)
+- **README Files:** 12 (throughout project)
+- **Source Files:** 70 (C/H files)
+- **Test Files:** 47 (C/Python files)
+- **Total Code:** 58,265 lines
+
+## 🏗️ Project Structure
+
+```
+firmware_new/
+├── 📄 Documentation (5 main docs)
+│   ├── README.md
+│   ├── BUILD_GUIDE.md
+│   ├── CODE_STRUCTURE.md
+│   ├── DOCUMENTATION.md
+│   └── CLEANUP_SUMMARY.md
+│
+├── 📂 Source Code
+│   ├── src/              → Source files
+│   ├── include/          → Header files
+│   └── cmake/            → CMake modules
+│
+├── 🧪 Testing
+│   └── tests/            → Test suite
+│
+├── 🔧 Utilities
+│   └── scripts/          → Build/deploy/test scripts
+│
+├── ⚙️ Configuration
+│   ├── config/           → Build configuration
+│   └── CMakeLists.txt    → CMake config
+│
+└── 📚 Documentation
+    └── docs/             → Full docs (symlink)
+```
+
+## 🎓 Learning Path
+
+### For New Developers
+1. Read [README.md](README.md) - Project overview
+2. Review [CODE_STRUCTURE.md](CODE_STRUCTURE.md) - Understanding architecture
+3. Read [BUILD_GUIDE.md](BUILD_GUIDE.md) - Building the project
+4. Explore [tests/README.md](tests/README.md) - Testing approach
+5. Check [docs/](docs/) - Detailed documentation
+
+### For Contributors
+1. Read [README.md](README.md) - Contributing guidelines
+2. Review [CODE_STRUCTURE.md](CODE_STRUCTURE.md) - Code organization
+3. Read [BUILD_GUIDE.md](BUILD_GUIDE.md) - Build system
+4. Follow [tests/README.md](tests/README.md) - Testing standards
+5. Update documentation as needed
+
+### For Operators
+1. Read [README.md](README.md) - System overview
+2. Check [BUILD_GUIDE.md](BUILD_GUIDE.md) - Installation
+3. Review [scripts/deploy/README.md](scripts/deploy/README.md) - Deployment
+4. Read [docs/user_guide/](docs/user_guide/) - User guides
+5. Check [docs/04-OPERATIONS/](docs/04-OPERATIONS/) - Operations
+
+## 🔗 External Resources
+
+### Main Project Docs
+- **Location:** `/home/orangepi/Desktop/OHT_V2/docs/05-IMPLEMENTATION/FIRMWARE/`
+- **Symlink:** `docs/` → Main documentation
+- **Access:** [DOCUMENTATION.md](DOCUMENTATION.md)
+
+### Online Resources
+- Project repository
+- Issue tracker
+- Wiki/knowledge base
+- Team communication channels
+
+## 📝 Quick Reference Cards
+
+### Build Commands
+```bash
+# Debug build
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+# Release build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+
+# With tests
+cmake -DBUILD_TESTING=ON ..
+
+# With coverage
+cmake -DENABLE_COVERAGE=ON ..
+```
+
+### Test Commands
+```bash
+# All tests
+ctest -V
+
+# Unit tests
+cd tests/unit && ctest -V
+
+# Integration tests
+cd tests/integration && ctest -V
+
+# API tests
+python3 tests/api/test_http_api.py
+```
+
+### Common Scripts
+```bash
+# Build
+./scripts/build/build.sh
+
+# Deploy
+./scripts/deploy/deploy.sh
+
+# Start
+./scripts/deploy/start_firmware.sh
+
+# Test all
+./scripts/test/run_all_tests.sh
+```
+
+## 🆘 Need Help?
+
+### Common Issues
+- **Build fails?** → [BUILD_GUIDE.md](BUILD_GUIDE.md) → Troubleshooting
+- **Test fails?** → [tests/README.md](tests/README.md) → Troubleshooting
+- **Can't find doc?** → [DOCUMENTATION.md](DOCUMENTATION.md)
+- **Understand code?** → [CODE_STRUCTURE.md](CODE_STRUCTURE.md)
+
+### Getting Support
+1. Check documentation first
+2. Review troubleshooting guides
+3. Search issue tracker
+4. Ask team for help
+
+## ✅ Document Checklist
+
+Before starting work:
+- [ ] Read README.md
+- [ ] Understand CODE_STRUCTURE.md
+- [ ] Review BUILD_GUIDE.md
+- [ ] Check relevant component docs
+
+Before committing:
+- [ ] Update relevant documentation
+- [ ] Test changes
+- [ ] Update changelog if needed
+- [ ] Review code quality
+
+## 🔄 Keeping Updated
+
+### Documentation Maintenance
+- Update docs when code changes
+- Review quarterly for accuracy
+- Mark deprecated content
+- Add examples for new features
+
+### Finding Updates
+- Check CLEANUP_SUMMARY.md for recent changes
+- Review git commit messages
+- Read changelog in README.md
+- Check team communications
+
+---
+
+**Navigation Help:**
+- 📄 Main docs are in root directory
+- 📂 Component docs are in subdirectories
+- 🔗 External docs via `docs/` symlink
+- 📚 Full docs index in DOCUMENTATION.md
+
+**Quick Links:**
+- [Project Home](README.md)
+- [Build Guide](BUILD_GUIDE.md)
+- [Code Structure](CODE_STRUCTURE.md)
+- [Documentation Index](DOCUMENTATION.md)
+- [Recent Changes](CLEANUP_SUMMARY.md)
+
+---
+
+**Last Updated:** 2025-10-07  
+**Maintained By:** Firmware Team  
+**Status:** ✅ Current
+
+

--- a/firmware_new/docs/06-REFERENCE/REF-004_Documentation_Navigation.md
+++ b/firmware_new/docs/06-REFERENCE/REF-004_Documentation_Navigation.md
@@ -1,0 +1,282 @@
+# OHT-50 Firmware Documentation Index
+
+Complete documentation for OHT-50 firmware development, deployment, and operations.
+
+## Documentation Location
+
+**Main Documentation:** `docs/` → `/home/orangepi/Desktop/OHT_V2/docs/05-IMPLEMENTATION/FIRMWARE`
+
+The `docs/` directory is a symbolic link to the main project documentation.
+
+## Documentation Structure
+
+```
+docs/ (symlink to OHT_V2/docs/05-IMPLEMENTATION/FIRMWARE/)
+├── 00-OVERVIEW/            # Project overview and introduction
+├── 01-ARCHITECTURE/        # Architecture documentation
+├── 02-IMPLEMENTATION/      # Implementation guides
+├── 03-DEPLOYMENT/          # Deployment procedures
+├── 04-OPERATIONS/          # Operations and maintenance
+├── api/                    # API documentation
+├── architecture/           # Architecture diagrams
+├── safety/                 # Safety documentation
+└── user_guide/             # User guides
+```
+
+## Key Documents
+
+### Overview
+- **README.md** - Main project README
+- **00-OVERVIEW/** - Project introduction and context
+
+### Architecture
+- **FW_APP_SAFETY_ARCHITECTURE.md** - Safety system architecture
+- **01-ARCHITECTURE/** - System architecture documentation
+- **architecture/** - Architecture diagrams and designs
+
+### Implementation
+- **FW_APP_IMPLEMENTATION_PLAN.md** - Implementation plan
+- **CTO_REFACTOR_ORDER.md** - Refactoring roadmap
+- **02-IMPLEMENTATION/** - Implementation guides
+
+### Deployment
+- **03-DEPLOYMENT/** - Deployment procedures and guides
+
+### Operations
+- **04-OPERATIONS/** - Operations and maintenance documentation
+
+### API
+- **api/** - API specifications and documentation
+
+### Safety
+- **safety/** - Safety system documentation and compliance
+
+### User Guide
+- **user_guide/** - End-user documentation
+
+## Local Documentation
+
+### In This Repository
+
+#### Root Level
+- `README.md` - Repository overview
+- `CODE_STRUCTURE.md` - Code organization
+- `DOCUMENTATION.md` - This file
+- `.gitignore` - Git ignore patterns
+
+#### Source Code
+- `src/README.md` - Source code structure (to be created)
+- `include/README.md` - Header files organization
+- `tests/README.md` - Test suite documentation
+
+#### Scripts
+- `scripts/build/README.md` - Build scripts
+- `scripts/deploy/README.md` - Deploy scripts
+- `scripts/test/README.md` - Test scripts
+- `scripts/rs485/README.md` - RS485 scripts
+- `scripts/lidar/README.md` - LiDAR scripts
+- `scripts/safety/README.md` - Safety scripts
+
+## Quick Reference
+
+### For Developers
+
+**Getting Started:**
+1. Read `README.md`
+2. Review `CODE_STRUCTURE.md`
+3. Check `docs/01-ARCHITECTURE/`
+4. Read implementation guides in `docs/02-IMPLEMENTATION/`
+
+**Architecture Understanding:**
+1. `docs/01-ARCHITECTURE/` - System architecture
+2. `FW_APP_SAFETY_ARCHITECTURE.md` - Safety architecture
+3. `architecture/` - Architecture diagrams
+
+**Implementation:**
+1. `FW_APP_IMPLEMENTATION_PLAN.md` - Implementation plan
+2. `CTO_REFACTOR_ORDER.md` - Refactoring guide
+3. `docs/02-IMPLEMENTATION/` - Implementation details
+
+**Testing:**
+1. `tests/README.md` - Test suite documentation
+2. Test scripts in `scripts/test/`
+
+### For Operators
+
+**Deployment:**
+1. `docs/03-DEPLOYMENT/` - Deployment procedures
+2. Deploy scripts in `scripts/deploy/`
+
+**Operations:**
+1. `docs/04-OPERATIONS/` - Operations guides
+2. `docs/user_guide/` - User guides
+
+**Maintenance:**
+1. `docs/04-OPERATIONS/` - Maintenance procedures
+2. Safety documentation in `docs/safety/`
+
+### For API Users
+
+**API Documentation:**
+1. `docs/api/` - API specifications
+2. API test examples in `tests/api/`
+
+## Documentation Standards
+
+### Markdown Format
+- All documentation in Markdown (.md)
+- Follow standard Markdown syntax
+- Use code blocks for examples
+- Include diagrams where helpful
+
+### Structure
+- Clear hierarchy
+- Table of contents for long documents
+- Cross-references between related documents
+- Version information and update dates
+
+### Content
+- Clear and concise writing
+- Technical accuracy
+- Code examples where appropriate
+- Diagrams and visualizations
+
+### Maintenance
+- Update documentation with code changes
+- Review documentation periodically
+- Keep version information current
+- Mark deprecated content clearly
+
+## Contributing to Documentation
+
+### Adding Documentation
+1. Choose appropriate location
+2. Follow naming conventions
+3. Use Markdown format
+4. Add to relevant index
+5. Update this file if needed
+
+### Updating Documentation
+1. Make changes in source location
+2. Update version/date information
+3. Review related documents
+4. Update indexes if structure changes
+
+### Documentation Review
+- Technical accuracy
+- Clarity and readability
+- Completeness
+- Up-to-date information
+- Proper formatting
+
+## Documentation Tools
+
+### Viewing
+- **Markdown viewers:** VSCode, Typora, Grip
+- **Online:** GitHub, GitLab
+- **CLI:** pandoc, markdown
+
+### Generating
+- **API docs:** Doxygen (for C code)
+- **Diagrams:** Mermaid, PlantUML
+- **PDF:** pandoc, LaTeX
+
+### Linting
+- **Markdown:** markdownlint
+- **Links:** markdown-link-check
+- **Spell check:** aspell, hunspell
+
+## Related Files
+
+### Local Documentation Files
+```
+firmware_new/
+├── README.md              # Main README
+├── CODE_STRUCTURE.md      # Code organization
+├── DOCUMENTATION.md       # This file
+├── src/README.md          # Source documentation (TBD)
+├── include/README.md      # Header documentation
+├── tests/README.md        # Test documentation
+└── scripts/*/README.md    # Script documentation
+```
+
+### External Documentation
+- Project-wide docs: `/home/orangepi/Desktop/OHT_V2/docs/`
+- Firmware docs: `/home/orangepi/Desktop/OHT_V2/docs/05-IMPLEMENTATION/FIRMWARE/`
+
+## Documentation Categories
+
+### Technical Documentation
+- Architecture designs
+- API specifications
+- Implementation guides
+- Test documentation
+
+### User Documentation
+- User guides
+- Operations manuals
+- Deployment procedures
+- Troubleshooting guides
+
+### Process Documentation
+- Development workflow
+- Review procedures
+- Testing strategy
+- Release process
+
+### Compliance Documentation
+- Safety documentation
+- Standards compliance
+- Certification records
+- Audit trails
+
+## Search and Navigation
+
+### Finding Documentation
+
+**By Topic:**
+```bash
+# Search all documentation
+grep -r "search_term" docs/
+
+# Search local docs only
+grep -r "search_term" *.md */README.md
+```
+
+**By File Type:**
+```bash
+# Find all markdown files
+find docs/ -name "*.md"
+
+# Find specific document
+find docs/ -name "*safety*"
+```
+
+### Navigation Tips
+1. Start with README files in each directory
+2. Follow cross-references
+3. Use table of contents in long documents
+4. Check related documents section
+
+## Documentation Maintenance
+
+### Regular Tasks
+- [ ] Review and update quarterly
+- [ ] Check for broken links monthly
+- [ ] Update version information with releases
+- [ ] Archive obsolete documentation
+
+### Quality Checks
+- [ ] Technical accuracy verified
+- [ ] Code examples tested
+- [ ] Links functional
+- [ ] Formatting correct
+- [ ] Up-to-date with code
+
+---
+
+**Last Updated:** 2025-10-07  
+**Version:** 1.0  
+**Maintained By:** Firmware Team
+
+

--- a/firmware_new/docs/06-REFERENCE/REF-005_API_Complete_Documentation.md
+++ b/firmware_new/docs/06-REFERENCE/REF-005_API_Complete_Documentation.md
@@ -1,0 +1,2505 @@
+# 📡 OHT-50 FIRMWARE API COMPLETE DOCUMENTATION
+
+**Version:** 3.0.0  
+**Date:** 2025-10-07  
+**Status:** ✅ **Production Ready - All 61 APIs Tested & Verified**  
+**Base URL:** `http://localhost:8080`  
+**Protocol:** HTTP/REST (WebSocket removed per CTO decision)
+
+---
+
+## 🎯 **OVERVIEW**
+
+OHT-50 Firmware cung cấp **61 REST API endpoints** với **Bearer Token Authentication**:
+
+### **📊 API Summary:**
+
+| **Category** | **Endpoints** | **Auth Required** | **Status** |
+|--------------|---------------|-------------------|------------|
+| **🌐 Network** | 27 | 17 protected | ✅ 100% |
+| **🤖 Core System** | 23 | 13 protected | ✅ 100% |
+| **👁️ LiDAR** | 11 | 2 protected | ✅ 100% |
+| **TOTAL** | **61** | **32 protected** | **✅ 100%** |
+
+---
+
+## 🔐 **AUTHENTICATION**
+
+### **Credentials (Development):**
+
+```bash
+# Admin Level (full access)
+ADMIN_TOKEN="oht50_admin_token_2025"
+
+# Operator Level (monitoring + basic control)
+OPERATOR_TOKEN="oht50_operator_token_2025"
+
+# Readonly Level (monitoring only)
+READONLY_TOKEN="oht50_readonly_token_2025"
+```
+
+### **Usage:**
+
+```bash
+# Public APIs (no auth required)
+curl http://localhost:8080/api/v1/network/status
+
+# Protected APIs (auth required)
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     http://localhost:8080/api/v1/network/config
+
+# POST APIs with data
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST -d '{"ssid":"OHT-50"}' \
+     http://localhost:8080/api/v1/network/ap/config
+```
+
+### **Auth Levels:**
+
+| **Level** | **Token** | **Access** |
+|-----------|-----------|------------|
+| **PUBLIC** | None | Monitoring endpoints |
+| **OPERATOR** | operator_token | Monitoring + Basic control |
+| **ADMIN** | admin_token | Full access |
+
+---
+
+## 📚 **TABLE OF CONTENTS**
+
+1. [Network APIs (27)](#network-apis)
+2. [Core System APIs (23)](#core-system-apis)
+3. [LiDAR APIs (11)](#lidar-apis)
+4. [Error Codes](#error-codes)
+5. [Best Practices](#best-practices)
+
+---
+
+## 🌐 **NETWORK APIs (27 Endpoints)**
+
+### **📊 Network Monitoring (10 Public APIs)**
+
+#### **1. GET /api/v1/network/status**
+
+**Description:** Get current network connection status
+
+**Auth:** ❌ Public (no auth required)
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/status
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "connected": false,
+    "current_ssid": "",
+    "signal_strength": 0,
+    "ip_address": "192.168.1.35",
+    "gateway": "192.168.1.1",
+    "dns": "8.8.8.8",
+    "bytes_sent": 0,
+    "bytes_received": 0,
+    "latency_ms": 0.0,
+    "roaming_active": false
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **2. GET /api/v1/network/health**
+
+**Description:** Get network health metrics
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/health
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "network_status": "Disconnected",
+    "signal_quality": "Excellent",
+    "connection_uptime": 0,
+    "success_rate": 100.0,
+    "roaming_events": 0,
+    "health_score": 0.0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **3. GET /api/v1/network/performance**
+
+**Description:** Get network performance metrics
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/performance
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "response_time_ms": 20,
+    "request_count": 2,
+    "error_count": 0,
+    "success_rate": 100.0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **4. GET /api/v1/network/wifi/status**
+
+**Description:** Get WiFi connection status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/wifi/status
+```
+
+**Response:** Same as `/api/v1/network/status`
+
+---
+
+#### **5. GET /api/v1/network/wifi/signal**
+
+**Description:** Get WiFi signal strength
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/wifi/signal
+```
+
+**Response:** Same as `/api/v1/network/status`
+
+---
+
+#### **6. GET /api/v1/network/wifi/scan**
+
+**Description:** Scan available WiFi networks
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/wifi/scan
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "networks": [
+      {
+        "ssid": "OHT-50-Network",
+        "bssid": "00:11:22:33:44:55",
+        "signal_strength": -45,
+        "frequency": 5000,
+        "channel": 36,
+        "security": "WPA2",
+        "band": "5G",
+        "hidden": false,
+        "connected": false
+      },
+      {
+        "ssid": "OHT-50-Backup",
+        "bssid": "00:11:22:33:44:66",
+        "signal_strength": -55,
+        "frequency": 2400,
+        "channel": 6,
+        "security": "WPA3",
+        "band": "2.4G",
+        "hidden": false,
+        "connected": false
+      }
+    ],
+    "count": 5
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **7. GET /api/v1/network/wifi/statistics**
+
+**Description:** Get WiFi connection statistics
+
+**Auth:** ❌ Public (monitoring)
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/wifi/statistics
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "connection_attempts": 0,
+    "successful_connections": 0,
+    "failed_connections": 0,
+    "roaming_events": 0,
+    "disconnection_events": 0,
+    "connection_success_rate": 100.0,
+    "total_uptime_seconds": 0,
+    "average_signal_strength_dbm": 0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **8. GET /api/v1/network/wifi/performance**
+
+**Description:** Get WiFi performance metrics
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/wifi/performance
+```
+
+**Response:** Same as `/api/v1/network/performance`
+
+---
+
+#### **9. GET /api/v1/network/wifi/health**
+
+**Description:** Get WiFi health status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/wifi/health
+```
+
+**Response:** Same as `/api/v1/network/health`
+
+---
+
+#### **10. GET /api/v1/network/ap/status**
+
+**Description:** Get WiFi Access Point status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/ap/status
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "status": 0,
+    "ap_enabled": false,
+    "ap_ssid": "",
+    "ap_ip": "",
+    "ap_channel": 0,
+    "connected_clients": 0,
+    "max_clients": 10,
+    "uptime_seconds": 0,
+    "total_bytes_sent": 0,
+    "total_bytes_received": 0,
+    "cpu_usage_percent": 0.7,
+    "memory_usage_percent": 13.6
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+### **🔒 Protected Network APIs (17 Endpoints)**
+
+#### **11. GET /api/v1/network/config**
+
+**Description:** Get network configuration
+
+**Auth:** ✅ OPERATOR
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_operator_token_2025" \
+     http://localhost:8080/api/v1/network/config
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "wifi_enabled": true,
+    "wifi_ssid": "OHT-50-Network",
+    "wifi_security_type": "WPA2",
+    "signal_strength": -70,
+    "fallback_enabled": true,
+    "roaming_enabled": false
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **12. POST /api/v1/network/config**
+
+**Description:** Update network configuration
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "wifi_enabled": true,
+       "wifi_ssid": "OHT-50-Network",
+       "wifi_password": "SecurePassword2025!",
+       "wifi_security_type": 2,
+       "signal_strength": -70
+     }' \
+     http://localhost:8080/api/v1/network/config
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Network configuration updated",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **13. GET /api/v1/network/statistics**
+
+**Description:** Get network statistics
+
+**Auth:** ✅ OPERATOR
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_operator_token_2025" \
+     http://localhost:8080/api/v1/network/statistics
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "connection_attempts": 0,
+    "successful_connections": 0,
+    "failed_connections": 0,
+    "roaming_events": 0,
+    "disconnection_events": 0,
+    "connection_success_rate": 100.0,
+    "total_uptime_seconds": 0,
+    "average_signal_strength_dbm": 0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **14. POST /api/v1/network/statistics/reset**
+
+**Description:** Reset network statistics
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/network/statistics/reset
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Statistics reset successfully",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **15. POST /api/v1/network/wifi/connect**
+
+**Description:** Connect to WiFi network
+
+**Auth:** ✅ OPERATOR
+
+**⚠️ Password Requirements:** Minimum 12 characters, must include uppercase, lowercase, number, special char
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_operator_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "ssid": "TestNetwork",
+       "password": "SecurePass@2025"
+     }' \
+     http://localhost:8080/api/v1/network/wifi/connect
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "WiFi connection successful",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+**Error Response (500 - Weak Password):**
+```json
+{
+  "success": false,
+  "error": "Weak password",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **16. POST /api/v1/network/wifi/disconnect**
+
+**Description:** Disconnect from WiFi
+
+**Auth:** ✅ OPERATOR
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_operator_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/network/wifi/disconnect
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "WiFi disconnected successfully",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+### **📡 WiFi Access Point APIs (12 Endpoints)**
+
+#### **17. POST /api/v1/network/ap/start**
+
+**Description:** Start WiFi Access Point
+
+**Auth:** ✅ ADMIN
+
+**⚠️ Password Requirements:** Minimum 12 characters, strong password
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "ssid": "OHT-50-Hotspot",
+       "password": "StrongP@ssw0rd2025!"
+     }' \
+     http://localhost:8080/api/v1/network/ap/start
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "WiFi AP started successfully",
+  "data": {
+    "ssid": "OHT-50-Hotspot",
+    "ip": "192.168.4.1",
+    "channel": 6
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+**Error (500 - Weak Password):**
+```json
+{
+  "success": false,
+  "error": "Weak password",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **18. POST /api/v1/network/ap/stop**
+
+**Description:** Stop WiFi Access Point
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/network/ap/stop
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "WiFi AP stopped successfully",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **19. GET /api/v1/network/ap/config**
+
+**Description:** Get AP configuration
+
+**Auth:** ✅ OPERATOR
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_operator_token_2025" \
+     http://localhost:8080/api/v1/network/ap/config
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "ap_enabled": false,
+    "ap_ssid": "OHT-50-Hotspot",
+    "ap_ip": "192.168.4.1",
+    "ap_channel": 6,
+    "ap_max_clients": 10,
+    "ap_security_type": "WPA2"
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **20. POST /api/v1/network/ap/config**
+
+**Description:** Update AP configuration
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "ssid": "OHT-50-Updated",
+       "password": "NewSecurePass@2025",
+       "channel": 11,
+       "max_clients": 15
+     }' \
+     http://localhost:8080/api/v1/network/ap/config
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "AP configuration updated",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **21. GET /api/v1/network/ap/clients**
+
+**Description:** Get list of connected AP clients
+
+**Auth:** ❌ Public (monitoring)
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/ap/clients
+```
+
+**Response (200 OK - No clients):**
+```json
+{
+  "success": true,
+  "data": {
+    "clients": [],
+    "count": 0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+**Response (200 OK - With clients):**
+```json
+{
+  "success": true,
+  "data": {
+    "clients": [
+      {
+        "mac_address": "AA:BB:CC:DD:EE:FF",
+        "ip_address": "192.168.4.100",
+        "hostname": "mobile-device",
+        "signal_strength_dbm": -45,
+        "connected_time_seconds": 1234,
+        "bytes_sent": 1024000,
+        "bytes_received": 2048000,
+        "authenticated": true
+      }
+    ],
+    "count": 1
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **22. POST /api/v1/network/ap/clients/kick**
+
+**Description:** Kick a client from AP
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "mac_address": "AA:BB:CC:DD:EE:FF"
+     }' \
+     http://localhost:8080/api/v1/network/ap/clients/kick
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Client kicked successfully",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **23. GET /api/v1/network/ap/statistics**
+
+**Description:** Get AP statistics
+
+**Auth:** ✅ OPERATOR
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_operator_token_2025" \
+     http://localhost:8080/api/v1/network/ap/statistics
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "total_clients_connected": 0,
+    "total_bytes_sent": 0,
+    "total_bytes_received": 0,
+    "uptime_seconds": 0,
+    "current_clients": 0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **24. POST /api/v1/network/ap/statistics/reset**
+
+**Description:** Reset AP statistics
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/network/ap/statistics/reset
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "AP statistics reset successfully",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+### **🔄 Fallback & Advanced (5 Endpoints)**
+
+#### **25. GET /api/v1/network/fallback/status**
+
+**Description:** Get auto-fallback status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/network/fallback/status
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "enabled": true,
+    "active": false,
+    "trigger_count": 0,
+    "last_trigger_time": 0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **26. POST /api/v1/network/fallback/enable**
+
+**Description:** Enable/disable auto-fallback
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{"enabled": true}' \
+     http://localhost:8080/api/v1/network/fallback/enable
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Auto-fallback configuration updated",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+**Error (400 - Missing Parameter):**
+```json
+{
+  "success": false,
+  "error": "Missing enabled parameter",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **27. POST /api/v1/network/fallback/trigger**
+
+**Description:** Manually trigger fallback
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/network/fallback/trigger
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Fallback triggered successfully",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+## 🤖 **CORE SYSTEM APIs (23 Endpoints)**
+
+### **🔍 System Monitoring (4 Public APIs)**
+
+#### **28. GET /health**
+
+**Description:** Health check endpoint (simple)
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/health
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "status": "healthy",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **29. GET /api/v1/system/status**
+
+**Description:** Get system status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/system/status
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "system": "OHT-50",
+    "status": "ok"
+  }
+}
+```
+
+---
+
+#### **30. GET /api/v1/system/state**
+
+**Description:** Get system state machine status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/system/state
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "current_state": "IDLE",
+    "previous_state": "INIT",
+    "transitions": 2,
+    "ready": true,
+    "safe": false,
+    "comm_ok": true
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **31. GET /api/v1/robot/status**
+
+**Description:** Get robot overall status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/robot/status
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "robot_id": "OHT-50",
+    "state": "IDLE",
+    "modules_online": 4,
+    "comm_health": 100.0,
+    "safety_ok": true,
+    "ready": true
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+### **🛡️ Safety APIs (2 Endpoints)**
+
+#### **32. GET /api/v1/safety/status**
+
+**Description:** Get safety system status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/safety/status
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "estop_active": false,
+    "safety_ok": true
+  }
+}
+```
+
+---
+
+#### **33. POST /api/v1/safety/estop**
+
+**Description:** Trigger emergency stop
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/safety/estop
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Emergency stop activated",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+### **🔧 Module Management APIs (11 Endpoints)**
+
+#### **34. GET /api/v1/rs485/modules**
+
+**Description:** Get all RS485 modules discovered
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/rs485/modules
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "modules": [
+      {
+        "address": 2,
+        "type": "POWER",
+        "device_id": 2,
+        "status": "ONLINE",
+        "health": 95
+      },
+      {
+        "address": 3,
+        "type": "SAFETY",
+        "device_id": 3,
+        "status": "ONLINE",
+        "health": 98
+      },
+      {
+        "address": 4,
+        "type": "TRAVEL_MOTOR",
+        "device_id": 4,
+        "status": "ONLINE",
+        "health": 97
+      },
+      {
+        "address": 5,
+        "type": "DOCK",
+        "device_id": 5,
+        "status": "ONLINE",
+        "health": 96
+      }
+    ],
+    "count": 4,
+    "discovery_time_ms": 17280
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **35. GET /api/v1/modules/stats**
+
+**Description:** Get modules statistics
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/modules/stats
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "total_modules": 4,
+    "online_modules": 4,
+    "offline_modules": 0,
+    "discovery_count": 1,
+    "health_checks": 10,
+    "comm_health": 100.0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **36. GET /api/v1/modules/{id}/telemetry**
+
+**Description:** Get module telemetry data (ID = 2, 3, 4, 5)
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/modules/2/telemetry
+```
+
+**Response (200 OK - Power Module):**
+```json
+{
+  "success": true,
+  "data": {
+    "module_id": 2,
+    "type": "POWER",
+    "battery_voltage": 24.0,
+    "battery_current": 5.4,
+    "battery_soc": 8.4,
+    "max_cell_voltage": 4005,
+    "min_cell_voltage": 3389,
+    "temperature": 249,
+    "relay_12v": 1,
+    "relay_5v": 1,
+    "relay_3v3": 1,
+    "connection_count": 1,
+    "status": 0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **37. GET /api/v1/modules/{id}/health**
+
+**Description:** Get module health status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/modules/2/health
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "module_id": 2,
+    "health_percentage": 95,
+    "health_level": "EXCELLENT",
+    "response_time_ms": 100,
+    "error_count": 0,
+    "last_check": 1728000000
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **38. GET /api/v1/modules/{id}/config**
+
+**Description:** Get module configuration
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/modules/2/config
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "module_id": 2,
+    "type": "POWER",
+    "poll_interval_ms": 1000,
+    "timeout_ms": 1000,
+    "retry_count": 3
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **39. POST /api/v1/modules/{id}/config**
+
+**Description:** Update module configuration
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "poll_interval_ms": 2000,
+       "timeout_ms": 1500
+     }' \
+     http://localhost:8080/api/v1/modules/2/config
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Module configuration updated",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **40. POST /api/v1/modules/{id}/command**
+
+**Description:** Send command to module
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "command": "reset",
+       "parameters": {}
+     }' \
+     http://localhost:8080/api/v1/modules/2/command
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Command sent successfully",
+  "result": "OK",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **41. GET /api/v1/modules/{id}/history**
+
+**Description:** Get module data history
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/modules/2/history?limit=10
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "module_id": 2,
+    "history": [
+      {
+        "timestamp": "2025-10-07T10:00:00Z",
+        "voltage": 24.0,
+        "current": 5.4,
+        "soc": 8.4
+      }
+    ],
+    "count": 1
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+### **⚡ State Control APIs (6 Endpoints)**
+
+#### **42. GET /api/v1/control/status**
+
+**Description:** Get control system status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/control/status
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "control_enabled": true,
+    "mode": "AUTO",
+    "state": "IDLE"
+  }
+}
+```
+
+---
+
+#### **43. GET /api/v1/state/statistics**
+
+**Description:** Get state machine statistics
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/state/statistics
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "total_transitions": 2,
+    "uptime_seconds": 120,
+    "error_count": 0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **44. POST /api/v1/state/move**
+
+**Description:** Command robot to move
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/state/move
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Move command accepted",
+  "new_state": "MOVING",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **45. POST /api/v1/state/stop**
+
+**Description:** Command robot to stop
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/state/stop
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Stop command accepted",
+  "new_state": "IDLE",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **46. POST /api/v1/state/emergency**
+
+**Description:** Trigger emergency stop (E-Stop)
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/state/emergency
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Emergency stop activated",
+  "new_state": "ESTOP",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **47. POST /api/v1/state/reset**
+
+**Description:** Reset system state
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/state/reset
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "System reset successful",
+  "new_state": "IDLE",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+### **🎮 Motion Control APIs (3 Endpoints)**
+
+#### **48. GET /api/v1/motion/state**
+
+**Description:** Get motion controller state
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/motion/state
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "state": "IDLE",
+    "position": 0.0,
+    "velocity": 0.0,
+    "target": 0.0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **49. POST /api/v1/motion/segment/start**
+
+**Description:** Start motion segment
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "target": 100.0,
+       "velocity": 1.0,
+       "acceleration": 0.5
+     }' \
+     http://localhost:8080/api/v1/motion/segment/start
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Motion segment started",
+  "segment_id": 1,
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **50. POST /api/v1/motion/segment/stop**
+
+**Description:** Stop current motion segment
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/motion/segment/stop
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Motion segment stopped",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+### **⚙️ Configuration APIs (3 Endpoints)**
+
+#### **51. GET /api/v1/config/state-machine**
+
+**Description:** Get state machine configuration
+
+**Auth:** ✅ OPERATOR
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_operator_token_2025" \
+     http://localhost:8080/api/v1/config/state-machine
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "timeout_ms": 5000,
+    "auto_recovery": true,
+    "safety_monitoring": true
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **52. POST /api/v1/config/state-machine**
+
+**Description:** Update state machine configuration
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "timeout_ms": 10000,
+       "auto_recovery": true
+     }' \
+     http://localhost:8080/api/v1/config/state-machine
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Configuration updated",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **53. POST /api/v1/config/timeouts**
+
+**Description:** Update timeout configurations
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "state_timeout_ms": 5000,
+       "comm_timeout_ms": 1000
+     }' \
+     http://localhost:8080/api/v1/config/timeouts
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Timeouts updated",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+## 👁️ **LIDAR APIs (11 Endpoints)**
+
+### **📡 LiDAR Monitoring (5 Public APIs)**
+
+#### **54. GET /api/v1/lidar/status**
+
+**Description:** Get LiDAR device status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/lidar/status
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "device_connected": true,
+    "scanning": true,
+    "model": "YDLIDAR X4",
+    "firmware_version": "1.0.0",
+    "scan_rate_hz": 10.0,
+    "sample_rate": 5000
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **55. GET /api/v1/lidar/scan_data**
+
+**Description:** Get latest LiDAR scan data
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/lidar/scan_data
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "scan_complete": true,
+    "point_count": 720,
+    "scan_time_ms": 100,
+    "points": [
+      {
+        "angle_deg": 0.0,
+        "distance_mm": 1500,
+        "quality": 15
+      }
+    ]
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **56. GET /api/v1/lidar/scan_frame_full**
+
+**Description:** Get full 360° scan frame with all points
+
+**Auth:** ❌ Public
+
+**Query Parameters:**
+- `normalize=1` - Normalize angles
+- `limit=100` - Limit points (0 = unlimited)
+- `block_until_rotation=1` - Wait for complete rotation
+- `timeout_ms=5000` - Wait timeout
+
+**Request:**
+```bash
+curl "http://localhost:8080/api/v1/lidar/scan_frame_full?normalize=1&limit=0&block_until_rotation=1&timeout_ms=5000"
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "points": 720,
+    "complete_rotation": true,
+    "scan_time_ms": 100,
+    "data": [[0.0, 1500, 15], [0.5, 1505, 14], ...]
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **57. GET /api/v1/lidar/scan_frame**
+
+**Description:** Get scan frame within angle window
+
+**Auth:** ❌ Public
+
+**Query Parameters:**
+- `min_deg=-30` - Minimum angle
+- `max_deg=30` - Maximum angle
+- `normalize=1` - Normalize angles
+- `limit=100` - Limit points
+
+**Request:**
+```bash
+curl "http://localhost:8080/api/v1/lidar/scan_frame?min_deg=-30&max_deg=30&normalize=1&limit=0"
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "angle_range": [-30, 30],
+    "points": 120,
+    "data": [[-30.0, 1500, 15], [-29.5, 1505, 14], ...]
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **58. GET /api/v1/lidar/scan_frame_360**
+
+**Description:** Get processed 360° scan (360 points, 1 per degree)
+
+**Auth:** ❌ Public
+
+**Query Parameters:**
+- `reducer=max|min|median` - Reducer algorithm
+- `min_q=5` - Minimum quality threshold
+- `max_range=8000` - Maximum distance (mm)
+- `interpolate=1` - Fill gaps
+
+**Request:**
+```bash
+curl "http://localhost:8080/api/v1/lidar/scan_frame_360?reducer=max&min_q=0&max_range=0&interpolate=1"
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "points": 360,
+    "reducer": "max",
+    "interpolated": true,
+    "distances": [1500, 1505, 1510, ...],
+    "qualities": [15, 14, 13, ...]
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **59. GET /api/v1/lidar/config**
+
+**Description:** Get LiDAR configuration
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/lidar/config
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "device_path": "/dev/ttyUSB0",
+    "baud_rate": 128000,
+    "scan_frequency_hz": 10.0,
+    "sample_rate": 5000,
+    "angle_min": 0.0,
+    "angle_max": 360.0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **60. GET /api/v1/lidar/safety_status**
+
+**Description:** Get LiDAR safety zone status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/lidar/safety_status
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "safe": true,
+    "warning_zones": [],
+    "danger_zones": [],
+    "min_distance_mm": 1500,
+    "obstacles_detected": 0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **61. GET /api/v1/lidar/health**
+
+**Description:** Get LiDAR health status
+
+**Auth:** ❌ Public
+
+**Request:**
+```bash
+curl http://localhost:8080/api/v1/lidar/health
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "health_score": 95,
+    "device_connected": true,
+    "scan_quality": "GOOD",
+    "error_count": 0
+  },
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+### **🎮 LiDAR Control (3 Protected APIs)**
+
+#### **62. POST /api/v1/lidar/start_scanning**
+
+**Description:** Start LiDAR scanning
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/lidar/start_scanning
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "LiDAR scanning started",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **63. POST /api/v1/lidar/stop_scanning**
+
+**Description:** Stop LiDAR scanning
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/lidar/stop_scanning
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "LiDAR scanning stopped",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+#### **64. POST /api/v1/lidar/config**
+
+**Description:** Update LiDAR configuration
+
+**Auth:** ✅ ADMIN
+
+**Request:**
+```bash
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{
+       "scan_frequency_hz": 12.0,
+       "sample_rate": 6000
+     }' \
+     http://localhost:8080/api/v1/lidar/config
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "LiDAR config updated (basic implementation)",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+## 🚨 **ERROR CODES**
+
+### **HTTP Status Codes:**
+
+| **Code** | **Meaning** | **Description** |
+|----------|-------------|-----------------|
+| **200** | OK | Request successful |
+| **201** | Created | Resource created successfully |
+| **400** | Bad Request | Invalid parameters or missing required fields |
+| **401** | Unauthorized | Missing or invalid authentication token |
+| **403** | Forbidden | Insufficient permissions |
+| **404** | Not Found | Endpoint or resource not found |
+| **500** | Server Error | Internal server error |
+
+### **Error Response Format:**
+
+```json
+{
+  "success": false,
+  "error": "Error description",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+### **Common Errors:**
+
+#### **401 Unauthorized:**
+```json
+{
+  "success": false,
+  "error": "Unauthorized",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+#### **400 Bad Request:**
+```json
+{
+  "success": false,
+  "error": "Missing enabled parameter",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+#### **500 Server Error:**
+```json
+{
+  "success": false,
+  "error": "Weak password",
+  "timestamp": "2025-10-07T10:00:00Z"
+}
+```
+
+---
+
+## 💡 **BEST PRACTICES**
+
+### **1. Authentication:**
+
+```bash
+# Always include Authorization header for protected endpoints
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     http://localhost:8080/api/v1/...
+
+# Use appropriate token level:
+# - ADMIN: Full access (start/stop, config changes)
+# - OPERATOR: Monitoring + basic control
+# - None: Public monitoring only
+```
+
+---
+
+### **2. Error Handling:**
+
+```bash
+# Check HTTP status code
+response=$(curl -s -w "\n%{http_code}" http://localhost:8080/api/v1/...)
+http_code=$(echo "$response" | tail -1)
+body=$(echo "$response" | head -n -1)
+
+if [ "$http_code" = "200" ]; then
+    echo "Success: $body"
+else
+    echo "Error $http_code: $body"
+fi
+```
+
+---
+
+### **3. JSON Parsing:**
+
+```bash
+# Using jq for parsing
+curl -s http://localhost:8080/api/v1/network/status | jq '.data.ip_address'
+
+# Extract specific field
+IP=$(curl -s http://localhost:8080/api/v1/network/status | jq -r '.data.ip_address')
+echo "Robot IP: $IP"
+```
+
+---
+
+### **4. Password Requirements:**
+
+```
+Minimum 12 characters
+Must include:
+  - Uppercase letter (A-Z)
+  - Lowercase letter (a-z)
+  - Number (0-9)
+  - Special character (!@#$%^&*)
+
+Valid:   "StrongP@ssw0rd2025!"
+Invalid: "test123" (too weak)
+```
+
+---
+
+### **5. Batch Requests:**
+
+```bash
+# Test multiple endpoints
+for endpoint in status health performance; do
+    echo "Testing /api/v1/network/$endpoint"
+    curl -s http://localhost:8080/api/v1/network/$endpoint | jq '.success'
+done
+```
+
+---
+
+## 📊 **QUICK REFERENCE**
+
+### **Most Used Endpoints:**
+
+```bash
+# 1. System health check
+curl http://localhost:8080/health
+
+# 2. Robot status
+curl http://localhost:8080/api/v1/robot/status
+
+# 3. Network status
+curl http://localhost:8080/api/v1/network/status
+
+# 4. Module list
+curl http://localhost:8080/api/v1/rs485/modules
+
+# 5. LiDAR scan data
+curl http://localhost:8080/api/v1/lidar/scan_data
+
+# 6. Emergency stop (ADMIN required)
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -X POST \
+     http://localhost:8080/api/v1/safety/estop
+
+# 7. WiFi scan
+curl http://localhost:8080/api/v1/network/wifi/scan
+
+# 8. AP clients
+curl http://localhost:8080/api/v1/network/ap/clients
+```
+
+---
+
+### **Complete API List:**
+
+#### **Network (27):**
+```
+✅ /api/v1/network/status                    GET    PUBLIC
+✅ /api/v1/network/health                    GET    PUBLIC
+✅ /api/v1/network/performance               GET    PUBLIC
+✅ /api/v1/network/config                    GET    OPERATOR
+✅ /api/v1/network/config                    POST   ADMIN
+✅ /api/v1/network/statistics                GET    OPERATOR
+✅ /api/v1/network/statistics/reset          POST   ADMIN
+✅ /api/v1/network/wifi/status               GET    PUBLIC
+✅ /api/v1/network/wifi/signal               GET    PUBLIC
+✅ /api/v1/network/wifi/scan                 GET    PUBLIC
+✅ /api/v1/network/wifi/statistics           GET    PUBLIC
+✅ /api/v1/network/wifi/performance          GET    PUBLIC
+✅ /api/v1/network/wifi/health               GET    PUBLIC
+✅ /api/v1/network/wifi/connect              POST   OPERATOR
+✅ /api/v1/network/wifi/disconnect           POST   OPERATOR
+✅ /api/v1/network/ap/status                 GET    PUBLIC
+✅ /api/v1/network/ap/config                 GET    OPERATOR
+✅ /api/v1/network/ap/config                 POST   ADMIN
+✅ /api/v1/network/ap/clients                GET    PUBLIC
+✅ /api/v1/network/ap/clients/kick           POST   ADMIN
+✅ /api/v1/network/ap/statistics             GET    OPERATOR
+✅ /api/v1/network/ap/statistics/reset       POST   ADMIN
+✅ /api/v1/network/ap/start                  POST   ADMIN
+✅ /api/v1/network/ap/stop                   POST   ADMIN
+✅ /api/v1/network/fallback/status           GET    PUBLIC
+✅ /api/v1/network/fallback/enable           POST   ADMIN
+✅ /api/v1/network/fallback/trigger          POST   ADMIN
+```
+
+#### **Core System (23):**
+```
+✅ /health                                   GET    PUBLIC
+✅ /api/v1/system/status                     GET    PUBLIC
+✅ /api/v1/system/state                      GET    PUBLIC
+✅ /api/v1/robot/status                      GET    PUBLIC
+✅ /api/v1/safety/status                     GET    PUBLIC
+✅ /api/v1/safety/estop                      POST   ADMIN
+✅ /api/v1/rs485/modules                     GET    PUBLIC
+✅ /api/v1/modules/stats                     GET    PUBLIC
+✅ /api/v1/modules/{id}/telemetry            GET    PUBLIC
+✅ /api/v1/modules/{id}/health               GET    PUBLIC
+✅ /api/v1/modules/{id}/config               GET    PUBLIC
+✅ /api/v1/modules/{id}/config               POST   ADMIN
+✅ /api/v1/modules/{id}/command              POST   ADMIN
+✅ /api/v1/modules/{id}/history              GET    PUBLIC
+✅ /api/v1/control/status                    GET    PUBLIC
+✅ /api/v1/state/statistics                  GET    PUBLIC
+✅ /api/v1/state/move                        POST   ADMIN
+✅ /api/v1/state/stop                        POST   ADMIN
+✅ /api/v1/state/emergency                   POST   ADMIN
+✅ /api/v1/state/reset                       POST   ADMIN
+✅ /api/v1/motion/state                      GET    PUBLIC
+✅ /api/v1/motion/segment/start              POST   ADMIN
+✅ /api/v1/motion/segment/stop               POST   ADMIN
+```
+
+#### **Configuration (3):**
+```
+✅ /api/v1/config/state-machine              GET    OPERATOR
+✅ /api/v1/config/state-machine              POST   ADMIN
+✅ /api/v1/config/timeouts                   POST   ADMIN
+```
+
+#### **LiDAR (11):**
+```
+✅ /api/v1/lidar/status                      GET    PUBLIC
+✅ /api/v1/lidar/scan_data                   GET    PUBLIC
+✅ /api/v1/lidar/scan_frame_full             GET    PUBLIC
+✅ /api/v1/lidar/scan_frame                  GET    PUBLIC
+✅ /api/v1/lidar/scan_frame_360              GET    PUBLIC
+✅ /api/v1/lidar/config                      GET    PUBLIC
+✅ /api/v1/lidar/safety_status               GET    PUBLIC
+✅ /api/v1/lidar/health                      GET    PUBLIC
+✅ /api/v1/lidar/start_scanning              POST   ADMIN
+✅ /api/v1/lidar/stop_scanning               POST   ADMIN
+✅ /api/v1/lidar/config                      POST   ADMIN
+```
+
+---
+
+## 🧪 **TESTING EXAMPLES**
+
+### **Complete Test Script:**
+
+```bash
+#!/bin/bash
+BASE_URL="http://localhost:8080"
+ADMIN_TOKEN="oht50_admin_token_2025"
+OPERATOR_TOKEN="oht50_operator_token_2025"
+
+echo "=== Testing Public APIs ==="
+curl -s $BASE_URL/health | jq
+curl -s $BASE_URL/api/v1/network/status | jq
+curl -s $BASE_URL/api/v1/robot/status | jq
+curl -s $BASE_URL/api/v1/lidar/status | jq
+
+echo ""
+echo "=== Testing Protected APIs (OPERATOR) ==="
+curl -s -H "Authorization: Bearer $OPERATOR_TOKEN" \
+     $BASE_URL/api/v1/network/config | jq
+
+echo ""
+echo "=== Testing Protected APIs (ADMIN) ==="
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+     -X POST \
+     $BASE_URL/api/v1/safety/estop | jq
+
+echo ""
+echo "=== Testing WiFi Control ==="
+curl -s -H "Authorization: Bearer $OPERATOR_TOKEN" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{"ssid":"TestNet","password":"SecurePass@2025"}' \
+     $BASE_URL/api/v1/network/wifi/connect | jq
+```
+
+---
+
+## 📈 **PERFORMANCE NOTES**
+
+### **Response Times (Measured):**
+
+| **Category** | **Avg Time** | **Max Time** |
+|--------------|--------------|--------------|
+| **Health Check** | 5ms | 10ms |
+| **Status APIs** | 10-20ms | 50ms |
+| **Module APIs** | 50-100ms | 200ms |
+| **LiDAR APIs** | 20-50ms | 100ms |
+| **Control APIs** | 20-100ms | 200ms |
+
+### **Rate Limits:**
+
+- **Default:** 1000 requests/minute per IP
+- **Burst:** 100 requests/second
+- **429 Response:** When rate limit exceeded
+
+---
+
+## 🔒 **SECURITY NOTES**
+
+### **⚠️ Development Tokens:**
+
+```
+CRITICAL: Current tokens are for DEVELOPMENT only!
+
+For PRODUCTION:
+1. Generate unique tokens per deployment
+2. Use JWT with expiration
+3. Implement token rotation
+4. Use HTTPS (not HTTP)
+5. Enable rate limiting
+```
+
+### **Best Practices:**
+
+1. **Always use HTTPS** in production
+2. **Rotate tokens** regularly
+3. **Monitor API usage** for suspicious activity
+4. **Validate all inputs** on client side
+5. **Handle errors gracefully**
+6. **Use strong passwords** (12+ chars)
+
+---
+
+## 🎯 **INTEGRATION EXAMPLES**
+
+### **Backend Integration:**
+
+```python
+import requests
+
+# Base configuration
+BASE_URL = "http://192.168.1.35:8080"
+ADMIN_TOKEN = "oht50_admin_token_2025"
+
+headers = {
+    "Authorization": f"Bearer {ADMIN_TOKEN}",
+    "Content-Type": "application/json"
+}
+
+# Get robot status
+response = requests.get(f"{BASE_URL}/api/v1/robot/status")
+status = response.json()
+print(f"Robot State: {status['data']['state']}")
+
+# Send command
+response = requests.post(
+    f"{BASE_URL}/api/v1/state/move",
+    headers=headers
+)
+result = response.json()
+print(f"Command Result: {result['success']}")
+
+# Get LiDAR data
+response = requests.get(f"{BASE_URL}/api/v1/lidar/scan_data")
+lidar = response.json()
+print(f"LiDAR Points: {lidar['data']['point_count']}")
+```
+
+---
+
+### **Frontend Integration (JavaScript):**
+
+```javascript
+const BASE_URL = "http://localhost:8080";
+const ADMIN_TOKEN = "oht50_admin_token_2025";
+
+// Fetch robot status
+async function getRobotStatus() {
+  const response = await fetch(`${BASE_URL}/api/v1/robot/status`);
+  const data = await response.json();
+  return data;
+}
+
+// Send control command (requires auth)
+async function sendCommand(endpoint) {
+  const response = await fetch(`${BASE_URL}/api/v1/state/${endpoint}`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${ADMIN_TOKEN}`
+    }
+  });
+  return await response.json();
+}
+
+// Connect WiFi
+async function connectWiFi(ssid, password) {
+  const response = await fetch(`${BASE_URL}/api/v1/network/wifi/connect`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${ADMIN_TOKEN}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ ssid, password })
+  });
+  return await response.json();
+}
+
+// Get LiDAR 360° scan
+async function getLidarScan360() {
+  const response = await fetch(
+    `${BASE_URL}/api/v1/lidar/scan_frame_360?reducer=max&interpolate=1`
+  );
+  const data = await response.json();
+  return data.data.distances; // Array of 360 distances
+}
+```
+
+---
+
+### **Mobile App Integration (React Native):**
+
+```javascript
+import axios from 'axios';
+
+const API = axios.create({
+  baseURL: 'http://192.168.1.35:8080',
+  timeout: 5000,
+  headers: {
+    'Authorization': 'Bearer oht50_operator_token_2025',
+    'Content-Type': 'application/json'
+  }
+});
+
+// Get network status
+export const getNetworkStatus = async () => {
+  try {
+    const response = await API.get('/api/v1/network/status');
+    return response.data;
+  } catch (error) {
+    console.error('Network status error:', error);
+    throw error;
+  }
+};
+
+// Scan WiFi networks
+export const scanWiFi = async () => {
+  try {
+    const response = await API.get('/api/v1/network/wifi/scan');
+    return response.data.data.networks;
+  } catch (error) {
+    console.error('WiFi scan error:', error);
+    throw error;
+  }
+};
+
+// Connect to WiFi
+export const connectWiFi = async (ssid, password) => {
+  try {
+    const response = await API.post('/api/v1/network/wifi/connect', {
+      ssid,
+      password
+    });
+    return response.data;
+  } catch (error) {
+    console.error('WiFi connect error:', error);
+    throw error;
+  }
+};
+```
+
+---
+
+## 🧪 **TESTING GUIDE**
+
+### **Test All APIs (Bash Script):**
+
+```bash
+#!/bin/bash
+BASE_URL="http://localhost:8080"
+ADMIN_TOKEN="oht50_admin_token_2025"
+
+echo "=== Testing Core APIs ==="
+curl -s $BASE_URL/health | jq
+curl -s $BASE_URL/api/v1/system/status | jq
+curl -s $BASE_URL/api/v1/robot/status | jq
+
+echo ""
+echo "=== Testing Network APIs ==="
+curl -s $BASE_URL/api/v1/network/status | jq
+curl -s $BASE_URL/api/v1/network/health | jq
+curl -s $BASE_URL/api/v1/network/wifi/scan | jq
+
+echo ""
+echo "=== Testing Module APIs ==="
+curl -s $BASE_URL/api/v1/rs485/modules | jq
+curl -s $BASE_URL/api/v1/modules/2/telemetry | jq
+
+echo ""
+echo "=== Testing LiDAR APIs ==="
+curl -s $BASE_URL/api/v1/lidar/status | jq
+curl -s $BASE_URL/api/v1/lidar/health | jq
+
+echo ""
+echo "=== Testing Protected APIs ==="
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+     $BASE_URL/api/v1/network/config | jq
+
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+     -X POST \
+     $BASE_URL/api/v1/state/stop | jq
+```
+
+---
+
+## 📝 **CHANGELOG**
+
+### **Version 3.0.0 (2025-10-07)**
+- ✅ **COMPLETE REWRITE** với 61 APIs tested & verified
+- ✅ Added authentication examples cho tất cả protected endpoints
+- ✅ Added detailed request/response examples
+- ✅ Added error codes và handling
+- ✅ Added password requirements
+- ✅ Added integration examples (Python, JavaScript, React Native)
+- ✅ Fixed 2 API bugs:
+  - WiFi statistics auth level (OPERATOR → PUBLIC)
+  - AP clients error (500 → 200 with empty list)
+- ✅ Verified all 61 APIs working correctly
+- ✅ Communication Health: 100%
+
+### **Version 2.6.0 (2025-01-28)**
+- WebSocket removed per CTO decision
+- HTTP-only on port 8080
+- Network APIs added
+
+---
+
+## 🎯 **SUPPORT**
+
+**Team:** Firmware Team - OHT-50  
+**Contact:** firmware@oht50.local  
+**Documentation:** `/home/orangepi/Desktop/OHT_V2/firmware_new/docs/`  
+**Source Code:** `/home/orangepi/Desktop/OHT_V2/firmware_new/src/app/api/`
+
+---
+
+**Last Updated:** 2025-10-07  
+**Version:** 3.0.0  
+**Status:** ✅ **Production Ready - All APIs Verified**

--- a/firmware_new/docs/06-REFERENCE/REF-006_LiDAR_HAL_API.md
+++ b/firmware_new/docs/06-REFERENCE/REF-006_LiDAR_HAL_API.md
@@ -1,0 +1,644 @@
+# 📚 **LiDAR HAL API Reference - Complete Guide**
+
+**Phiên bản:** 2.3.0  
+**Ngày cập nhật:** 2025-01-28  
+**Team:** EMBED  
+**Mục tiêu:** Tài liệu API đầy đủ cho tất cả LiDAR HAL features
+
+---
+
+## 📋 **TỔNG QUAN API**
+
+### **LiDAR HAL v2.3.0 Features:**
+- ✅ **Enhanced Resolution System** (v2.0.0)
+- ✅ **Advanced Multi-Sample & Calibration** (v2.1.0)
+- ✅ **Multi-Threading & Memory Pool** (v2.2.0)
+- ✅ **Adaptive Processing & Hardware Acceleration** (v2.3.0)
+
+### **API Categories:**
+1. **Core LiDAR Functions** - Basic LiDAR operations
+2. **Enhanced Resolution** - Adaptive resolution system
+3. **Advanced Multi-Sample** - Statistical averaging & calibration
+4. **Multi-Threading** - Parallel processing & memory management
+5. **Adaptive Processing** - Dynamic optimization & hardware acceleration
+
+---
+
+## 🔧 **CORE LIDAR FUNCTIONS**
+
+### **Initialization & Control**
+```c
+// Initialize LiDAR HAL
+hal_status_t hal_lidar_init(void);
+
+// Reset LiDAR
+hal_status_t hal_lidar_reset(void);
+
+// Start/Stop scanning
+hal_status_t hal_lidar_start_scan(void);
+hal_status_t hal_lidar_stop_scan(void);
+
+// Get scan data
+hal_status_t hal_lidar_get_scan_data(lidar_scan_data_t *scan_data);
+```
+
+### **Status & Information**
+```c
+// Get LiDAR status
+hal_status_t hal_lidar_get_status(lidar_status_t *status);
+
+// Get LiDAR information
+hal_status_t hal_lidar_get_info(lidar_info_t *info);
+
+// Get version
+const char* hal_lidar_get_version(void);
+```
+
+---
+
+## 🎯 **ENHANCED RESOLUTION SYSTEM (v2.0.0)**
+
+### **Adaptive Resolution Configuration**
+```c
+// Configure adaptive resolution
+hal_status_t hal_lidar_set_adaptive_resolution(
+    const lidar_adaptive_config_t *config
+);
+
+// Set focus area
+hal_status_t hal_lidar_set_focus_area(
+    float start_angle_deg,
+    float end_angle_deg,
+    float resolution_deg
+);
+
+// Get adaptive status
+hal_status_t hal_lidar_get_adaptive_status(
+    lidar_adaptive_config_t *config
+);
+```
+
+### **Data Structures**
+```c
+typedef struct {
+    float base_resolution_deg;        // Base resolution (default: 0.72°)
+    float focus_resolution_deg;       // Focus resolution (default: 0.36°)
+    float focus_start_angle_deg;      // Focus start angle (default: 0°)
+    float focus_end_angle_deg;        // Focus end angle (default: 90°)
+    bool enable_adaptive;             // Enable adaptive resolution (default: true)
+    bool enable_focus_area;           // Enable focus area (default: true)
+} lidar_adaptive_config_t;
+```
+
+### **Constants**
+```c
+#define LIDAR_BASE_RESOLUTION_DEG     0.72f
+#define LIDAR_FOCUS_RESOLUTION_DEG    0.36f
+#define LIDAR_MIN_RESOLUTION_DEG      0.18f
+#define LIDAR_MAX_RESOLUTION_DEG      1.44f
+#define LIDAR_FOCUS_AREA_MIN_DEG      0.0f
+#define LIDAR_FOCUS_AREA_MAX_DEG      360.0f
+```
+
+---
+
+## 📊 **ADVANCED MULTI-SAMPLE & CALIBRATION (v2.1.0)**
+
+### **Accuracy Configuration**
+```c
+// Configure accuracy settings
+hal_status_t hal_lidar_configure_accuracy(
+    const lidar_accuracy_config_t *config
+);
+
+// Configure advanced accuracy
+hal_status_t hal_lidar_configure_advanced_accuracy(
+    const lidar_accuracy_config_t *config
+);
+
+// Enable statistical averaging
+hal_status_t hal_lidar_enable_statistical_averaging(
+    bool enable,
+    float confidence_level
+);
+```
+
+### **Distance Calibration**
+```c
+// Calibrate distance
+hal_status_t hal_lidar_calibrate_distance(
+    float known_distance_mm,
+    float measured_distance_mm
+);
+
+// Apply calibration
+hal_status_t hal_lidar_apply_calibration(
+    const lidar_calibration_t *calibration
+);
+
+// Auto calibrate
+hal_status_t hal_lidar_auto_calibrate(void);
+
+// Calibrate multiple points
+hal_status_t hal_lidar_calibrate_multiple_points(
+    const lidar_calibration_point_t *points,
+    uint8_t point_count
+);
+
+// Detect calibration drift
+hal_status_t hal_lidar_detect_calibration_drift(
+    float *drift_factor,
+    bool *drift_detected
+);
+```
+
+### **Data Structures**
+```c
+typedef struct {
+    uint8_t sample_count;             // Sample count (default: 5)
+    uint32_t sample_interval_ms;      // Sample interval (default: 20ms)
+    bool enable_outlier_filter;       // Enable outlier filter (default: true)
+    float outlier_threshold;          // Outlier threshold (default: 20.0%)
+    bool enable_smoothing;            // Enable smoothing (default: true)
+    float smoothing_factor;           // Smoothing factor (default: 0.3)
+    
+    // Advanced features
+    bool enable_statistical_averaging; // Statistical averaging (default: false)
+    float confidence_level;           // Confidence level (default: 0.95)
+    bool enable_weighted_averaging;   // Weighted averaging (default: false)
+    bool enable_temporal_filtering;   // Temporal filtering (default: false)
+    uint32_t temporal_window_size;    // Temporal window size (default: 10)
+    float quality_threshold;          // Quality threshold (default: 0.8)
+} lidar_accuracy_config_t;
+
+typedef struct {
+    float calibration_factor;         // Calibration factor (default: 1.0)
+    float calibration_offset_mm;      // Calibration offset (default: 0.0mm)
+    bool enable_auto_calibration;     // Auto calibration (default: false)
+    uint32_t calibration_count;       // Calibration count (default: 0)
+    float calibration_confidence;     // Calibration confidence (default: 0.0)
+    
+    // Advanced features
+    bool enable_dynamic_calibration;  // Dynamic calibration (default: false)
+    float calibration_confidence;     // Calibration confidence (default: 0.0)
+    lidar_calibration_point_t calibration_points[LIDAR_MAX_CALIBRATION_POINTS];
+    float calibration_errors[LIDAR_MAX_CALIBRATION_POINTS];
+    bool enable_adaptive_calibration; // Adaptive calibration (default: false)
+    float calibration_drift_threshold; // Drift threshold (default: 0.05)
+} lidar_calibration_t;
+
+typedef struct {
+    float angle_deg;                  // Angle in degrees
+    float known_distance_mm;          // Known distance in mm
+    float measured_distance_mm;       // Measured distance in mm
+    float error_mm;                   // Error in mm
+    float confidence;                 // Confidence level
+} lidar_calibration_point_t;
+```
+
+### **Constants**
+```c
+#define LIDAR_MAX_SAMPLE_COUNT        20
+#define LIDAR_DEFAULT_CONFIDENCE      0.95f
+#define LIDAR_MAX_CALIBRATION_POINTS  10
+```
+
+---
+
+## 🧵 **MULTI-THREADING & MEMORY POOL (v2.2.0)**
+
+### **Threading Configuration**
+```c
+// Configure threading
+hal_status_t hal_lidar_configure_threading(
+    const lidar_threading_config_t *config
+);
+
+// Enable parallel processing
+hal_status_t hal_lidar_enable_parallel_processing(bool enable);
+
+// Set thread priority
+hal_status_t hal_lidar_set_thread_priority(
+    uint8_t thread_id,
+    int priority
+);
+
+// Set thread affinity
+hal_status_t hal_lidar_set_thread_affinity(
+    uint8_t thread_id,
+    uint8_t cpu_core
+);
+```
+
+### **Memory Pool Management**
+```c
+// Configure memory pool
+hal_status_t hal_lidar_configure_memory_pool(
+    const lidar_memory_pool_t *config
+);
+
+// Allocate memory block
+hal_status_t hal_lidar_allocate_memory_block(
+    size_t size,
+    void **memory_block
+);
+
+// Deallocate memory block
+hal_status_t hal_lidar_deallocate_memory_block(void *memory_block);
+
+// Compact memory pool
+hal_status_t hal_lidar_compact_memory_pool(void);
+```
+
+### **Data Structures**
+```c
+typedef struct {
+    uint8_t thread_count;             // Thread count (default: 4)
+    size_t thread_stack_size;         // Stack size (default: 64KB)
+    int thread_priority;              // Priority (default: 0)
+    bool enable_parallel_processing;  // Parallel processing (default: true)
+    bool enable_thread_priority;      // Thread priority (default: true)
+    bool enable_cpu_affinity;         // CPU affinity (default: false)
+    uint8_t cpu_core;                 // CPU core (default: 0)
+} lidar_threading_config_t;
+
+typedef struct {
+    size_t pool_size;                 // Pool size (default: 1MB)
+    size_t block_size;                // Block size (default: 4KB)
+    uint32_t max_blocks;              // Max blocks (default: 256)
+    uint32_t alignment;               // Alignment (default: 64)
+    bool enable_compaction;           // Enable compaction (default: true)
+    bool enable_statistics;           // Enable statistics (default: true)
+} lidar_memory_pool_t;
+```
+
+### **Constants**
+```c
+#define LIDAR_MAX_THREADS             6
+#define LIDAR_DEFAULT_THREAD_COUNT    4
+#define LIDAR_THREAD_STACK_SIZE       65536
+#define LIDAR_THREAD_PRIORITY_HIGH    10
+#define LIDAR_THREAD_PRIORITY_NORMAL  0
+#define LIDAR_THREAD_PRIORITY_LOW     -10
+
+#define LIDAR_MEMORY_POOL_SIZE        1048576
+#define LIDAR_MEMORY_BLOCK_SIZE       4096
+#define LIDAR_MAX_MEMORY_BLOCKS       256
+#define LIDAR_MEMORY_ALIGNMENT        64
+```
+
+---
+
+## 🚀 **ADAPTIVE PROCESSING & HARDWARE ACCELERATION (v2.3.0)**
+
+### **Adaptive Processing**
+```c
+// Configure adaptive processing
+hal_status_t hal_lidar_configure_adaptive_processing(
+    const lidar_adaptive_processing_config_t *config
+);
+
+// Enable adaptive processing
+hal_status_t hal_lidar_enable_adaptive_processing(bool enable);
+
+// Get adaptive processing status
+hal_status_t hal_lidar_get_adaptive_processing_status(
+    lidar_adaptive_processing_config_t *config,
+    bool *enabled
+);
+```
+
+### **Hardware Acceleration**
+```c
+// Configure hardware acceleration
+hal_status_t hal_lidar_configure_hardware_acceleration(
+    const lidar_hardware_acceleration_config_t *config
+);
+
+// Enable hardware acceleration
+hal_status_t hal_lidar_enable_hardware_acceleration(bool enable);
+
+// Get hardware acceleration status
+hal_status_t hal_lidar_get_hardware_acceleration_status(
+    lidar_hardware_acceleration_config_t *config,
+    bool *enabled
+);
+```
+
+### **Load Balancing**
+```c
+// Configure load balancing
+hal_status_t hal_lidar_configure_load_balancing(
+    const lidar_load_balancing_config_t *config
+);
+
+// Enable load balancing
+hal_status_t hal_lidar_enable_load_balancing(bool enable);
+
+// Get load balancing status
+hal_status_t hal_lidar_get_load_balancing_status(
+    lidar_load_balancing_config_t *config,
+    bool *enabled
+);
+```
+
+### **Performance Scaling**
+```c
+// Configure performance scaling
+hal_status_t hal_lidar_configure_performance_scaling(
+    const lidar_performance_scaling_config_t *config
+);
+
+// Enable performance scaling
+hal_status_t hal_lidar_enable_performance_scaling(bool enable);
+
+// Get performance scaling status
+hal_status_t hal_lidar_get_performance_scaling_status(
+    lidar_performance_scaling_config_t *config,
+    bool *enabled
+);
+```
+
+### **Performance Optimization**
+```c
+// Optimize performance
+hal_status_t hal_lidar_optimize_performance(void);
+
+// Scale performance
+hal_status_t hal_lidar_scale_performance(uint32_t target_frequency_mhz);
+
+// Balance workload
+hal_status_t hal_lidar_balance_workload(void);
+```
+
+### **Performance Monitoring**
+```c
+// Get performance metrics
+hal_status_t hal_lidar_get_performance_metrics(
+    float *efficiency,
+    float *throughput,
+    float *latency
+);
+
+// Get power consumption
+hal_status_t hal_lidar_get_power_consumption(uint32_t *power_mw);
+
+// Get thermal status
+hal_status_t hal_lidar_get_thermal_status(float *temperature_c);
+```
+
+### **Data Structures**
+```c
+typedef struct {
+    uint8_t max_algorithms;           // Max algorithms (default: 6)
+    uint32_t update_interval_ms;      // Update interval (default: 100ms)
+    float learning_rate;              // Learning rate (default: 0.15)
+    float convergence_threshold;      // Convergence threshold (default: 0.01)
+    uint32_t performance_window_ms;   // Performance window (default: 1000ms)
+    bool enable_optimization;         // Enable optimization (default: true)
+    bool enable_scaling;              // Enable scaling (default: true)
+    bool enable_balancing;            // Enable balancing (default: true)
+} lidar_adaptive_processing_config_t;
+
+typedef struct {
+    uint8_t max_devices;              // Max devices (default: 3)
+    uint32_t batch_size;              // Batch size (default: 128)
+    uint32_t queue_size;              // Queue size (default: 256)
+    bool enable_gpu;                  // Enable GPU (default: true)
+    bool enable_dsp;                  // Enable DSP (default: true)
+    bool enable_neon;                 // Enable NEON (default: true)
+    float gpu_utilization;            // GPU utilization (default: 0.8)
+    float dsp_utilization;            // DSP utilization (default: 0.7)
+    float neon_utilization;           // NEON utilization (default: 0.9)
+} lidar_hardware_acceleration_config_t;
+
+typedef struct {
+    uint8_t max_workloads;            // Max workloads (default: 8)
+    uint32_t update_rate_ms;          // Update rate (default: 50ms)
+    float threshold;                  // Migration threshold (default: 0.75)
+    float migration_cost;             // Migration cost (default: 0.1)
+    bool enable_migration;            // Enable migration (default: true)
+    bool enable_scheduling;           // Enable scheduling (default: true)
+    bool enable_monitoring;           // Enable monitoring (default: true)
+} lidar_load_balancing_config_t;
+
+typedef struct {
+    uint32_t min_frequency_mhz;       // Min frequency (default: 200)
+    uint32_t max_frequency_mhz;       // Max frequency (default: 2400)
+    uint32_t step_size_mhz;           // Step size (default: 100)
+    uint32_t target_latency_ms;       // Target latency (default: 5)
+    uint32_t power_budget_mw;         // Power budget (default: 8000)
+    bool enable_dynamic_scaling;      // Dynamic scaling (default: true)
+    bool enable_power_management;     // Power management (default: true)
+    bool enable_thermal_control;      // Thermal control (default: true)
+} lidar_performance_scaling_config_t;
+```
+
+### **Constants**
+```c
+#define LIDAR_ADAPTIVE_MAX_ALGORITHMS          6
+#define LIDAR_ADAPTIVE_UPDATE_INTERVAL         100     // ms
+#define LIDAR_ADAPTIVE_LEARNING_RATE           0.15
+#define LIDAR_ADAPTIVE_CONVERGENCE_THRESHOLD   0.01
+#define LIDAR_ADAPTIVE_PERFORMANCE_WINDOW      1000    // ms
+
+#define LIDAR_HW_ACCEL_GPU_ENABLED             true
+#define LIDAR_HW_ACCEL_DSP_ENABLED             true
+#define LIDAR_HW_ACCEL_NEON_ENABLED            true
+#define LIDAR_HW_ACCEL_MAX_DEVICES             3
+#define LIDAR_HW_ACCEL_BATCH_SIZE              128
+#define LIDAR_HW_ACCEL_QUEUE_SIZE              256
+
+#define LIDAR_LOAD_BALANCE_MAX_WORKLOADS       8
+#define LIDAR_LOAD_BALANCE_UPDATE_RATE         50      // ms
+#define LIDAR_LOAD_BALANCE_THRESHOLD           0.75
+#define LIDAR_LOAD_BALANCE_MIGRATION_COST      0.1
+
+#define LIDAR_PERF_SCALE_MIN_FREQ              200     // MHz
+#define LIDAR_PERF_SCALE_MAX_FREQ              2400    // MHz
+#define LIDAR_PERF_SCALE_STEP_SIZE             100     // MHz
+#define LIDAR_PERF_SCALE_TARGET_LATENCY        5       // ms
+#define LIDAR_PERF_SCALE_POWER_BUDGET          8000    // mW
+```
+
+---
+
+## 🔍 **ERROR CODES**
+
+### **HAL Status Codes**
+```c
+typedef enum {
+    HAL_OK = 0,                      // Success
+    HAL_ERROR = -1,                  // General error
+    HAL_ERROR_INVALID_PARAM = -2,    // Invalid parameter
+    HAL_ERROR_NOT_INITIALIZED = -3,  // Not initialized
+    HAL_ERROR_ALREADY_INITIALIZED = -4, // Already initialized
+    HAL_ERROR_HARDWARE_FAILURE = -5, // Hardware failure
+    HAL_ERROR_MEMORY_ALLOCATION = -6, // Memory allocation failure
+    HAL_ERROR_THREAD_CREATION = -7,  // Thread creation failure
+    HAL_ERROR_TIMEOUT = -8,          // Timeout
+    HAL_ERROR_NOT_SUPPORTED = -9     // Not supported
+} hal_status_t;
+```
+
+---
+
+## 💡 **USAGE EXAMPLES**
+
+### **Complete Setup Example**
+```c
+#include "hal_lidar.h"
+
+int main() {
+    // Initialize LiDAR HAL
+    hal_status_t status = hal_lidar_init();
+    if (status != HAL_OK) {
+        printf("❌ LiDAR initialization failed\n");
+        return -1;
+    }
+    
+    // Configure Enhanced Resolution
+    lidar_adaptive_config_t adaptive_config = {
+        .base_resolution_deg = 0.72f,
+        .focus_resolution_deg = 0.36f,
+        .focus_start_angle_deg = 45.0f,
+        .focus_end_angle_deg = 135.0f,
+        .enable_adaptive = true,
+        .enable_focus_area = true
+    };
+    hal_lidar_set_adaptive_resolution(&adaptive_config);
+    
+    // Configure Advanced Multi-Sample
+    lidar_accuracy_config_t accuracy_config = {
+        .sample_count = 5,
+        .sample_interval_ms = 20,
+        .enable_outlier_filter = true,
+        .outlier_threshold = 20.0f,
+        .enable_smoothing = true,
+        .smoothing_factor = 0.3f,
+        .enable_statistical_averaging = true,
+        .confidence_level = 0.95f
+    };
+    hal_lidar_configure_accuracy(&accuracy_config);
+    
+    // Configure Multi-Threading
+    lidar_threading_config_t threading_config = {
+        .thread_count = 4,
+        .thread_stack_size = 65536,
+        .thread_priority = 0,
+        .enable_parallel_processing = true,
+        .enable_thread_priority = true,
+        .enable_cpu_affinity = false
+    };
+    hal_lidar_configure_threading(&threading_config);
+    
+    // Configure Adaptive Processing
+    lidar_adaptive_processing_config_t adaptive_processing_config = {
+        .max_algorithms = 6,
+        .update_interval_ms = 100,
+        .learning_rate = 0.15f,
+        .convergence_threshold = 0.01f,
+        .performance_window_ms = 1000,
+        .enable_optimization = true,
+        .enable_scaling = true,
+        .enable_balancing = true
+    };
+    hal_lidar_configure_adaptive_processing(&adaptive_processing_config);
+    
+    // Enable all features
+    hal_lidar_enable_adaptive_processing(true);
+    hal_lidar_enable_parallel_processing(true);
+    
+    // Start scanning
+    status = hal_lidar_start_scan();
+    if (status == HAL_OK) {
+        printf("✅ LiDAR scanning started with all enhanced features\n");
+    }
+    
+    return 0;
+}
+```
+
+---
+
+## 🧪 **TESTING**
+
+### **Test Programs**
+```bash
+# Enhanced Resolution Test
+make -f Makefile.enhanced test
+
+# Advanced Multi-Sample Test
+make -f Makefile.enhanced test-advanced
+
+# Multi-Threading Test
+make -f Makefile.enhanced test-multithreading
+
+# Adaptive Processing Test
+make -f Makefile.enhanced test-adaptive
+
+# All Tests
+make -f Makefile.enhanced test-all
+```
+
+### **Test Coverage**
+- ✅ **Core LiDAR Functions**
+- ✅ **Enhanced Resolution System**
+- ✅ **Advanced Multi-Sample & Calibration**
+- ✅ **Multi-Threading & Memory Pool**
+- ✅ **Adaptive Processing & Hardware Acceleration**
+- ✅ **Error Handling & Edge Cases**
+
+---
+
+## 📊 **PERFORMANCE METRICS**
+
+### **Overall Performance Improvement**
+| Feature | Baseline | Enhanced | Improvement |
+|---------|----------|----------|-------------|
+| **Resolution** | 0.72° | 0.18° | +300% |
+| **Accuracy** | ±30mm | ±15mm | +100% |
+| **Efficiency** | 60% | 95% | +58% |
+| **Throughput** | 1000 ops/s | 2079 ops/s | +108% |
+| **Latency** | 15ms | 6.72ms | -55% |
+| **Power** | 8000mW | 4600mW | -43% |
+
+---
+
+## 📚 **RELATED DOCUMENTS**
+
+- **Enhanced Resolution Guide:** `LIDAR_ENHANCED_RESOLUTION_GUIDE.md`
+- **Advanced Multi-Sample Guide:** `LIDAR_ADVANCED_MULTI_SAMPLE_GUIDE.md`
+- **Multi-Threading Guide:** `LIDAR_MULTI_THREADING_GUIDE.md`
+- **Adaptive Processing Guide:** `LIDAR_ADAPTIVE_PROCESSING_GUIDE.md`
+- **LiDAR HAL Header:** `hal_lidar.h`
+
+---
+
+## 🚀 **CHANGELOG**
+
+### **Version 2.3.0 (2025-01-28)**
+- ✅ **Added Adaptive Processing & Hardware Acceleration**
+- ✅ **Added Load Balancing & Performance Scaling**
+- ✅ **Added Real-time Optimization**
+- ✅ **Added Performance Monitoring**
+- ✅ **Updated API Reference** với complete documentation
+
+### **Version 2.2.0 (2025-01-28)**
+- ✅ **Added Multi-Threading & Memory Pool**
+- ✅ **Added Thread Priority & CPU Affinity**
+- ✅ **Added Memory Management**
+
+### **Version 2.1.0 (2025-01-28)**
+- ✅ **Added Advanced Multi-Sample & Calibration**
+- ✅ **Added Statistical Averaging**
+- ✅ **Added Dynamic Calibration**
+
+### **Version 2.0.0 (2025-01-28)**
+- ✅ **Added Enhanced Resolution System**
+- ✅ **Added Adaptive Resolution**
+- ✅ **Added Focus Area Control**
+
+---
+
+**🎯 LiDAR HAL v2.3.0 API Reference - Complete and ready for production use!**

--- a/firmware_new/docs/06-REFERENCE/REF-007_Safety_Architecture.md
+++ b/firmware_new/docs/06-REFERENCE/REF-007_Safety_Architecture.md
@@ -1,0 +1,770 @@
+# 🏗️ **OHT-50 FIRMWARE APP SAFETY ARCHITECTURE - CTO DECISION**
+
+**Phiên bản:** 1.0  
+**Ngày tạo:** 2025-01-28  
+**Người tạo:** CTO Team  
+**Trạng thái:** ✅ APPROVED - Production Ready  
+**Mục tiêu:** Định nghĩa cấu trúc firmware app an toàn và đạt chuẩn nhất cho OHT-50
+
+---
+
+## 🎯 **TỔNG QUAN KIẾN TRÚC**
+
+### **Nguyên tắc thiết kế:**
+1. **Safety-First Architecture** - An toàn là ưu tiên tuyệt đối
+2. **Fail-Safe Design** - Thiết kế an toàn khi lỗi
+3. **Real-time Performance** - Hiệu suất thời gian thực
+4. **Modular Architecture** - Kiến trúc module hóa
+5. **ISO/IEC 12207 Compliance** - Tuân thủ chuẩn quốc tế
+6. **MISRA C:2012 Standards** - Tiêu chuẩn coding an toàn
+
+---
+
+## 🏗️ **KIẾN TRÚC TỔNG THỂ**
+
+### **4-Layer Architecture:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OHT-50 FIRMWARE APP                     │
+├─────────────────────────────────────────────────────────────┤
+│  🎯 APPLICATION LAYER (App Logic & API)                    │
+│  ├─ State Machine, Module Handlers, API Endpoints          │
+│  ├─ Safety Monitor, Control Logic, Communication           │
+│  └─ Configuration, Logging, Diagnostics                    │
+├─────────────────────────────────────────────────────────────┤
+│  🛡️ SAFETY LAYER (Safety-Critical Systems)                 │
+│  ├─ E-Stop System, Safety Interlocks, Watchdog            │
+│  ├─ Emergency Procedures, Fault Detection                  │
+│  └─ Safety State Machine, Hazard Analysis                 │
+├─────────────────────────────────────────────────────────────┤
+│  ⚙️ HAL LAYER (Hardware Abstraction)                       │
+│  ├─ RS485 HAL, GPIO HAL, Network HAL                       │
+│  ├─ LED HAL, Relay HAL, Sensor HAL                         │
+│  └─ Platform Abstraction, Driver Interface                 │
+├─────────────────────────────────────────────────────────────┤
+│  🔧 DRIVER LAYER (Platform-Specific Drivers)               │
+│  ├─ UART Drivers, GPIO Drivers, Network Drivers             │
+│  ├─ Hardware Drivers, System Drivers                       │
+│  └─ Orange Pi 5B Specific, RK3588 Drivers                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### **Kiến trúc chi tiết với luồng dữ liệu:**
+```mermaid
+graph TB
+    subgraph "APPLICATION LAYER"
+        A1[App Controller]
+        A2[State Machine]
+        A3[Module Handlers]
+        A4[API Server]
+        A5[Telemetry System]
+    end
+    
+    subgraph "SAFETY LAYER"
+        S1[Safety Monitor]
+        S2[E-Stop System]
+        S3[Safety Interlocks]
+        S4[Watchdog System]
+        S5[Emergency Procedures]
+    end
+    
+    subgraph "HAL LAYER"
+        H1[RS485 HAL]
+        H2[GPIO HAL]
+        H3[Network HAL]
+        H4[LED HAL]
+        H5[Relay HAL]
+    end
+    
+    subgraph "DRIVER LAYER"
+        D1[UART Driver]
+        D2[GPIO Driver]
+        D3[Network Driver]
+        D4[System Driver]
+    end
+    
+    subgraph "HARDWARE"
+        HW1[Orange Pi 5B]
+        HW2[RS485 Bus]
+        HW3[GPIO Pins]
+        HW4[Network Interface]
+    end
+    
+    A1 --> S1
+    A2 --> S2
+    A3 --> S3
+    A4 --> S4
+    A5 --> S5
+    
+    S1 --> H1
+    S2 --> H2
+    S3 --> H3
+    S4 --> H4
+    S5 --> H5
+    
+    H1 --> D1
+    H2 --> D2
+    H3 --> D3
+    H4 --> D4
+    H5 --> D4
+    
+    D1 --> HW1
+    D2 --> HW3
+    D3 --> HW4
+    D4 --> HW1
+    
+    HW1 --> HW2
+```
+
+### **Luồng dữ liệu an toàn:**
+```mermaid
+sequenceDiagram
+    participant App as Application Layer
+    participant Safety as Safety Layer
+    participant HAL as HAL Layer
+    participant Driver as Driver Layer
+    participant HW as Hardware
+    
+    App->>Safety: Request Operation
+    Safety->>Safety: Validate Safety
+    alt Safety OK
+        Safety->>HAL: Execute Operation
+        HAL->>Driver: Hardware Command
+        Driver->>HW: Physical Action
+        HW-->>Driver: Status Response
+        Driver-->>HAL: Hardware Status
+        HAL-->>Safety: Operation Result
+        Safety-->>App: Success Response
+    else Safety Violation
+        Safety->>Safety: Trigger E-Stop
+        Safety->>HAL: Emergency Stop
+        HAL->>Driver: Emergency Command
+        Driver->>HW: Emergency Action
+        Safety-->>App: Safety Error
+    end
+```
+
+---
+
+## 🎯 **APPLICATION LAYER - CORE STRUCTURE**
+
+### **1. Main Application Controller**
+```c
+// src/app/core/app_controller.h
+typedef struct {
+    system_state_t current_state;
+    safety_status_t safety_status;
+    module_manager_t module_manager;
+    communication_manager_t comm_manager;
+    config_manager_t config_manager;
+    logger_t logger;
+    watchdog_t watchdog;
+} app_controller_t;
+
+// Main application entry point
+int app_main(void);
+int app_init(void);
+int app_run(void);
+int app_shutdown(void);
+```
+
+### **2. State Machine System**
+```c
+// src/app/core/state_machine.h
+typedef enum {
+    STATE_INIT = 0,
+    STATE_IDLE,
+    STATE_MOVING,
+    STATE_DOCKING,
+    STATE_MAINTENANCE,
+    STATE_FAULT,
+    STATE_EMERGENCY_STOP,
+    STATE_SHUTDOWN
+} system_state_t;
+
+typedef struct {
+    system_state_t current_state;
+    system_state_t previous_state;
+    uint32_t state_entry_time;
+    uint32_t state_timeout;
+    bool state_valid;
+} state_machine_t;
+```
+
+### **3. Safety Monitor System**
+```c
+// src/app/safety/safety_monitor.h
+typedef struct {
+    bool e_stop_active;
+    bool safety_interlock_ok;
+    bool watchdog_ok;
+    bool communication_ok;
+    bool hardware_ok;
+    uint32_t last_safety_check;
+    safety_level_t safety_level;
+} safety_monitor_t;
+
+// Safety-critical functions
+int safety_monitor_init(void);
+int safety_monitor_check(void);
+int safety_emergency_stop(void);
+int safety_validate_operation(operation_t op);
+```
+
+---
+
+## 🛡️ **SAFETY LAYER - CRITICAL SYSTEMS**
+
+### **1. E-Stop System Architecture**
+```c
+// src/app/safety/estop_system.h
+typedef struct {
+    bool hardware_estop;
+    bool software_estop;
+    bool network_estop;
+    bool safety_zone_estop;
+    uint32_t estop_timestamp;
+    estop_source_t estop_source;
+} estop_system_t;
+
+// E-Stop functions (CRITICAL - < 100ms response)
+int estop_hardware_check(void);
+int estop_software_trigger(void);
+int estop_network_trigger(void);
+int estop_safety_zone_trigger(void);
+int estop_emergency_shutdown(void);
+```
+
+### **2. Safety Interlock System**
+```c
+// src/app/safety/safety_interlock.h
+typedef struct {
+    bool power_module_ok;
+    bool safety_module_ok;
+    bool motor_module_ok;
+    bool dock_module_ok;
+    bool communication_ok;
+    bool lidar_safety_ok;
+    uint32_t interlock_check_time;
+} safety_interlock_t;
+
+// Interlock validation
+int safety_interlock_validate(void);
+int safety_interlock_check_module(uint8_t module_id);
+int safety_interlock_emergency_lock(void);
+```
+
+### **3. Watchdog System**
+```c
+// src/app/safety/watchdog_system.h
+typedef struct {
+    uint32_t last_feed_time;
+    uint32_t timeout_period;
+    bool watchdog_active;
+    bool watchdog_triggered;
+    uint32_t feed_interval;
+} watchdog_system_t;
+
+// Watchdog functions
+int watchdog_init(uint32_t timeout_ms);
+int watchdog_feed(void);
+int watchdog_check(void);
+int watchdog_emergency_reset(void);
+```
+
+---
+
+## ⚙️ **HAL LAYER - HARDWARE ABSTRACTION**
+
+### **1. RS485 Communication HAL**
+```c
+// src/hal/rs485_hal.h
+typedef struct {
+    int uart_fd;
+    int de_re_gpio;
+    uint32_t baudrate;
+    uint8_t data_bits;
+    uint8_t stop_bits;
+    char parity;
+    bool termination_enabled;
+    uint32_t timeout_ms;
+} rs485_config_t;
+
+// RS485 HAL API
+int rs485_hal_init(rs485_config_t *config);
+int rs485_hal_send(uint8_t *data, size_t len);
+int rs485_hal_receive(uint8_t *buffer, size_t max_len);
+int rs485_hal_set_termination(bool enable);
+int rs485_hal_get_stats(rs485_stats_t *stats);
+```
+
+### **2. GPIO Control HAL**
+```c
+// src/hal/gpio_hal.h
+typedef enum {
+    RELAY_CHANNEL_1 = 1,
+    RELAY_CHANNEL_2 = 2,
+    LED_POWER = 3,
+    LED_SYSTEM = 4,
+    LED_COMM = 5,
+    LED_NETWORK = 6,
+    LED_ERROR = 7
+} gpio_channel_t;
+
+// GPIO HAL API
+int gpio_hal_init(void);
+int gpio_hal_set_relay(relay_channel_t channel, bool state);
+int gpio_hal_set_led(led_channel_t channel, bool state);
+int gpio_hal_get_estop_status(void);
+int gpio_hal_emergency_off_all(void);
+```
+
+### **3. Network Communication HAL**
+```c
+// src/hal/network_hal.h
+typedef struct {
+    int socket_fd;
+    char server_ip[16];
+    uint16_t server_port;
+    bool connection_active;
+    uint32_t last_heartbeat;
+    uint32_t timeout_ms;
+} network_config_t;
+
+// Network HAL API
+int network_hal_init(network_config_t *config);
+int network_hal_connect(void);
+int network_hal_send(uint8_t *data, size_t len);
+int network_hal_receive(uint8_t *buffer, size_t max_len);
+int network_hal_disconnect(void);
+```
+
+---
+
+## 🔧 **DRIVER LAYER - PLATFORM SPECIFIC**
+
+### **1. Orange Pi 5B Platform Drivers**
+```c
+// src/drivers/orange_pi_5b/platform_driver.h
+// UART1 RS485 Driver
+int uart1_driver_init(void);
+int uart1_driver_send(uint8_t *data, size_t len);
+int uart1_driver_receive(uint8_t *buffer, size_t max_len);
+
+// GPIO Drivers
+int gpio_driver_init(void);
+int gpio_driver_set_pin(uint8_t pin, bool state);
+int gpio_driver_get_pin(uint8_t pin);
+
+// System Drivers
+int system_driver_init(void);
+int system_driver_get_temperature(void);
+int system_driver_get_voltage(void);
+```
+
+### **2. RK3588 SoC Drivers**
+```c
+// src/drivers/rk3588/soc_driver.h
+// SoC-specific functions
+int rk3588_driver_init(void);
+int rk3588_driver_configure_uart1(void);
+int rk3588_driver_configure_gpio(void);
+int rk3588_driver_configure_pinctrl(void);
+```
+
+---
+
+## 📁 **FILE STRUCTURE - PRODUCTION READY**
+
+### **Complete Directory Structure:**
+```
+firmware_new/
+├── src/
+│   ├── app/                          # Application Layer
+│   │   ├── core/                    # Core application logic
+│   │   │   ├── app_controller.c/h   # Main application controller
+│   │   │   ├── state_machine.c/h    # System state machine
+│   │   │   ├── control_loop.c/h     # Motion control loop
+│   │   │   └── system_controller.c/h # System coordination
+│   │   ├── safety/                  # Safety-critical systems
+│   │   │   ├── safety_monitor.c/h   # Safety monitoring
+│   │   │   ├── estop_system.c/h     # E-Stop system
+│   │   │   ├── safety_interlock.c/h # Safety interlocks
+│   │   │   └── watchdog_system.c/h  # Watchdog system
+│   │   ├── modules/                 # Module handlers
+│   │   │   ├── power_module.c/h     # Power module handler
+│   │   │   ├── safety_module.c/h    # Safety module handler
+│   │   │   ├── motor_module.c/h     # Motor module handler
+│   │   │   └── dock_module.c/h      # Dock module handler
+│   │   ├── communication/           # Communication systems
+│   │   │   ├── api_server.c/h       # HTTP API server
+│   │   │   ├── modbus_handler.c/h   # Modbus RTU handler
+│   │   │   └── telemetry_sender.c/h  # Telemetry system
+│   │   └── configuration/           # Configuration management
+│   │       ├── config_manager.c/h   # Configuration manager
+│   │       ├── config_storage.c/h   # Configuration storage
+│   │       └── config_validation.c/h # Configuration validation
+│   ├── hal/                         # Hardware Abstraction Layer
+│   │   ├── rs485_hal.c/h           # RS485 HAL
+│   │   ├── gpio_hal.c/h            # GPIO HAL
+│   │   ├── network_hal.c/h         # Network HAL
+│   │   ├── led_hal.c/h             # LED HAL
+│   │   ├── relay_hal.c/h           # Relay HAL
+│   │   └── sensor_hal.c/h          # Sensor HAL
+│   ├── drivers/                     # Platform-specific drivers
+│   │   ├── orange_pi_5b/           # Orange Pi 5B drivers
+│   │   │   ├── platform_driver.c/h # Platform driver
+│   │   │   ├── uart_driver.c/h     # UART driver
+│   │   │   ├── gpio_driver.c/h     # GPIO driver
+│   │   │   └── system_driver.c/h   # System driver
+│   │   └── rk3588/                 # RK3588 SoC drivers
+│   │       ├── soc_driver.c/h      # SoC driver
+│   │       ├── pinctrl_driver.c/h  # Pin control driver
+│   │       └── clock_driver.c/h    # Clock driver
+│   ├── common/                      # Common utilities
+│   │   ├── logger.c/h              # Logging system
+│   │   ├── error_handler.c/h        # Error handling
+│   │   ├── memory_manager.c/h       # Memory management
+│   │   └── utils.c/h               # Utility functions
+│   └── main.c                       # Main entry point
+├── include/                         # Header files
+│   ├── app/                        # Application headers
+│   ├── hal/                        # HAL headers
+│   ├── drivers/                    # Driver headers
+│   └── common/                     # Common headers
+├── tests/                          # Test suites
+│   ├── unit/                       # Unit tests
+│   ├── integration/                # Integration tests
+│   ├── safety/                     # Safety tests
+│   └── performance/                # Performance tests
+├── scripts/                        # Build and deployment scripts
+│   ├── build.sh                    # Build script
+│   ├── test.sh                     # Test script
+│   ├── deploy.sh                   # Deployment script
+│   └── safety_test.sh              # Safety test script
+├── config/                         # Configuration files
+│   ├── default_config.json         # Default configuration
+│   ├── safety_config.json          # Safety configuration
+│   └── hardware_config.json        # Hardware configuration
+├── docs/                          # Documentation
+│   ├── architecture/              # Architecture documentation
+│   ├── api/                       # API documentation
+│   ├── safety/                    # Safety documentation
+│   └── user_guide/                # User guide
+└── CMakeLists.txt                 # CMake build configuration
+```
+
+---
+
+## 🛡️ **SAFETY REQUIREMENTS - CRITICAL**
+
+### **1. Safety Integrity Level (SIL)**
+- **SIL Level:** SIL 2 (Basic Safety)
+- **Safety Functions:** E-Stop, Safety Interlocks, Watchdog
+- **Failure Rate:** < 10^-6 failures/hour
+- **Response Time:** E-Stop < 100ms
+- **Safety Validation:** Hardware-in-the-Loop testing
+
+### **2. Safety Architecture Principles**
+```c
+// Safety-critical function example
+int safety_emergency_stop(void) {
+    // CRITICAL: Must complete within 100ms
+    uint32_t start_time = get_system_time_ms();
+    
+    // 1. Hardware E-Stop (highest priority)
+    if (hardware_estop_active()) {
+        gpio_hal_emergency_off_all();
+        relay_hal_emergency_off_all();
+        motor_hal_emergency_stop();
+        return SAFETY_ESTOP_HARDWARE;
+    }
+    
+    // 2. Software E-Stop
+    if (software_estop_triggered()) {
+        motor_hal_emergency_stop();
+        return SAFETY_ESTOP_SOFTWARE;
+    }
+    
+    // 3. Safety zone violation
+    if (safety_zone_violated()) {
+        motor_hal_emergency_stop();
+        return SAFETY_ESTOP_ZONE;
+    }
+    
+    // Validate response time
+    uint32_t response_time = get_system_time_ms() - start_time;
+    if (response_time > 100) {
+        // CRITICAL: Response time exceeded
+        log_critical_error("E-Stop response time exceeded: %dms", response_time);
+        return SAFETY_ERROR_TIMEOUT;
+    }
+    
+    return SAFETY_OK;
+}
+```
+
+### **3. Safety State Machine**
+```c
+// Safety state machine
+typedef enum {
+    SAFETY_STATE_NORMAL = 0,
+    SAFETY_STATE_WARNING,
+    SAFETY_STATE_FAULT,
+    SAFETY_STATE_EMERGENCY,
+    SAFETY_STATE_SHUTDOWN
+} safety_state_t;
+
+// Safety state transitions
+int safety_state_transition(safety_state_t new_state) {
+    // Validate state transition
+    if (!safety_state_transition_valid(current_state, new_state)) {
+        return SAFETY_ERROR_INVALID_TRANSITION;
+    }
+    
+    // Execute safety actions for new state
+    switch (new_state) {
+        case SAFETY_STATE_EMERGENCY:
+            return safety_emergency_stop();
+        case SAFETY_STATE_FAULT:
+            return safety_fault_handling();
+        case SAFETY_STATE_SHUTDOWN:
+            return safety_shutdown_sequence();
+        default:
+            break;
+    }
+    
+    return SAFETY_OK;
+}
+```
+
+---
+
+## ⚡ **REAL-TIME REQUIREMENTS**
+
+### **1. Real-time Constraints**
+- **Control Loop:** 10ms cycle time
+- **Safety Check:** 5ms cycle time
+- **Communication:** 50ms timeout
+- **E-Stop Response:** < 100ms
+- **Watchdog:** 1s timeout
+
+### **2. Real-time Implementation**
+```c
+// Real-time control loop
+void control_loop_task(void) {
+    static uint32_t last_cycle_time = 0;
+    uint32_t current_time = get_system_time_ms();
+    
+    // Ensure 10ms cycle time
+    if (current_time - last_cycle_time < 10) {
+        return; // Too early for next cycle
+    }
+    
+    // Update cycle time
+    last_cycle_time = current_time;
+    
+    // Execute control logic
+    control_loop_execute();
+    
+    // Update safety status
+    safety_monitor_check();
+    
+    // Send telemetry
+    telemetry_send_update();
+}
+```
+
+---
+
+## 🔒 **SECURITY REQUIREMENTS**
+
+### **1. Security Architecture**
+- **Authentication:** Bearer token validation
+- **Authorization:** Role-based access control
+- **Encryption:** TLS 1.3 for network communication
+- **Secure Boot:** Verified boot sequence
+- **Secure Storage:** Encrypted configuration storage
+
+### **2. Security Implementation**
+```c
+// Security functions
+int security_validate_token(const char *token);
+int security_check_permissions(uint8_t user_id, uint8_t operation);
+int security_encrypt_data(uint8_t *data, size_t len, uint8_t *encrypted);
+int security_decrypt_data(uint8_t *encrypted, size_t len, uint8_t *data);
+```
+
+---
+
+## 📊 **PERFORMANCE REQUIREMENTS**
+
+### **1. Performance Metrics**
+- **CPU Usage:** < 60% average
+- **Memory Usage:** < 512MB
+- **Response Time:** API < 50ms
+- **Throughput:** 1000+ requests/second
+- **Latency:** Network < 10ms
+
+### **2. Performance Monitoring**
+```c
+// Performance monitoring
+typedef struct {
+    uint32_t cpu_usage_percent;
+    uint32_t memory_usage_mb;
+    uint32_t response_time_ms;
+    uint32_t throughput_rps;
+    uint32_t error_count;
+} performance_metrics_t;
+
+int performance_monitor_init(void);
+int performance_monitor_update(performance_metrics_t *metrics);
+int performance_monitor_check_thresholds(void);
+```
+
+---
+
+## 🧪 **TESTING STRATEGY**
+
+### **1. Testing Levels**
+- **Unit Tests:** Individual function testing
+- **Integration Tests:** Module integration testing
+- **Safety Tests:** Safety-critical function testing
+- **Performance Tests:** Real-time performance testing
+- **HIL Tests:** Hardware-in-the-Loop testing
+
+### **2. Test Implementation**
+```c
+// Test framework
+int test_safety_estop_response_time(void) {
+    uint32_t start_time = get_system_time_ms();
+    int result = safety_emergency_stop();
+    uint32_t response_time = get_system_time_ms() - start_time;
+    
+    // Assert response time < 100ms
+    assert(response_time < 100);
+    assert(result == SAFETY_OK);
+    
+    return TEST_PASS;
+}
+```
+
+---
+
+## 🚀 **DEPLOYMENT STRATEGY**
+
+### **1. Build Configuration**
+```cmake
+# CMakeLists.txt
+cmake_minimum_required(VERSION 3.16)
+project(OHT50_Firmware)
+
+# Safety configuration
+set(SAFETY_LEVEL SIL2)
+set(RESPONSE_TIME_MS 100)
+set(WATCHDOG_TIMEOUT_MS 1000)
+
+# Platform configuration
+set(PLATFORM OrangePi5B)
+set(SOC RK3588)
+
+# Build targets
+add_executable(firmware_app src/main.c)
+target_link_libraries(firmware_app hal drivers common)
+```
+
+### **2. Deployment Process**
+```bash
+# Build script
+#!/bin/bash
+./scripts/build.sh Release
+./scripts/test.sh
+./scripts/safety_test.sh
+./scripts/deploy.sh
+```
+
+---
+
+## 📋 **IMPLEMENTATION CHECKLIST**
+
+### **Phase 1: Foundation (Week 1-2)**
+- [ ] Core application structure
+- [ ] HAL layer implementation
+- [ ] Basic safety system
+- [ ] Unit tests
+
+### **Phase 2: Safety Systems (Week 3-4)**
+- [ ] E-Stop system implementation
+- [ ] Safety interlock system
+- [ ] Watchdog system
+- [ ] Safety tests
+
+### **Phase 3: Communication (Week 5-6)**
+- [ ] RS485 communication
+- [ ] HTTP API server
+- [ ] Telemetry system
+- [ ] Integration tests
+
+### **Phase 4: Module Handlers (Week 7-8)**
+- [ ] Power module handler
+- [ ] Safety module handler
+- [ ] Motor module handler
+- [ ] Dock module handler
+
+### **Phase 5: Integration (Week 9-10)**
+- [ ] End-to-end integration
+- [ ] Performance optimization
+- [ ] Security implementation
+- [ ] Documentation
+
+---
+
+## 🎯 **SUCCESS CRITERIA**
+
+### **Technical Criteria**
+- ✅ **Safety:** SIL 2 compliance, E-Stop < 100ms
+- ✅ **Performance:** Real-time constraints met
+- ✅ **Reliability:** 99.9% uptime target
+- ✅ **Security:** Authentication, encryption, secure boot
+- ✅ **Maintainability:** Modular architecture, comprehensive tests
+
+### **Quality Criteria**
+- ✅ **Code Quality:** MISRA C:2012 compliance
+- ✅ **Documentation:** Complete API and architecture docs
+- ✅ **Testing:** 90%+ code coverage
+- ✅ **Performance:** All performance targets met
+- ✅ **Safety:** All safety requirements validated
+
+---
+
+## 🔄 **MAINTENANCE & UPDATES**
+
+### **1. Update Strategy**
+- **OTA Updates:** Secure over-the-air updates
+- **Rollback Capability:** Safe rollback to previous version
+- **Version Control:** Semantic versioning
+- **Change Management:** Controlled change process
+
+### **2. Monitoring & Diagnostics**
+- **Health Monitoring:** System health checks
+- **Performance Monitoring:** Real-time performance metrics
+- **Error Logging:** Comprehensive error logging
+- **Diagnostic Tools:** Built-in diagnostic capabilities
+
+---
+
+**🚨 CTO DECISION: Cấu trúc firmware app này đảm bảo an toàn tối đa và tuân thủ các tiêu chuẩn quốc tế. Kiến trúc 4-layer với safety-first approach và real-time performance đáp ứng đầy đủ yêu cầu của OHT-50 Master Module.**
+
+**Changelog v1.0:**
+- ✅ Created comprehensive firmware app architecture
+- ✅ Added safety-first design principles
+- ✅ Implemented 4-layer architecture
+- ✅ Added real-time requirements
+- ✅ Added security requirements
+- ✅ Added performance requirements
+- ✅ Added testing strategy
+- ✅ Added deployment strategy
+- ✅ Added success criteria
+- ✅ Added maintenance strategy
+
+**🚨 Lưu ý:** Cấu trúc này đảm bảo an toàn tối đa với SIL 2 compliance và response time < 100ms cho E-Stop system.

--- a/firmware_new/docs/06-REFERENCE/REF-008_Network_Technical.md
+++ b/firmware_new/docs/06-REFERENCE/REF-008_Network_Technical.md
@@ -1,0 +1,639 @@
+# 🔌 OHT-50 Network Management - Technical Documentation
+
+**Version:** 1.1.0  
+**Date:** 2025-01-28  
+**Team:** Firmware & Network Integration  
+**Status:** 📋 Design Phase - Simplified for OHT-50 Robot  
+**Priority:** 🔴 High - Critical for System Connectivity
+
+---
+
+## 🎯 **OVERVIEW**
+
+OHT-50 Network Management system provides **WiFi-based** network connectivity for OHT-50 robot systems. This system is designed specifically for **mobile robots** that move on overhead rails in industrial environments where **WiFi provides continuous connectivity** during movement.
+
+**Key Design Principles:**
+- ✅ **WiFi Primary** - 802.11ac industrial WiFi
+- ✅ **Roaming Support** - Seamless handover between access points
+- ✅ **Industrial Grade** - EMI/EMC compliant, high reliability
+- ✅ **Mobile Connectivity** - Continuous connection during movement
+- ✅ **Mobile App Support** - Remote control and monitoring
+
+---
+
+## 🏗️ **ARCHITECTURE DESIGN**
+
+### **System Architecture:**
+```
+┌─────────────────────────────────────────────────────────┐
+│                    OHT-50 FIRMWARE                     │
+│  ┌─────────────────┐  ┌─────────────────┐              │
+│  │   Network       │  │   Protocol      │              │
+│  │   Manager       │  │   Gateway       │              │
+│  │                 │  │                 │              │
+│  │ • WiFi Config   │  │ • HTTP Server   │              │
+│  │ • Roaming       │  │ • WebSocket     │              │
+│  │ • Handover      │  │ • RS485         │              │
+│  │ • Monitoring    │  │ • API Endpoints │              │
+│  └─────────────────┘  └─────────────────┘              │
+└─────────────────┬─────────────────┬─────────────────────┘
+                  │                 │
+    ┌─────────────▼─────┐ ┌─────────▼─────────┐
+    │   Network Layer   │ │   Hardware Layer  │
+    │                   │ │                   │
+    │ • WiFi Interface  │ │ • RS485 Modules   │
+    │ • Roaming Stack   │ │ • GPIO Controls   │
+    │ • Network Stack   │ │ • Safety Systems  │
+    └───────────────────┘ └───────────────────┘
+```
+
+### **Network Stack:**
+```
+┌─────────────────────────────────────┐
+│         Application Layer           │
+│  ┌─────────────────────────────────┐│
+│  │     Network Management APIs     ││
+│  │  • Status Monitoring            ││
+│  │  • Configuration Management     ││
+│  │  • WiFi Scanning & Connection   ││
+│  │  • Failover Control             ││
+│  └─────────────────────────────────┘│
+└─────────────────┬───────────────────┘
+                  │
+┌─────────────────▼───────────────────┐
+│         Network Manager             │
+│  ┌─────────────────────────────────┐│
+│  │  • Connection Management        ││
+│  │  • Failover Logic               ││
+│  │  • Network Monitoring           ││
+│  │  • Configuration Storage        ││
+│  └─────────────────────────────────┘│
+└─────────────────┬───────────────────┘
+                  │
+┌─────────────────▼───────────────────┐
+│         Linux Network Stack         │
+│  ┌─────────────────────────────────┐│
+│  │  • Network Interfaces           ││
+│  │  • IP Configuration             ││
+│  │  │  • DHCP Client               ││
+│  │  │  • Static IP                 ││
+│  │  • WiFi Management              ││
+│  │  │  • wpa_supplicant            ││
+│  │  │  • Network Scanning          ││
+│  │  • Ethernet Management          ││
+│  │  │  • Link Detection            ││
+│  │  │  • Speed Negotiation         ││
+│  └─────────────────────────────────┘│
+└─────────────────┬───────────────────┘
+                  │
+┌─────────────────▼───────────────────┐
+│         Hardware Interfaces         │
+│  ┌─────────────────────────────────┐│
+│  │  • Ethernet Port (RJ45)         ││
+│  │  • WiFi Antenna                 ││
+│  │  • Network LEDs                 ││
+│  │  • Power Management             ││
+│  └─────────────────────────────────┘│
+└─────────────────────────────────────┘
+```
+
+---
+
+## 🔧 **TECHNICAL SPECIFICATIONS**
+
+### **Hardware Requirements:**
+- **Platform:** Orange Pi 5B (RK3588)
+- **WiFi:** 802.11ac dual-band (2.4GHz + 5GHz) - **PRIMARY**
+- **Antenna:** External WiFi antenna with IP65 rating
+- **Industrial Grade:** EMI/EMC compliant
+- **LEDs:** Network status indicators
+- **Power:** Industrial power supply
+
+### **Software Requirements:**
+- **OS:** Linux (Orange Pi OS)
+- **Network Stack:** Linux kernel networking
+- **WiFi Management:** wpa_supplicant with roaming support
+- **DHCP Client:** dhcpcd for dynamic IP
+- **Network Tools:** iproute2, iw, iwlist, wpa_cli
+
+### **Performance Requirements:**
+- **Connection Time:** < 5 seconds (WiFi connection)
+- **Roaming Time:** < 2 seconds (handover between APs)
+- **API Response:** < 100ms
+- **Network Latency:** < 10ms (WiFi network)
+- **Uptime:** > 99.9%
+- **Signal Strength:** > -70 dBm (reliable connection)
+
+---
+
+## 📊 **DATA STRUCTURES**
+
+### **Network Configuration:**
+```c
+typedef struct {
+    // Ethernet configuration
+    bool ethernet_enabled;
+    bool ethernet_dhcp_enabled;
+    char ethernet_static_ip[16];
+    char ethernet_gateway[16];
+    char ethernet_dns[16];
+    char ethernet_netmask[16];
+    
+    // WiFi configuration
+    bool wifi_enabled;
+    char wifi_ssid[32];
+    char wifi_password[64];
+    int wifi_security_type; // WPA2, WPA3, etc.
+    int wifi_channel;
+    bool wifi_hidden;
+    
+    // Network policies
+    int connection_priority; // 1=Ethernet, 2=WiFi
+    bool auto_failover_enabled;
+    int failover_timeout_ms;
+    bool mobile_app_access_enabled;
+    int mobile_app_port;
+    
+    // Advanced settings
+    bool network_monitoring_enabled;
+    int monitoring_interval_ms;
+    bool traffic_logging_enabled;
+    int max_retry_attempts;
+} network_config_t;
+```
+
+### **Network Status:**
+```c
+typedef struct {
+    // Connection status
+    bool ethernet_connected;
+    bool wifi_connected;
+    char active_connection[16]; // "ethernet" or "wifi"
+    char primary_connection[16];
+    char backup_connection[16];
+    
+    // Ethernet status
+    char ethernet_ip[16];
+    char ethernet_mac[18];
+    int ethernet_speed; // Mbps
+    bool ethernet_link_up;
+    uint32_t ethernet_uptime_seconds;
+    
+    // WiFi status
+    char wifi_ssid[32];
+    char wifi_ip[16];
+    char wifi_mac[18];
+    int wifi_signal_strength; // dBm
+    int wifi_frequency; // MHz
+    int wifi_channel;
+    uint32_t wifi_uptime_seconds;
+    
+    // Network statistics
+    uint64_t bytes_sent;
+    uint64_t bytes_received;
+    uint32_t packets_sent;
+    uint32_t packets_received;
+    uint32_t connection_errors;
+    uint32_t failover_count;
+    
+    // Health metrics
+    float network_health_score; // 0-100%
+    uint32_t last_failover_time;
+    bool failover_in_progress;
+} network_status_t;
+```
+
+### **WiFi Network Information:**
+```c
+typedef struct {
+    char ssid[32];
+    char bssid[18];
+    int signal_strength; // dBm
+    int frequency; // MHz
+    int channel;
+    char security[16]; // WPA2, WPA3, Open, etc.
+    bool hidden;
+    uint32_t last_seen;
+} wifi_network_t;
+```
+
+---
+
+## 🔌 **API ENDPOINTS**
+
+### **Network Status APIs:**
+
+#### **1. Get Network Status**
+```http
+GET /api/v1/network/status
+```
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "ethernet": {
+      "connected": true,
+      "ip_address": "192.168.1.100",
+      "mac_address": "00:11:22:33:44:55",
+      "speed": 1000,
+      "link_up": true,
+      "uptime_seconds": 3600
+    },
+    "wifi": {
+      "connected": false,
+      "ssid": "",
+      "ip_address": "",
+      "mac_address": "00:11:22:33:44:66",
+      "signal_strength": 0,
+      "frequency": 0,
+      "channel": 0,
+      "uptime_seconds": 0
+    },
+    "active_connection": "ethernet",
+    "primary_connection": "ethernet",
+    "backup_connection": "wifi",
+    "statistics": {
+      "bytes_sent": 1024000,
+      "bytes_received": 2048000,
+      "packets_sent": 1500,
+      "packets_received": 2000,
+      "connection_errors": 0,
+      "failover_count": 2
+    },
+    "health": {
+      "network_health_score": 95.5,
+      "last_failover_time": 1706441000,
+      "failover_in_progress": false
+    }
+  }
+}
+```
+
+#### **2. Get Network Configuration**
+```http
+GET /api/v1/network/config
+```
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "ethernet": {
+      "enabled": true,
+      "dhcp_enabled": true,
+      "static_ip": "192.168.1.100",
+      "gateway": "192.168.1.1",
+      "dns": "8.8.8.8",
+      "netmask": "255.255.255.0"
+    },
+    "wifi": {
+      "enabled": true,
+      "ssid": "OHT-50-Network",
+      "security_type": "WPA2",
+      "channel": 6,
+      "hidden": false
+    },
+    "policies": {
+      "connection_priority": 1,
+      "auto_failover_enabled": true,
+      "failover_timeout_ms": 5000,
+      "mobile_app_access": true,
+      "mobile_app_port": 8080
+    },
+    "advanced": {
+      "network_monitoring_enabled": true,
+      "monitoring_interval_ms": 1000,
+      "traffic_logging_enabled": true,
+      "max_retry_attempts": 3
+    }
+  }
+}
+```
+
+### **Network Configuration APIs:**
+
+#### **3. Update Network Configuration**
+```http
+POST /api/v1/network/config
+Authorization: Bearer oht50_admin_token_2025
+Content-Type: application/json
+```
+**Request:**
+```json
+{
+  "ethernet": {
+    "enabled": true,
+    "dhcp_enabled": false,
+    "static_ip": "192.168.1.100",
+    "gateway": "192.168.1.1",
+    "dns": "8.8.8.8",
+    "netmask": "255.255.255.0"
+  },
+  "wifi": {
+    "enabled": true,
+    "ssid": "Factory-WiFi",
+    "password": "secure_password",
+    "security_type": "WPA2",
+    "channel": 11,
+    "hidden": false
+  },
+  "policies": {
+    "connection_priority": 1,
+    "auto_failover_enabled": true,
+    "failover_timeout_ms": 3000,
+    "mobile_app_access": true,
+    "mobile_app_port": 8080
+  },
+  "advanced": {
+    "network_monitoring_enabled": true,
+    "monitoring_interval_ms": 500,
+    "traffic_logging_enabled": true,
+    "max_retry_attempts": 5
+  }
+}
+```
+
+### **WiFi Management APIs:**
+
+#### **4. Scan WiFi Networks**
+```http
+GET /api/v1/network/wifi/scan
+```
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "networks": [
+      {
+        "ssid": "OHT-50-Network",
+        "bssid": "00:11:22:33:44:55",
+        "signal_strength": -45,
+        "frequency": 2437,
+        "channel": 6,
+        "security": "WPA2",
+        "hidden": false,
+        "last_seen": 1706441400
+      },
+      {
+        "ssid": "Factory-WiFi",
+        "bssid": "00:11:22:33:44:66",
+        "signal_strength": -60,
+        "frequency": 2462,
+        "channel": 11,
+        "security": "WPA3",
+        "hidden": false,
+        "last_seen": 1706441400
+      }
+    ],
+    "scan_time": 1706441400,
+    "total_networks": 2
+  }
+}
+```
+
+#### **5. Connect to WiFi**
+```http
+POST /api/v1/network/wifi/connect
+Authorization: Bearer oht50_operator_token_2025
+Content-Type: application/json
+```
+**Request:**
+```json
+{
+  "ssid": "OHT-50-Network",
+  "password": "secure_password",
+  "security_type": "WPA2",
+  "hidden": false
+}
+```
+
+#### **6. Disconnect WiFi**
+```http
+POST /api/v1/network/wifi/disconnect
+Authorization: Bearer oht50_operator_token_2025
+```
+
+### **Network Control APIs:**
+
+#### **7. Switch Network Connection**
+```http
+POST /api/v1/network/switch
+Authorization: Bearer oht50_operator_token_2025
+Content-Type: application/json
+```
+**Request:**
+```json
+{
+  "connection_type": "wifi",
+  "reason": "Manual switch for testing",
+  "force_switch": false
+}
+```
+
+#### **8. Enable/Disable Failover**
+```http
+POST /api/v1/network/failover
+Authorization: Bearer oht50_admin_token_2025
+Content-Type: application/json
+```
+**Request:**
+```json
+{
+  "enabled": true,
+  "timeout_ms": 5000,
+  "retry_attempts": 3
+}
+```
+
+---
+
+## 🔒 **SECURITY IMPLEMENTATION**
+
+### **Authentication Levels:**
+- **Admin Token:** Full network configuration access
+- **Operator Token:** WiFi connection và network switching
+- **Read-only Access:** Network status và monitoring
+
+### **Security Features:**
+- **WiFi Encryption:** WPA2/WPA3 support
+- **Network Isolation:** Separate networks for different purposes
+- **Access Control:** Role-based network access
+- **Audit Logging:** All network changes logged
+- **Configuration Validation:** Input validation và sanitization
+
+### **Security Headers:**
+```c
+// Security validation
+int network_config_validate(const network_config_t *config) {
+    // Validate IP addresses
+    if (!is_valid_ip(config->ethernet_static_ip)) {
+        return NETWORK_ERROR_INVALID_IP;
+    }
+    
+    // Validate WiFi credentials
+    if (strlen(config->wifi_password) < 8) {
+        return NETWORK_ERROR_WEAK_PASSWORD;
+    }
+    
+    // Validate security settings
+    if (config->wifi_security_type < WPA2) {
+        return NETWORK_ERROR_INSECURE_WIFI;
+    }
+    
+    return NETWORK_SUCCESS;
+}
+```
+
+---
+
+## 📊 **MONITORING & DIAGNOSTICS**
+
+### **Network Health Monitoring:**
+```c
+typedef struct {
+    float connection_stability; // 0-100%
+    float signal_quality; // 0-100%
+    float throughput_efficiency; // 0-100%
+    uint32_t error_rate; // errors per hour
+    uint32_t latency_ms; // average latency
+    bool network_healthy;
+} network_health_t;
+
+// Health monitoring functions
+int network_monitor_get_health(network_health_t *health);
+int network_monitor_start_monitoring(int interval_ms);
+int network_monitor_stop_monitoring(void);
+int network_monitor_get_statistics(network_stats_t *stats);
+```
+
+### **Diagnostic Commands:**
+```c
+// Network diagnostics
+int network_diagnostic_ping(const char *host, int timeout_ms);
+int network_diagnostic_traceroute(const char *host);
+int network_diagnostic_speed_test(void);
+int network_diagnostic_interface_status(void);
+int network_diagnostic_wifi_scan(void);
+```
+
+---
+
+## 🧪 **TESTING FRAMEWORK**
+
+### **Unit Tests:**
+```c
+// Network configuration tests
+void test_network_config_validation(void);
+void test_network_config_save_load(void);
+void test_network_config_reset(void);
+
+// Network connection tests
+void test_ethernet_connection(void);
+void test_wifi_connection(void);
+void test_network_failover(void);
+
+// Network monitoring tests
+void test_network_status_monitoring(void);
+void test_network_health_monitoring(void);
+void test_network_statistics(void);
+```
+
+### **Integration Tests:**
+```bash
+# Test network status API
+curl http://localhost:8080/api/v1/network/status
+
+# Test network configuration API
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST http://localhost:8080/api/v1/network/config \
+     -d '{"ethernet": {"enabled": true, "dhcp_enabled": true}}'
+
+# Test WiFi scan API
+curl http://localhost:8080/api/v1/network/wifi/scan
+
+# Test WiFi connection API
+curl -H "Authorization: Bearer oht50_operator_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST http://localhost:8080/api/v1/network/wifi/connect \
+     -d '{"ssid": "Test-Network", "password": "test123", "security_type": "WPA2"}'
+
+# Test network failover API
+curl -H "Authorization: Bearer oht50_admin_token_2025" \
+     -H "Content-Type: application/json" \
+     -X POST http://localhost:8080/api/v1/network/failover \
+     -d '{"enabled": true, "timeout_ms": 5000}'
+```
+
+### **Performance Tests:**
+```c
+// Network performance tests
+void test_network_connection_speed(void);
+void test_network_failover_time(void);
+void test_network_api_response_time(void);
+void test_network_throughput(void);
+void test_network_latency(void);
+```
+
+---
+
+## 📋 **IMPLEMENTATION CHECKLIST**
+
+### **Phase 1 - Core Network Management:**
+- [ ] Network Manager initialization
+- [ ] Ethernet configuration (DHCP/Static)
+- [ ] Basic WiFi connection
+- [ ] Network status monitoring
+- [ ] Configuration storage
+
+### **Phase 2 - Advanced Features:**
+- [ ] WiFi network scanning
+- [ ] Network failover logic
+- [ ] Network health monitoring
+- [ ] Traffic statistics
+- [ ] Mobile app access
+
+### **Phase 3 - Optimization:**
+- [ ] Performance optimization
+- [ ] Advanced diagnostics
+- [ ] Network security hardening
+- [ ] Comprehensive testing
+- [ ] Documentation completion
+
+---
+
+## 🔗 **DEPENDENCIES**
+
+### **System Dependencies:**
+- **Linux Kernel:** Network stack support
+- **wpa_supplicant:** WiFi management
+- **dhcpcd:** DHCP client
+- **iproute2:** Network configuration tools
+- **iw/iwlist:** WiFi scanning tools
+
+### **Firmware Dependencies:**
+- **API Framework:** HTTP server và WebSocket
+- **Configuration Manager:** Settings storage
+- **Logging System:** Network event logging
+- **Security Framework:** Authentication và authorization
+
+---
+
+## 📝 **CHANGELOG**
+
+### **v1.0.0 (2025-01-28) - Initial Design**
+- ✅ Network architecture design
+- ✅ API endpoints specification
+- ✅ Data structures definition
+- ✅ Security implementation plan
+- ✅ Testing framework design
+- ✅ Implementation roadmap
+
+---
+
+**📋 Generated by Firmware Team - OHT-50 Project**  
+**🕒 Date: 2025-01-28**  
+**✅ Status: v1.0 DESIGN COMPLETE**  
+**🎯 Next: Implementation Phase**

--- a/firmware_new/docs/CLEANUP_FINAL_REPORT.md
+++ b/firmware_new/docs/CLEANUP_FINAL_REPORT.md
@@ -1,0 +1,475 @@
+# 🎊 FIRMWARE DOCS CLEANUP - FINAL REPORT
+
+**Ngày hoàn thành:** 2025-10-07  
+**Team:** PM + QA  
+**Status:** ✅ **100% COMPLETED**  
+**Standard:** ISO 9001:2015 Compliant
+
+---
+
+## ✅ **EXECUTIVE SUMMARY**
+
+Đã **hoàn thành 100%** việc dọn dẹp và tái tổ chức tài liệu firmware theo chuẩn **ISO 9001:2015**!
+
+### **🎯 Kết quả chính:**
+- ✅ **Xóa:** 4 folders rỗng + 2 folders cũ + 2 files duplicate
+- ✅ **Di chuyển:** 12 files sang vị trí ISO chuẩn
+- ✅ **Đổi tên:** 8 files theo ISO naming convention
+- ✅ **Cập nhật:** 5 README files với cấu trúc mới
+- ✅ **Tổ chức:** 100% ISO 9001:2015 compliant structure
+
+---
+
+## 📊 **TRƯỚC VÀ SAU**
+
+### **❌ TRƯỚC DỌN DẸP (Messy):**
+```
+docs/
+├── 00-OVERVIEW/                  ← CŨ
+├── 01-ARCHITECTURE/              ← CŨ
+├── 02-IMPLEMENTATION/            ← MIXED
+├── 03-DEPLOYMENT/                ← CŨ
+├── 04-OPERATIONS/                ← CŨ
+├── api/                          ← RỖNG
+├── architecture/                 ← RỖNG
+├── safety/                       ← RỖNG
+├── user_guide/                   ← RỖNG
+├── 01-QUALITY_POLICY/            ← ISO (mới)
+├── 02-QUALITY_MANUAL/            ← ISO (mới)
+├── 03-PROCEDURES/                ← ISO (mới)
+├── 04-WORK_INSTRUCTIONS/         ← ISO (mới)
+├── 05-FORMS_RECORDS/             ← ISO (mới)
+├── 06-REFERENCE/                 ← ISO (mới)
+├── CTO_REFACTOR_ORDER.md         ← LOOSE FILE
+├── FW_APP_IMPLEMENTATION_PLAN.md ← LOOSE FILE
+├── FW_APP_SAFETY_ARCHITECTURE.md ← DUPLICATE
+└── README.md
+
+**Issues:** 17 folders, 80+ files, mixed structure, duplicates, loose files
+```
+
+### **✅ SAU DỌN DẸP (Clean & ISO Compliant):**
+```
+docs/
+├── 📜 01-QUALITY_POLICY/         # ✅ ISO Level 1 - Policies
+│   ├── QP-001_Security_Policy.md
+│   ├── QP-002_License.md
+│   ├── QP-003_Quality_Policy.md
+│   └── README.md
+│
+├── 📘 02-QUALITY_MANUAL/         # ✅ ISO Level 2 - Manual
+│   ├── QM-001_Project_Overview.md
+│   ├── QM-002_Code_Structure.md
+│   └── README.md
+│
+├── 🔧 03-PROCEDURES/             # ✅ ISO Level 3 - Procedures
+│   ├── PR-001_Build_Procedure.md
+│   ├── PR-002_Contributing_Procedure.md
+│   ├── PR-003_Code_Quality_Procedure.md
+│   └── README.md
+│
+├── 📚 04-WORK_INSTRUCTIONS/      # ✅ ISO Level 4 - Instructions
+│   ├── WI-001_Installation_Guide.md
+│   ├── WI-002_Usage_Guide.md
+│   ├── WI-003_Development_Guide.md
+│   ├── WI-004_Troubleshooting_Guide.md
+│   ├── WI-005_LiDAR_Debug_Guide.md
+│   ├── WI-006_Network_Deployment.md
+│   └── README.md
+│
+├── 📋 05-FORMS_RECORDS/          # ✅ Records & History
+│   ├── REC-001_Change_Log.md
+│   ├── REC-002_Migration_Log_v1.0.1.md
+│   ├── REC-003_Domain_Driven_Migration_Summary.md
+│   ├── REC-004_Cleanup_Summary.md
+│   ├── REC-005_Final_Cleanup_Report.md
+│   ├── REC-006_Documentation_Update_Summary.md
+│   ├── REC-007_LiDAR_HAL_Implementation.md
+│   ├── REC-008_CTO_Refactor_Order.md
+│   ├── REC-009_Network_Tracking.md
+│   └── README.md
+│
+├── 📚 06-REFERENCE/               # ✅ Technical Reference
+│   ├── REF-001_Control_Loop_Guide.md
+│   ├── REF-002_Architecture_Quick_Reference.md
+│   ├── REF-003_Documentation_Index.md
+│   ├── REF-004_Documentation_Navigation.md
+│   ├── REF-005_API_Complete_Documentation.md
+│   ├── REF-006_LiDAR_HAL_API.md
+│   ├── REF-007_Safety_Architecture.md
+│   ├── REF-008_Network_Technical.md
+│   └── README.md
+│
+├── 🏗️ 02-IMPLEMENTATION/         # ✅ Technical Specs (Keep)
+│   ├── 01-QMS/
+│   ├── 03-REQUIREMENTS/
+│   ├── 04-SLC/
+│   ├── 05-SAFETY/
+│   └── 06-QUALITY/
+│
+├── CLEANUP_PLAN_ISO.md           # 📋 Cleanup Plan
+└── README.md                      # 📖 Main Index
+
+**Result:** 12 directories, 39 files, 100% ISO compliant, no duplicates!
+```
+
+---
+
+## 📋 **CHI TIẾT HÀNH ĐỘNG**
+
+### **❌ XÓA (8 items):**
+| # | Item | Type | Reason |
+|---|------|------|--------|
+| 1 | `api/` | Folder | Empty folder |
+| 2 | `architecture/` | Folder | Empty folder |
+| 3 | `safety/` | Folder | Empty folder |
+| 4 | `user_guide/` | Folder | Empty folder |
+| 5 | `00-OVERVIEW/` | Folder | Content merged to QM-001 |
+| 6 | `01-ARCHITECTURE/` | Folder | Files moved to 06-REFERENCE |
+| 7 | `03-DEPLOYMENT/` | Folder | Files moved to WI/REF |
+| 8 | `04-OPERATIONS/` | Folder | Files moved to REC |
+| 9 | `FW_APP_SAFETY_ARCHITECTURE.md` | File | Duplicate (already in 02-IMPLEMENTATION/05-SAFETY/) |
+
+### **✅ DI CHUYỂN (12 files):**
+| # | From | To | Reason |
+|---|------|-----|--------|
+| 1 | `01-ARCHITECTURE/02-HAL/CONTROL_LOOP_DEV_GUIDE.md` | `06-REFERENCE/REF-001_Control_Loop_Guide.md` | Technical reference |
+| 2 | `01-ARCHITECTURE/02-HAL/LIDAR_HAL_API_REFERENCE.md` | `06-REFERENCE/REF-006_LiDAR_HAL_API.md` | API reference |
+| 3 | `01-ARCHITECTURE/02-HAL/LIDAR_HAL_IMPLEMENTATION_SUMMARY.md` | `05-FORMS_RECORDS/REC-007_LiDAR_HAL_Implementation.md` | Implementation record |
+| 4 | `01-ARCHITECTURE/02-HAL/03-lidar/LIDAR_DEBUG_GUIDE.md` | `04-WORK_INSTRUCTIONS/WI-005_LiDAR_Debug_Guide.md` | Work instruction |
+| 5 | `02-IMPLEMENTATION/API_DOCUMENTATION.md` | `06-REFERENCE/REF-005_API_Complete_Documentation.md` | Complete API docs |
+| 6 | `02-IMPLEMENTATION/01-QMS/01-policies/quality_policy.md` | `01-QUALITY_POLICY/QP-003_Quality_Policy.md` | Quality policy |
+| 7 | `02-IMPLEMENTATION/05-SAFETY/FW_APP_SAFETY_ARCHITECTURE.md` | `06-REFERENCE/REF-007_Safety_Architecture.md` | Technical reference |
+| 8 | `03-DEPLOYMENT/plant/NETWORK_MANAGEMENT_PLANT_IMPLEMENTATION.md` | `04-WORK_INSTRUCTIONS/WI-006_Network_Deployment.md` | Deployment guide |
+| 9 | `03-DEPLOYMENT/technical/NETWORK_MANAGEMENT_TECHNICAL.md` | `06-REFERENCE/REF-008_Network_Technical.md` | Technical reference |
+| 10 | `04-OPERATIONS/tracking/NETWORK_MANAGEMENT_TRACKING_PLANT.md` | `05-FORMS_RECORDS/REC-009_Network_Tracking.md` | Tracking record |
+| 11 | `CTO_REFACTOR_ORDER.md` | `05-FORMS_RECORDS/REC-008_CTO_Refactor_Order.md` | Implementation record |
+| 12 | `FW_APP_IMPLEMENTATION_PLAN.md` | `02-IMPLEMENTATION/04-SLC/01-planning/` | Planning document |
+
+### **📝 CẬP NHẬT (5 READMEs):**
+| # | File | Changes |
+|---|------|---------|
+| 1 | `README.md` | Updated với cấu trúc ISO đầy đủ |
+| 2 | `01-QUALITY_POLICY/README.md` | Added QP-003 |
+| 3 | `04-WORK_INSTRUCTIONS/README.md` | Added WI-005, WI-006 |
+| 4 | `05-FORMS_RECORDS/README.md` | Added REC-007, REC-008, REC-009 |
+| 5 | `06-REFERENCE/README.md` | Completely rebuilt với 8 REF files |
+
+---
+
+## 📊 **METRICS**
+
+### **📁 Folder Structure:**
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| **Total Folders** | 17 | 12 | -5 (cleaned) |
+| **Empty Folders** | 4 | 0 | -4 (deleted) |
+| **ISO Folders** | 6 | 6 | 0 (kept) |
+| **Legacy Folders** | 7 | 0 | -7 (cleaned) |
+| **Implementation Folders** | 6 | 6 | 0 (kept) |
+
+### **📄 File Organization:**
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| **Total .md Files** | ~82 | ~75 | -7 (cleaned) |
+| **Loose Files (root)** | 4 | 2 | -2 (organized) |
+| **Duplicate Files** | 3 | 0 | -3 (removed) |
+| **ISO Named Files** | 16 | 32 | +16 (reorganized) |
+
+### **📝 Documentation Quality:**
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| **README Files** | 12 | 12 | 0 (all updated) |
+| **Updated READMEs** | 0 | 5 | +5 (enhanced) |
+| **Broken Links** | ~15 | 0 | -15 (fixed) |
+| **ISO Compliance** | 60% | 100% | +40% (achieved) |
+
+---
+
+## 🎯 **ISO 9001:2015 COMPLIANCE**
+
+### **✅ Document Hierarchy (100% Compliant):**
+
+| **ISO Level** | **Folder** | **Purpose** | **Files** | **Status** |
+|---------------|------------|-------------|-----------|------------|
+| **Level 1** | 01-QUALITY_POLICY | Policies | 3 | ✅ Complete |
+| **Level 2** | 02-QUALITY_MANUAL | Manual | 2 | ✅ Complete |
+| **Level 3** | 03-PROCEDURES | Procedures | 3 | ✅ Complete |
+| **Level 4** | 04-WORK_INSTRUCTIONS | Instructions | 6 | ✅ Complete |
+| **Level 5** | 05-FORMS_RECORDS | Records | 9 | ✅ Complete |
+| **Reference** | 06-REFERENCE | Technical | 8 | ✅ Complete |
+| **Technical** | 02-IMPLEMENTATION | Specs | ~45 | ✅ Complete |
+
+---
+
+## 🔍 **VALIDATION RESULTS**
+
+### **✅ Structure Validation:**
+- ✅ **No empty folders**
+- ✅ **No duplicate files**
+- ✅ **No loose files at root** (except README và reports)
+- ✅ **All files properly numbered**
+- ✅ **All READMEs updated**
+- ✅ **ISO naming convention applied**
+
+### **✅ Content Validation:**
+- ✅ **No content lost** (all moved/merged)
+- ✅ **No broken links** (all references updated)
+- ✅ **Consistent formatting** (ISO standard)
+- ✅ **Complete documentation** (100% coverage)
+
+### **✅ Quality Validation:**
+- ✅ **Professional presentation**
+- ✅ **Clear navigation**
+- ✅ **Logical organization**
+- ✅ **Easy maintenance**
+
+---
+
+## 📁 **FINAL STRUCTURE**
+
+### **📜 01-QUALITY_POLICY/** (3 files)
+```
+QP-001_Security_Policy.md          - Security policy và vulnerability reporting
+QP-002_License.md                   - MIT license và third-party licenses
+QP-003_Quality_Policy.md            - Quality objectives và management principles
+```
+
+### **📘 02-QUALITY_MANUAL/** (2 files)
+```
+QM-001_Project_Overview.md          - Project overview, features, architecture
+QM-002_Code_Structure.md            - Code structure chi tiết (58K lines)
+```
+
+### **🔧 03-PROCEDURES/** (3 files)
+```
+PR-001_Build_Procedure.md           - Build process và configuration
+PR-002_Contributing_Procedure.md    - Git workflow và PR process
+PR-003_Code_Quality_Procedure.md    - Quality control procedures
+```
+
+### **📚 04-WORK_INSTRUCTIONS/** (6 files)
+```
+WI-001_Installation_Guide.md        - Installation step-by-step
+WI-002_Usage_Guide.md               - Usage guide với examples
+WI-003_Development_Guide.md         - Development workflow
+WI-004_Troubleshooting_Guide.md     - Common issues và solutions
+WI-005_LiDAR_Debug_Guide.md         - LiDAR debugging guide
+WI-006_Network_Deployment.md        - Network deployment guide
+```
+
+### **📋 05-FORMS_RECORDS/** (9 files)
+```
+REC-001_Change_Log.md               - Version history (v0.1.0 → v1.0.1)
+REC-002_Migration_Log_v1.0.1.md    - Migration details
+REC-003_Domain_Driven_Migration_Summary.md - DDD migration
+REC-004_Cleanup_Summary.md          - Code cleanup report
+REC-005_Final_Cleanup_Report.md     - Executive summary
+REC-006_Documentation_Update_Summary.md - Doc updates
+REC-007_LiDAR_HAL_Implementation.md - LiDAR v2.3.0 record
+REC-008_CTO_Refactor_Order.md       - CTO refactor priorities
+REC-009_Network_Tracking.md         - Network tracking
+```
+
+### **📚 06-REFERENCE/** (8 files)
+```
+REF-001_Control_Loop_Guide.md       - Control loop development
+REF-002_Architecture_Quick_Reference.md - Architecture cheat sheet
+REF-003_Documentation_Index.md      - Quick navigation
+REF-004_Documentation_Navigation.md - Full doc map
+REF-005_API_Complete_Documentation.md - Complete API (37 endpoints)
+REF-006_LiDAR_HAL_API.md            - LiDAR HAL API v2.3.0
+REF-007_Safety_Architecture.md      - Safety system architecture
+REF-008_Network_Technical.md        - Network technical docs
+```
+
+### **🏗️ 02-IMPLEMENTATION/** (Technical - Keep as-is)
+```
+01-QMS/                             - Quality Management System
+03-REQUIREMENTS/                    - Requirements specs
+04-SLC/                             - System Life Cycle planning
+05-SAFETY/                          - Safety systems docs
+06-QUALITY/                         - Quality assurance
+```
+
+---
+
+## 🎯 **IMPROVEMENTS ACHIEVED**
+
+### **🏆 Organization:**
+- ✅ **100% ISO 9001:2015 compliant** document structure
+- ✅ **Clear hierarchy** từ Level 1 (Policy) → Level 5 (Records)
+- ✅ **Logical categorization** theo ISO standards
+- ✅ **Consistent naming** với prefix codes (QP-, QM-, PR-, WI-, REC-, REF-)
+
+### **🎨 Presentation:**
+- ✅ **Professional** documentation structure
+- ✅ **Easy navigation** với README indexes
+- ✅ **Visual clarity** với icons và formatting
+- ✅ **Quick reference** tables trong mỗi README
+
+### **🔧 Maintenance:**
+- ✅ **Easy to find** documents (ISO numbering)
+- ✅ **Easy to update** (clear structure)
+- ✅ **Easy to audit** (ISO compliance)
+- ✅ **Easy to extend** (numbered system)
+
+### **📊 Quality:**
+- ✅ **No duplicates** (eliminated all duplicates)
+- ✅ **No gaps** (sequential numbering)
+- ✅ **No orphans** (all files categorized)
+- ✅ **Complete** (100% documentation coverage)
+
+---
+
+## 🔍 **COMPLIANCE CHECKLIST**
+
+### **✅ ISO 9001:2015 Requirements:**
+- ✅ **Section 5.2:** Quality Policy (QP-001, QP-002, QP-003)
+- ✅ **Section 7.5:** Documented Information (02-QUALITY_MANUAL)
+- ✅ **Section 8:** Operation (03-PROCEDURES)
+- ✅ **Section 7.5:** Work Instructions (04-WORK_INSTRUCTIONS)
+- ✅ **Section 7.5.3:** Control of Documented Information (05-FORMS_RECORDS)
+- ✅ **Section 7.5:** External Documents (06-REFERENCE)
+
+### **✅ Best Practices:**
+- ✅ **Version Control:** All documents versioned
+- ✅ **Change Management:** All changes tracked in REC-001
+- ✅ **Traceability:** Cross-references complete
+- ✅ **Accessibility:** Clear navigation paths
+- ✅ **Maintainability:** Consistent structure
+
+---
+
+## 📈 **PERFORMANCE METRICS**
+
+### **⏱️ Execution Time:**
+- **Estimated:** 110 minutes
+- **Actual:** ~45 minutes
+- **Efficiency:** 141% (faster than estimated!)
+
+### **📊 Quality Metrics:**
+- **Accuracy:** 100% (no errors)
+- **Completeness:** 100% (all planned actions completed)
+- **Compliance:** 100% (ISO 9001:2015)
+- **Consistency:** 100% (naming convention applied)
+
+---
+
+## 🚀 **BENEFITS ACHIEVED**
+
+### **For Development Team:**
+- 🎯 **Clear structure** → Find docs faster
+- 📚 **Better organization** → Less confusion
+- 🔍 **Quick reference** → Faster development
+- 📖 **Complete guides** → Less questions
+
+### **For Quality Team:**
+- ✅ **ISO compliant** → Audit ready
+- 📋 **Proper records** → Traceability
+- 🔍 **Easy audit** → Clear structure
+- 📊 **Quality metrics** → Measurable
+
+### **For Management:**
+- 🏆 **Professional** → Better impression
+- 📊 **Measurable** → Clear metrics
+- 🔒 **Compliant** → Reduced risk
+- 🚀 **Scalable** → Growth ready
+
+---
+
+## 🎓 **LESSONS LEARNED**
+
+### **✅ What Worked Well:**
+1. **ISO structure** → Very clear và maintainable
+2. **Numbered naming** → Easy to reference
+3. **README indexes** → Excellent navigation
+4. **Batch operations** → Fast execution
+5. **Version control** → Safe cleanup
+
+### **⚠️ What Could Be Improved:**
+1. **Earlier planning** → Should plan structure from start
+2. **Migration early** → Migrate to ISO earlier in project
+3. **Automated tools** → Could use scripts for validation
+4. **Link checking** → Automated link validation needed
+
+### **📝 Recommendations:**
+1. ✅ **Maintain** ISO structure going forward
+2. ✅ **Update** READMEs khi thêm files mới
+3. ✅ **Follow** naming convention strictly
+4. ✅ **Review** structure quarterly
+5. ✅ **Backup** before major changes
+
+---
+
+## 🔗 **NEXT STEPS**
+
+### **Immediate (Today):**
+- [x] Verify all links working
+- [x] Test documentation navigation
+- [x] Update main project README
+- [x] Commit changes to git
+
+### **Short-term (This Week):**
+- [ ] Review với team
+- [ ] Collect feedback
+- [ ] Minor adjustments if needed
+- [ ] Update project documentation references
+
+### **Long-term (This Month):**
+- [ ] Quarterly structure review
+- [ ] Add missing documentation
+- [ ] Improve cross-references
+- [ ] Automated validation scripts
+
+---
+
+## 🎉 **SUCCESS CRITERIA - ALL MET!**
+
+- ✅ **ISO 9001:2015 Compliant** → 100%
+- ✅ **No duplicate files** → 0 duplicates
+- ✅ **No empty folders** → 0 empty
+- ✅ **All files categorized** → 100% organized
+- ✅ **Sequential numbering** → No gaps
+- ✅ **READMEs updated** → 5/5 updated
+- ✅ **Navigation clear** → Easy to navigate
+- ✅ **Professional presentation** → Excellent quality
+
+---
+
+## 📞 **CONTACT & SUPPORT**
+
+### **Documentation Team:**
+- **PM:** Documentation planning và coordination
+- **QA:** Quality validation và compliance
+- **Tech Writers:** Content creation và maintenance
+
+### **Questions:**
+- 📧 **Email:** docs@oht50.com
+- 💬 **Slack:** #docs-firmware channel
+- 📋 **Issues:** GitHub Issues tagged `documentation`
+
+---
+
+## 📚 **RELATED DOCUMENTS**
+
+- 📋 [CLEANUP_PLAN_ISO.md](./CLEANUP_PLAN_ISO.md) - Original cleanup plan
+- 📖 [README.md](./README.md) - Main documentation index
+- 🔍 [REF-003_Documentation_Index.md](./06-REFERENCE/REF-003_Documentation_Index.md) - Quick navigation
+- 🗺️ [REF-004_Documentation_Navigation.md](./06-REFERENCE/REF-004_Documentation_Navigation.md) - Complete map
+
+---
+
+**🎊 CLEANUP STATUS: COMPLETED SUCCESSFULLY!**
+
+**📅 Completion Date:** 2025-10-07  
+**⏱️ Execution Time:** 45 minutes  
+**✅ Quality:** 100% ISO 9001:2015 Compliant  
+**🏆 Result:** Professional, organized, và maintainable documentation!
+
+---
+
+**Maintained By:** PM & QA Team  
+**Next Review:** 2025-11-07 (Monthly)  
+**Version:** 1.0.0
+

--- a/firmware_new/docs/CLEANUP_PLAN_ISO.md
+++ b/firmware_new/docs/CLEANUP_PLAN_ISO.md
@@ -1,0 +1,384 @@
+# 📋 FIRMWARE DOCS CLEANUP PLAN - ISO STANDARDIZATION
+
+**Ngày thực hiện:** 2025-10-07  
+**Mục tiêu:** Dọn dẹp và chuẩn hóa tài liệu firmware theo ISO 9001:2015  
+**Team:** PM + QA
+
+---
+
+## 🎯 **PHÂN TÍCH HIỆN TRẠNG**
+
+### **✅ CẤU TRÚC ISO ĐÃ TẠO (GIỮ LẠI):**
+```
+01-QUALITY_POLICY/           # ✅ GIỮ - ISO compliant
+├── QP-001_Security_Policy.md
+├── QP-002_License.md
+└── README.md
+
+02-QUALITY_MANUAL/           # ✅ GIỮ - ISO compliant
+├── QM-001_Project_Overview.md
+├── QM-002_Code_Structure.md
+└── README.md
+
+03-PROCEDURES/               # ✅ GIỮ - ISO compliant
+├── PR-001_Build_Procedure.md
+├── PR-002_Contributing_Procedure.md
+├── PR-003_Code_Quality_Procedure.md
+└── README.md
+
+04-WORK_INSTRUCTIONS/        # ✅ GIỮ - ISO compliant
+├── WI-001_Installation_Guide.md
+├── WI-002_Usage_Guide.md
+├── WI-003_Development_Guide.md
+├── WI-004_Troubleshooting_Guide.md
+└── README.md
+
+05-FORMS_RECORDS/            # ✅ GIỮ - ISO compliant
+├── REC-001_Change_Log.md
+├── REC-002_Migration_Log_v1.0.1.md
+├── REC-003_Domain_Driven_Migration_Summary.md
+├── REC-004_Cleanup_Summary.md
+├── REC-005_Final_Cleanup_Report.md
+├── REC-006_Documentation_Update_Summary.md
+└── README.md
+
+06-REFERENCE/                # ✅ GIỮ - ISO compliant
+├── REF-001_API_Reference.md
+├── REF-002_Architecture_Quick_Reference.md
+├── REF-003_Documentation_Index.md
+├── REF-004_Documentation_Navigation.md
+└── README.md
+```
+
+---
+
+## ❌ **CẤU TRÚC CŨ (CẦN DỌN DẸP):**
+
+### **1. FOLDERS RỖNG (XÓA NGAY):**
+```
+❌ api/              - EMPTY, XÓA
+❌ architecture/     - EMPTY, XÓA
+❌ safety/           - EMPTY, XÓA
+❌ user_guide/       - EMPTY, XÓA
+```
+
+### **2. CẤU TRÚC CŨ (CẦN DI CHUYỂN/GỘP):**
+
+#### **00-OVERVIEW/ (ĐÁNH GIÁ)**
+```
+⚠️ 00-OVERVIEW/README.md
+   → NỘI DUNG: Basic overview, ISO/IEC 12207 compliant
+   → HÀNH ĐỘNG: GỘP vào 02-QUALITY_MANUAL/QM-001_Project_Overview.md
+   → SAU ĐÓ: XÓA folder 00-OVERVIEW/
+```
+
+#### **01-ARCHITECTURE/ (ĐÁNH GIÁ)**
+```
+⚠️ 01-ARCHITECTURE/02-HAL/
+   ├── CONTROL_LOOP_DEV_GUIDE.md           → DI CHUYỂN sang 06-REFERENCE/
+   ├── LIDAR_HAL_API_REFERENCE.md          → DI CHUYỂN sang 06-REFERENCE/
+   ├── LIDAR_HAL_IMPLEMENTATION_SUMMARY.md → DI CHUYỂN sang 05-FORMS_RECORDS/
+   ├── README.md                            → GỘP vào 06-REFERENCE/
+   └── 03-lidar/LIDAR_DEBUG_GUIDE.md       → DI CHUYỂN sang 04-WORK_INSTRUCTIONS/
+```
+
+#### **02-IMPLEMENTATION/ (ĐÁNH GIÁ)**
+```
+⚠️ 02-IMPLEMENTATION/
+   ├── API_DOCUMENTATION.md (3557 lines!)   → TÁCH & DI CHUYỂN
+   │   → Quá lớn! Cần tách thành:
+   │      - API Reference → 06-REFERENCE/REF-001_API_Reference.md (UPDATE)
+   │      - Backend Integration → 04-WORK_INSTRUCTIONS/WI-005_Backend_Integration.md (MỚI)
+   │      - Frontend Integration → 04-WORK_INSTRUCTIONS/WI-006_Frontend_Integration.md (MỚI)
+   │
+   ├── 01-QMS/                              → GIỮ (quan trọng)
+   │   ├── 01-policies/quality_policy.md    → DI CHUYỂN sang 01-QUALITY_POLICY/
+   │   └── README.md                        → UPDATE references
+   │
+   ├── 03-REQUIREMENTS/                     → GIỮ (specs quan trọng)
+   │   ├── 03-FIRMWARE-REQUIREMENTS/        → GIỮ
+   │   │   ├── REQ_*.md (8 files)           → GIỮ (technical specs)
+   │   │   └── 04-IMPLEMENTED-MODULES/      → GIỮ
+   │   └── README.md                        → GIỮ
+   │
+   ├── 04-SLC/                              → GIỮ (planning docs)
+   │   ├── 01-planning/*.md (7 files)       → GIỮ (implementation plans)
+   │   ├── CHANGELOG.md                     → GỘP vào 05-FORMS_RECORDS/REC-001
+   │   ├── OHT50_FIRMWARE_IMPLEMENTATION_PLAN.md → GIỮ
+   │   └── README.md                        → UPDATE
+   │
+   ├── 05-SAFETY/                           → ĐÁNH GIÁ
+   │   ├── FW_APP_SAFETY_ARCHITECTURE.md    → DI CHUYỂN sang 06-REFERENCE/
+   │   └── README.md                        → UPDATE
+   │
+   └── 06-QUALITY/                          → GIỮ
+       └── README.md                        → UPDATE
+```
+
+#### **03-DEPLOYMENT/ (ĐÁNH GIÁ)**
+```
+⚠️ 03-DEPLOYMENT/
+   ├── plant/NETWORK_MANAGEMENT_PLANT_IMPLEMENTATION.md
+   └── technical/NETWORK_MANAGEMENT_TECHNICAL.md
+   
+   → NỘI DUNG: Network management implementation
+   → HÀNH ĐỘNG: DI CHUYỂN sang 04-WORK_INSTRUCTIONS/ hoặc 03-PROCEDURES/
+   → SAU ĐÓ: XÓA folder 03-DEPLOYMENT/
+```
+
+#### **04-OPERATIONS/ (ĐÁNH GIÁ)**
+```
+⚠️ 04-OPERATIONS/
+   └── tracking/NETWORK_MANAGEMENT_TRACKING_PLANT.md
+   
+   → NỘI DUNG: Tracking documents
+   → HÀNH ĐỘNG: DI CHUYỂN sang 05-FORMS_RECORDS/
+   → SAU ĐÓ: XÓA folder 04-OPERATIONS/
+```
+
+#### **ROOT DOCS FILES (ĐÁNH GIÁ)**
+```
+⚠️ CTO_REFACTOR_ORDER.md         → DI CHUYỂN sang 05-FORMS_RECORDS/ (record)
+⚠️ FW_APP_IMPLEMENTATION_PLAN.md → DI CHUYỂN sang 02-IMPLEMENTATION/04-SLC/01-planning/
+⚠️ FW_APP_SAFETY_ARCHITECTURE.md → ĐÃ CÓ trong 02-IMPLEMENTATION/05-SAFETY/ (TRÙNG!)
+⚠️ README.md                      → UPDATE với ISO structure
+```
+
+---
+
+## 🔧 **HÀNH ĐỘNG CHI TIẾT**
+
+### **PHASE 1: XÓA FOLDERS RỖNG** ⏱️ 5 phút
+```bash
+❌ rm -rf api/
+❌ rm -rf architecture/
+❌ rm -rf safety/
+❌ rm -rf user_guide/
+```
+
+### **PHASE 2: DI CHUYỂN HAL DOCS** ⏱️ 10 phút
+```bash
+# Di chuyển HAL docs sang 06-REFERENCE/
+✅ mv 01-ARCHITECTURE/02-HAL/CONTROL_LOOP_DEV_GUIDE.md → 06-REFERENCE/REF-005_Control_Loop_Guide.md
+✅ mv 01-ARCHITECTURE/02-HAL/LIDAR_HAL_API_REFERENCE.md → 06-REFERENCE/REF-006_LiDAR_HAL_API.md
+✅ mv 01-ARCHITECTURE/02-HAL/03-lidar/LIDAR_DEBUG_GUIDE.md → 04-WORK_INSTRUCTIONS/WI-005_LiDAR_Debug_Guide.md
+
+# Di chuyển implementation summary
+✅ mv 01-ARCHITECTURE/02-HAL/LIDAR_HAL_IMPLEMENTATION_SUMMARY.md → 05-FORMS_RECORDS/REC-007_LiDAR_HAL_Implementation.md
+
+# Gộp HAL README
+✅ GỘP 01-ARCHITECTURE/02-HAL/README.md → 06-REFERENCE/README.md (append section)
+
+# Xóa folder cũ
+❌ rm -rf 01-ARCHITECTURE/
+```
+
+### **PHASE 3: TÁCH API_DOCUMENTATION.md (3557 LINES!)** ⏱️ 30 phút
+```bash
+# File này quá lớn - TÁCH thành 3 parts:
+
+1️⃣ API Reference (endpoints only)
+   → UPDATE 06-REFERENCE/REF-001_API_Reference.md
+   
+2️⃣ Backend Integration Guide
+   → TẠO MỚI 04-WORK_INSTRUCTIONS/WI-005_Backend_Integration.md
+   
+3️⃣ Frontend Integration Guide  
+   → TẠO MỚI 04-WORK_INSTRUCTIONS/WI-006_Frontend_Integration.md
+
+# Sau khi tách xong
+❌ XÓA 02-IMPLEMENTATION/API_DOCUMENTATION.md
+```
+
+### **PHASE 4: DI CHUYỂN QMS POLICY** ⏱️ 5 phút
+```bash
+✅ mv 02-IMPLEMENTATION/01-QMS/01-policies/quality_policy.md → 01-QUALITY_POLICY/QP-003_Quality_Policy.md
+✅ UPDATE 02-IMPLEMENTATION/01-QMS/README.md (update references)
+```
+
+### **PHASE 5: DI CHUYỂN SAFETY DOCS** ⏱️ 10 phút
+```bash
+# Safety architecture
+✅ mv 02-IMPLEMENTATION/05-SAFETY/FW_APP_SAFETY_ARCHITECTURE.md → 06-REFERENCE/REF-007_Safety_Architecture.md
+
+# Root safety file (DUPLICATE - xóa)
+❌ rm FW_APP_SAFETY_ARCHITECTURE.md
+
+# Update README
+✅ UPDATE 02-IMPLEMENTATION/05-SAFETY/README.md
+```
+
+### **PHASE 6: DI CHUYỂN DEPLOYMENT & OPERATIONS** ⏱️ 10 phút
+```bash
+# Deployment docs → Work Instructions
+✅ mv 03-DEPLOYMENT/plant/NETWORK_MANAGEMENT_PLANT_IMPLEMENTATION.md → 04-WORK_INSTRUCTIONS/WI-007_Network_Deployment.md
+✅ mv 03-DEPLOYMENT/technical/NETWORK_MANAGEMENT_TECHNICAL.md → 06-REFERENCE/REF-008_Network_Technical.md
+
+# Operations docs → Forms/Records
+✅ mv 04-OPERATIONS/tracking/NETWORK_MANAGEMENT_TRACKING_PLANT.md → 05-FORMS_RECORDS/REC-007_Network_Tracking.md
+
+# Xóa folders cũ
+❌ rm -rf 03-DEPLOYMENT/
+❌ rm -rf 04-OPERATIONS/
+```
+
+### **PHASE 7: DI CHUYỂN ROOT FILES** ⏱️ 5 phút
+```bash
+✅ mv CTO_REFACTOR_ORDER.md → 05-FORMS_RECORDS/REC-008_CTO_Refactor_Order.md
+✅ mv FW_APP_IMPLEMENTATION_PLAN.md → 02-IMPLEMENTATION/04-SLC/01-planning/
+❌ rm FW_APP_SAFETY_ARCHITECTURE.md (DUPLICATE - đã có trong 02-IMPLEMENTATION/05-SAFETY/)
+```
+
+### **PHASE 8: GỘP OVERVIEW** ⏱️ 10 phút
+```bash
+✅ GỘP 00-OVERVIEW/README.md → 02-QUALITY_MANUAL/QM-001_Project_Overview.md
+❌ rm -rf 00-OVERVIEW/
+```
+
+### **PHASE 9: GỘP CHANGELOGS** ⏱️ 10 phút
+```bash
+✅ GỘP 02-IMPLEMENTATION/04-SLC/CHANGELOG.md → 05-FORMS_RECORDS/REC-001_Change_Log.md
+```
+
+### **PHASE 10: UPDATE README.md & INDEXES** ⏱️ 15 phút
+```bash
+✅ UPDATE docs/README.md (main index)
+✅ UPDATE all category README.md files
+✅ UPDATE cross-references
+```
+
+---
+
+## 📊 **SUMMARY**
+
+### **Actions:**
+| Action | Count | Time |
+|--------|-------|------|
+| ❌ **XÓA folders rỗng** | 4 folders | 5 min |
+| ❌ **XÓA files duplicate** | 2 files | 2 min |
+| ✅ **DI CHUYỂN files** | 12 files | 40 min |
+| ✅ **GỘP files** | 3 files | 20 min |
+| ✅ **TẠO MỚI files** | 2 files | 20 min |
+| ✅ **UPDATE files** | 8 files | 15 min |
+| **TOTAL** | **31 actions** | **~102 min** |
+
+### **Before Cleanup:**
+- **Folders:** 13 folders (4 rỗng, 9 có nội dung)
+- **Files:** ~80 .md files
+- **Structure:** Mixed (cũ + ISO)
+
+### **After Cleanup:**
+- **Folders:** 6 ISO folders + 2 implementation folders
+- **Files:** ~70 .md files (organized)
+- **Structure:** 100% ISO 9001:2015 compliant
+
+---
+
+## ✅ **EXPECTED RESULT**
+
+```
+firmware_new/docs/
+├── README.md                        # ✅ Master index (updated)
+│
+├── 📜 01-QUALITY_POLICY/           # ✅ ISO Level 1
+│   ├── QP-001_Security_Policy.md
+│   ├── QP-002_License.md
+│   ├── QP-003_Quality_Policy.md    # ← MỚI (từ QMS)
+│   └── README.md
+│
+├── 📘 02-QUALITY_MANUAL/           # ✅ ISO Level 2
+│   ├── QM-001_Project_Overview.md  # ← UPDATED (gộp OVERVIEW)
+│   ├── QM-002_Code_Structure.md
+│   └── README.md
+│
+├── 🔧 03-PROCEDURES/               # ✅ ISO Level 3
+│   ├── PR-001_Build_Procedure.md
+│   ├── PR-002_Contributing_Procedure.md
+│   ├── PR-003_Code_Quality_Procedure.md
+│   └── README.md
+│
+├── 📚 04-WORK_INSTRUCTIONS/        # ✅ ISO Level 4
+│   ├── WI-001_Installation_Guide.md
+│   ├── WI-002_Usage_Guide.md
+│   ├── WI-003_Development_Guide.md
+│   ├── WI-004_Troubleshooting_Guide.md
+│   ├── WI-005_LiDAR_Debug_Guide.md        # ← MỚI
+│   ├── WI-006_Backend_Integration.md      # ← MỚI (từ API_DOCUMENTATION)
+│   ├── WI-007_Frontend_Integration.md     # ← MỚI (từ API_DOCUMENTATION)
+│   ├── WI-008_Network_Deployment.md       # ← MỚI (từ DEPLOYMENT)
+│   └── README.md                          # ← UPDATED
+│
+├── 📋 05-FORMS_RECORDS/            # ✅ Records & History
+│   ├── REC-001_Change_Log.md              # ← UPDATED (gộp SLC CHANGELOG)
+│   ├── REC-002_Migration_Log_v1.0.1.md
+│   ├── REC-003_Domain_Driven_Migration_Summary.md
+│   ├── REC-004_Cleanup_Summary.md
+│   ├── REC-005_Final_Cleanup_Report.md
+│   ├── REC-006_Documentation_Update_Summary.md
+│   ├── REC-007_LiDAR_HAL_Implementation.md  # ← MỚI
+│   ├── REC-008_Network_Tracking.md          # ← MỚI
+│   ├── REC-009_CTO_Refactor_Order.md        # ← MỚI
+│   └── README.md                            # ← UPDATED
+│
+├── 📚 06-REFERENCE/                # ✅ Technical Reference
+│   ├── REF-001_API_Reference.md           # ← UPDATED (API core)
+│   ├── REF-002_Architecture_Quick_Reference.md
+│   ├── REF-003_Documentation_Index.md
+│   ├── REF-004_Documentation_Navigation.md
+│   ├── REF-005_Control_Loop_Guide.md      # ← MỚI
+│   ├── REF-006_LiDAR_HAL_API.md           # ← MỚI
+│   ├── REF-007_Safety_Architecture.md     # ← MỚI
+│   ├── REF-008_Network_Technical.md       # ← MỚI
+│   └── README.md                          # ← UPDATED
+│
+└── 🏗️ 02-IMPLEMENTATION/          # ✅ GIỮ (technical specs)
+    ├── 01-QMS/                    # Quality Management
+    ├── 03-REQUIREMENTS/           # Requirements specs
+    ├── 04-SLC/                    # Implementation planning
+    ├── 05-SAFETY/                 # Safety systems
+    └── 06-QUALITY/                # Quality assurance
+```
+
+---
+
+## 🚨 **RISKS & MITIGATION**
+
+### **Risks:**
+1. **Broken Links:** Internal references có thể bị broken
+2. **Lost Content:** Có thể mất content khi di chuyển
+3. **Build Impact:** Có thể ảnh hưởng build nếu có references
+
+### **Mitigation:**
+1. ✅ **Backup trước khi dọn:** `tar -czf docs_backup_$(date +%Y%m%d).tar.gz docs/`
+2. ✅ **Test links:** Kiểm tra tất cả internal links sau khi di chuyển
+3. ✅ **Verify content:** Đảm bảo không mất nội dung quan trọng
+4. ✅ **Update references:** Cập nhật tất cả references trong code
+
+---
+
+## ⏱️ **TIMELINE**
+
+- **Phase 1-2:** 15 phút (xóa rỗng + di chuyển HAL)
+- **Phase 3:** 30 phút (tách API_DOCUMENTATION)
+- **Phase 4-7:** 30 phút (di chuyển files)
+- **Phase 8-9:** 20 phút (gộp files)
+- **Phase 10:** 15 phút (update indexes)
+- **TOTAL:** ~110 phút (< 2 giờ)
+
+---
+
+## ✅ **ACCEPTANCE CRITERIA**
+
+- [ ] All empty folders deleted
+- [ ] All duplicate files removed
+- [ ] All docs properly categorized in ISO structure
+- [ ] All README.md files updated
+- [ ] All cross-references working
+- [ ] No broken links
+- [ ] Backup created
+- [ ] Final report generated
+
+---
+
+**Status:** 📋 PLAN READY - Awaiting Execution Approval
+

--- a/firmware_new/docs/CLEANUP_SUMMARY_FINAL.md
+++ b/firmware_new/docs/CLEANUP_SUMMARY_FINAL.md
@@ -1,0 +1,89 @@
+# 🎉 DỌN DẸP TÀI LIỆU FIRMWARE - TÓM TẮT FINAL
+
+**Ngày:** 2025-10-07  
+**Thời gian thực hiện:** 45 phút  
+**Status:** ✅ **HOÀN THÀNH 100%**
+
+---
+
+## ✅ **ĐÃ HOÀN THÀNH**
+
+### **❌ ĐÃ XÓA (9 items):**
+1. ❌ `api/` - Folder rỗng
+2. ❌ `architecture/` - Folder rỗng
+3. ❌ `safety/` - Folder rỗng
+4. ❌ `user_guide/` - Folder rỗng
+5. ❌ `00-OVERVIEW/` - Nội dung đã gộp vào QM-001
+6. ❌ `01-ARCHITECTURE/` - Files đã di chuyển
+7. ❌ `03-DEPLOYMENT/` - Files đã di chuyển
+8. ❌ `04-OPERATIONS/` - Files đã di chuyển
+9. ❌ `FW_APP_SAFETY_ARCHITECTURE.md` - File duplicate
+
+### **✅ ĐÃ DI CHUYỂN (12 files):**
+1. ✅ HAL docs (4 files) → `06-REFERENCE/` & `04-WORK_INSTRUCTIONS/`
+2. ✅ API_DOCUMENTATION.md → `06-REFERENCE/REF-005_API_Complete_Documentation.md`
+3. ✅ Quality Policy → `01-QUALITY_POLICY/QP-003_Quality_Policy.md`
+4. ✅ Safety docs → `06-REFERENCE/REF-007_Safety_Architecture.md`
+5. ✅ Network docs (3 files) → `04-WORK_INSTRUCTIONS/` & `06-REFERENCE/` & `05-FORMS_RECORDS/`
+6. ✅ Root files (2 files) → `05-FORMS_RECORDS/` & `02-IMPLEMENTATION/04-SLC/`
+
+### **📝 ĐÃ CẬP NHẬT (5 READMEs):**
+1. ✅ `docs/README.md` - Main index
+2. ✅ `01-QUALITY_POLICY/README.md`
+3. ✅ `04-WORK_INSTRUCTIONS/README.md`
+4. ✅ `05-FORMS_RECORDS/README.md`
+5. ✅ `06-REFERENCE/README.md`
+
+---
+
+## 📊 **KẾT QUẢ**
+
+### **Trước:**
+- 📁 **Folders:** 17 (4 rỗng, 13 có nội dung)
+- 📄 **Files:** ~82 .md files
+- 🏗️ **Structure:** Mixed (cũ + ISO)
+- ⚠️ **Issues:** Duplicates, loose files, inconsistent
+
+### **Sau:**
+- 📁 **Folders:** 12 (0 rỗng, 12 có nội dung)
+- 📄 **Files:** 40 .md files (organized)
+- 🏗️ **Structure:** 100% ISO 9001:2015
+- ✅ **Quality:** Clean, professional, maintainable
+
+---
+
+## 🎯 **CẤU TRÚC FINAL**
+
+```
+docs/
+├── 📜 01-QUALITY_POLICY/        (4 files)  - Chính sách
+├── 📘 02-QUALITY_MANUAL/        (3 files)  - Sổ tay
+├── 🔧 03-PROCEDURES/            (4 files)  - Thủ tục
+├── 📚 04-WORK_INSTRUCTIONS/     (7 files)  - Hướng dẫn
+├── 📋 05-FORMS_RECORDS/         (10 files) - Hồ sơ
+├── 📚 06-REFERENCE/             (9 files)  - Tham khảo
+└── 🏗️ 02-IMPLEMENTATION/        (~45 files) - Technical Specs
+```
+
+---
+
+## ✅ **COMPLIANCE**
+
+- ✅ **ISO 9001:2015:** 100% compliant
+- ✅ **ISO/IEC 12207:** Referenced
+- ✅ **Naming Convention:** Consistent
+- ✅ **Structure:** Professional
+- ✅ **Navigation:** Clear
+- ✅ **Maintainability:** Excellent
+
+---
+
+## 🎊 **HOÀN THÀNH!**
+
+Tài liệu firmware đã được **tổ chức lại hoàn toàn** theo chuẩn ISO 9001:2015!
+
+### **📚 Tài liệu tham khảo:**
+- [CLEANUP_FINAL_REPORT.md](./CLEANUP_FINAL_REPORT.md) - Báo cáo chi tiết
+- [ISO_STRUCTURE_VISUAL.md](./ISO_STRUCTURE_VISUAL.md) - Hướng dẫn visual
+- [README.md](./README.md) - Master index
+

--- a/firmware_new/docs/FINAL_DISPLAY.txt
+++ b/firmware_new/docs/FINAL_DISPLAY.txt
@@ -1,0 +1,174 @@
+╔═══════════════════════════════════════════════════════════════════╗
+║                                                                   ║
+║        🎊 FIRMWARE DOCUMENTATION CLEANUP - COMPLETED! 🎊         ║
+║                                                                   ║
+║              ✅ 100% ISO 9001:2015 COMPLIANT ✅                  ║
+║                                                                   ║
+╚═══════════════════════════════════════════════════════════════════╝
+
+┌───────────────────────────────────────────────────────────────────┐
+│                    📊 EXECUTION SUMMARY                           │
+└───────────────────────────────────────────────────────────────────┘
+
+   ⏱️  Thời gian thực hiện:    45 phút
+   📁  Folders xóa:            6 folders (empty + old structure)
+   📄  Files di chuyển:        12 files
+   📝  READMEs cập nhật:       5 files
+   ✅  Kết quả:                100% thành công!
+
+┌───────────────────────────────────────────────────────────────────┐
+│                   📁 CẤU TRÚC ISO CUỐI CÙNG                       │
+└───────────────────────────────────────────────────────────────────┘
+
+docs/
+├── 📜 01-QUALITY_POLICY/         (4 files)  ← ISO Level 1
+│   ├── QP-001_Security_Policy.md
+│   ├── QP-002_License.md
+│   ├── QP-003_Quality_Policy.md
+│   └── README.md
+│
+├── 📘 02-QUALITY_MANUAL/         (3 files)  ← ISO Level 2
+│   ├── QM-001_Project_Overview.md
+│   ├── QM-002_Code_Structure.md
+│   └── README.md
+│
+├── 🔧 03-PROCEDURES/             (4 files)  ← ISO Level 3
+│   ├── PR-001_Build_Procedure.md
+│   ├── PR-002_Contributing_Procedure.md
+│   ├── PR-003_Code_Quality_Procedure.md
+│   └── README.md
+│
+├── 📚 04-WORK_INSTRUCTIONS/      (7 files)  ← ISO Level 4
+│   ├── WI-001_Installation_Guide.md
+│   ├── WI-002_Usage_Guide.md
+│   ├── WI-003_Development_Guide.md
+│   ├── WI-004_Troubleshooting_Guide.md
+│   ├── WI-005_LiDAR_Debug_Guide.md       ← NEW!
+│   ├── WI-006_Network_Deployment.md      ← NEW!
+│   └── README.md
+│
+├── 📋 05-FORMS_RECORDS/          (10 files) ← ISO Level 5
+│   ├── REC-001_Change_Log.md
+│   ├── REC-002_Migration_Log_v1.0.1.md
+│   ├── REC-003_Domain_Driven_Migration_Summary.md
+│   ├── REC-004_Cleanup_Summary.md
+│   ├── REC-005_Final_Cleanup_Report.md
+│   ├── REC-006_Documentation_Update_Summary.md
+│   ├── REC-007_LiDAR_HAL_Implementation.md  ← NEW!
+│   ├── REC-008_CTO_Refactor_Order.md        ← NEW!
+│   ├── REC-009_Network_Tracking.md          ← NEW!
+│   └── README.md
+│
+├── 📚 06-REFERENCE/              (9 files)  ← Technical Reference
+│   ├── REF-001_Control_Loop_Guide.md        ← NEW!
+│   ├── REF-002_Architecture_Quick_Reference.md
+│   ├── REF-003_Documentation_Index.md
+│   ├── REF-004_Documentation_Navigation.md
+│   ├── REF-005_API_Complete_Documentation.md ← MOVED!
+│   ├── REF-006_LiDAR_HAL_API.md             ← NEW!
+│   ├── REF-007_Safety_Architecture.md       ← NEW!
+│   ├── REF-008_Network_Technical.md         ← NEW!
+│   └── README.md
+│
+└── 🏗️ 02-IMPLEMENTATION/         (~45 files) ← Technical Specs
+    ├── 01-QMS/
+    ├── 03-REQUIREMENTS/
+    ├── 04-SLC/
+    ├── 05-SAFETY/
+    └── 06-QUALITY/
+
+┌───────────────────────────────────────────────────────────────────┐
+│                      📈 METRICS                                   │
+└───────────────────────────────────────────────────────────────────┘
+
+   BEFORE CLEANUP:
+   • Folders:          17 (including 4 empty)
+   • Files:            ~82 .md files
+   • Structure:        Mixed (old + ISO)
+   • Duplicates:       3 files
+   • Loose files:      4 files at root
+   • ISO Compliance:   60%
+
+   AFTER CLEANUP:
+   • Folders:          12 (0 empty) ✅
+   • Files:            40 .md files ✅
+   • Structure:        100% ISO 9001:2015 ✅
+   • Duplicates:       0 files ✅
+   • Loose files:      2 files (reports) ✅
+   • ISO Compliance:   100% ✅
+
+┌───────────────────────────────────────────────────────────────────┐
+│                     🎯 QUALITY METRICS                            │
+└───────────────────────────────────────────────────────────────────┘
+
+   ✅ No duplicates             100%
+   ✅ No empty folders          100%
+   ✅ Sequential numbering      100%
+   ✅ Updated READMEs           100%
+   ✅ ISO compliance            100%
+   ✅ Professional quality      100%
+
+┌───────────────────────────────────────────────────────────────────┐
+│                  🚀 BENEFITS ACHIEVED                             │
+└───────────────────────────────────────────────────────────────────┘
+
+   For Developers:
+   • ⚡ Faster doc search
+   • 📚 Better organization
+   • 🔍 Clear references
+   • 📖 Complete guides
+
+   For Quality Team:
+   • ✅ ISO compliant
+   • 📋 Proper records
+   • 🔍 Easy audit
+   • 📊 Clear metrics
+
+   For Management:
+   • 🏆 Professional
+   • 📊 Measurable
+   • 🔒 Compliant
+   • 🚀 Scalable
+
+┌───────────────────────────────────────────────────────────────────┐
+│                   📚 KEY DOCUMENTS                                │
+└───────────────────────────────────────────────────────────────────┘
+
+   🔴 CRITICAL (Must Read):
+   • README.md                           - Master index
+   • REF-005_API_Complete_Documentation  - Complete API (3557 lines!)
+   • WI-001_Installation_Guide           - Setup guide
+   • WI-002_Usage_Guide                  - Usage guide
+
+   🟡 IMPORTANT (Should Read):
+   • PR-001_Build_Procedure              - Build process
+   • WI-003_Development_Guide            - Development
+   • REF-001_Control_Loop_Guide          - Control loop
+   • REF-006_LiDAR_HAL_API               - LiDAR API
+
+   🟢 REFERENCE (When Needed):
+   • All REC-xxx files                   - History & records
+   • REF-002_Architecture                - Architecture
+   • REF-007_Safety_Architecture         - Safety system
+
+┌───────────────────────────────────────────────────────────────────┐
+│                    ✨ FINAL NOTES                                 │
+└───────────────────────────────────────────────────────────────────┘
+
+   ✅ All files organized theo ISO 9001:2015
+   ✅ No duplicates, no gaps, no loose files
+   ✅ Professional presentation
+   ✅ Easy to navigate và maintain
+   ✅ Ready for audit và compliance review
+
+   📋 Reports Generated:
+   • CLEANUP_PLAN_ISO.md          - Original plan
+   • CLEANUP_FINAL_REPORT.md      - Detailed report
+   • ISO_STRUCTURE_VISUAL.md      - Visual guide
+   • CLEANUP_SUMMARY_FINAL.md     - This summary
+
+╔═══════════════════════════════════════════════════════════════════╗
+║                                                                   ║
+║                  🎉 DONE! READY TO USE! 🎉                       ║
+║                                                                   ║
+╚═══════════════════════════════════════════════════════════════════╝

--- a/firmware_new/docs/ISO_STRUCTURE_VISUAL.md
+++ b/firmware_new/docs/ISO_STRUCTURE_VISUAL.md
@@ -1,0 +1,477 @@
+# 🎨 ISO DOCUMENTATION STRUCTURE - VISUAL GUIDE
+
+**Version:** 1.0.0  
+**Date:** 2025-10-07  
+**Standard:** ISO 9001:2015  
+**Status:** ✅ COMPLETE
+
+---
+
+## 🏢 **ISO 9001:2015 DOCUMENT PYRAMID**
+
+```
+                        ┌─────────────────────────┐
+                        │   📜 LEVEL 1: POLICY    │
+                        │   (QP-001, QP-002,003)  │
+                        └───────────┬─────────────┘
+                                    │
+                        ┌───────────▼─────────────┐
+                        │  📘 LEVEL 2: MANUAL     │
+                        │  (QM-001, QM-002)       │
+                        └───────────┬─────────────┘
+                                    │
+                        ┌───────────▼─────────────┐
+                        │ 🔧 LEVEL 3: PROCEDURES  │
+                        │ (PR-001, PR-002, PR-003)│
+                        └───────────┬─────────────┘
+                                    │
+                    ┌───────────────▼──────────────┐
+                    │ 📚 LEVEL 4: WORK INSTRUCTIONS│
+                    │ (WI-001→006)                 │
+                    └───────────────┬──────────────┘
+                                    │
+                ┌───────────────────▼─────────────────┐
+                │    📋 LEVEL 5: FORMS & RECORDS      │
+                │    (REC-001→009)                    │
+                └─────────────────────────────────────┘
+```
+
+---
+
+## 📊 **FOLDER OVERVIEW**
+
+### **🎯 Quick Reference:**
+
+| **Folder** | **Purpose** | **Files** | **ISO Level** | **Access** |
+|------------|-------------|-----------|---------------|------------|
+| 📜 **01-QUALITY_POLICY** | Policies | 3 + README | Level 1 | ⭐⭐⭐ Critical |
+| 📘 **02-QUALITY_MANUAL** | Manual | 2 + README | Level 2 | ⭐⭐⭐ Critical |
+| 🔧 **03-PROCEDURES** | Procedures | 3 + README | Level 3 | ⭐⭐ Important |
+| 📚 **04-WORK_INSTRUCTIONS** | Instructions | 6 + README | Level 4 | ⭐⭐ Important |
+| 📋 **05-FORMS_RECORDS** | Records | 9 + README | Level 5 | ⭐ Reference |
+| 📚 **06-REFERENCE** | Tech Docs | 8 + README | Reference | ⭐⭐⭐ Critical |
+| 🏗️ **02-IMPLEMENTATION** | Specs | ~45 files | Technical | ⭐⭐ Important |
+
+---
+
+## 🗺️ **NAVIGATION MAP**
+
+### **❓ "Tôi muốn..."**
+
+| **Goal** | **Go to** | **File** |
+|----------|-----------|----------|
+| 🚀 **Cài đặt firmware** | 04-WORK_INSTRUCTIONS | WI-001_Installation_Guide.md |
+| 📖 **Sử dụng firmware** | 04-WORK_INSTRUCTIONS | WI-002_Usage_Guide.md |
+| 🔧 **Build firmware** | 03-PROCEDURES | PR-001_Build_Procedure.md |
+| 🌐 **Gọi API** | 06-REFERENCE | REF-005_API_Complete_Documentation.md |
+| 🐛 **Debug LiDAR** | 04-WORK_INSTRUCTIONS | WI-005_LiDAR_Debug_Guide.md |
+| 🏗️ **Hiểu architecture** | 06-REFERENCE | REF-002_Architecture_Quick_Reference.md |
+| 🤝 **Đóng góp code** | 03-PROCEDURES | PR-002_Contributing_Procedure.md |
+| 🔒 **Bảo mật** | 01-QUALITY_POLICY | QP-001_Security_Policy.md |
+| ⚖️ **License** | 01-QUALITY_POLICY | QP-002_License.md |
+| 📊 **Xem changelog** | 05-FORMS_RECORDS | REC-001_Change_Log.md |
+| 🎯 **Control loop** | 06-REFERENCE | REF-001_Control_Loop_Guide.md |
+| 🛡️ **Safety system** | 06-REFERENCE | REF-007_Safety_Architecture.md |
+
+---
+
+## 📁 **DETAILED STRUCTURE**
+
+### **📜 01-QUALITY_POLICY (Policies)**
+```
+📋 QP-001_Security_Policy.md          210 lines  - Security & vulnerability
+📋 QP-002_License.md                  206 lines  - MIT license
+📋 QP-003_Quality_Policy.md           201 lines  - Quality objectives
+📖 README.md                           68 lines  - Policy index
+────────────────────────────────────────────────
+TOTAL: 4 files                         685 lines
+```
+
+### **📘 02-QUALITY_MANUAL (Manual)**
+```
+📖 QM-001_Project_Overview.md         500+ lines - Project overview
+📖 QM-002_Code_Structure.md           400+ lines - Code structure  
+📖 README.md                           63 lines  - Manual index
+────────────────────────────────────────────────
+TOTAL: 3 files                        ~1000 lines
+```
+
+### **🔧 03-PROCEDURES (Procedures)**
+```
+📋 PR-001_Build_Procedure.md          540 lines  - Build process
+📋 PR-002_Contributing_Procedure.md   450 lines  - Contributing
+📋 PR-003_Code_Quality_Procedure.md   380 lines  - Quality control
+📖 README.md                           75 lines  - Procedure index
+────────────────────────────────────────────────
+TOTAL: 4 files                         1445 lines
+```
+
+### **📚 04-WORK_INSTRUCTIONS (Instructions)**
+```
+📋 WI-001_Installation_Guide.md       540 lines  - Installation
+📋 WI-002_Usage_Guide.md              420 lines  - Usage
+📋 WI-003_Development_Guide.md        360 lines  - Development
+📋 WI-004_Troubleshooting_Guide.md    380 lines  - Troubleshooting
+📋 WI-005_LiDAR_Debug_Guide.md         95 lines  - LiDAR debug
+📋 WI-006_Network_Deployment.md       200+ lines - Network deploy
+📖 README.md                          100 lines  - Instruction index
+────────────────────────────────────────────────
+TOTAL: 7 files                        ~2100 lines
+```
+
+### **📋 05-FORMS_RECORDS (Records)**
+```
+📋 REC-001_Change_Log.md              211 lines  - Changelog
+📋 REC-002_Migration_Log_v1.0.1.md    565 lines  - Migration log
+📋 REC-003_Domain_Driven_Migration    450 lines  - DDD migration
+📋 REC-004_Cleanup_Summary.md         200+ lines - Cleanup
+📋 REC-005_Final_Cleanup_Report.md    180 lines  - Executive summary
+📋 REC-006_Documentation_Update       220 lines  - Doc updates
+📋 REC-007_LiDAR_HAL_Implementation   431 lines  - LiDAR impl
+📋 REC-008_CTO_Refactor_Order.md      623 lines  - CTO order
+📋 REC-009_Network_Tracking.md        250+ lines - Network tracking
+📖 README.md                          100 lines  - Records index
+────────────────────────────────────────────────
+TOTAL: 10 files                       ~3200 lines
+```
+
+### **📚 06-REFERENCE (Technical Reference)**
+```
+📋 REF-001_Control_Loop_Guide.md       70 lines  - Control loop
+📋 REF-002_Architecture_Quick_Ref     320 lines  - Architecture
+📋 REF-003_Documentation_Index        295 lines  - Doc index
+📋 REF-004_Documentation_Navigation   283 lines  - Doc nav
+📋 REF-005_API_Complete_Docs         3557 lines  - Complete API
+📋 REF-006_LiDAR_HAL_API              645 lines  - LiDAR API
+📋 REF-007_Safety_Architecture        771 lines  - Safety arch
+📋 REF-008_Network_Technical          400+ lines - Network tech
+📖 README.md                          120 lines  - Reference index
+────────────────────────────────────────────────
+TOTAL: 9 files                        ~6500 lines
+```
+
+---
+
+## 🎨 **VISUAL HIERARCHY**
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                     📚 DOCS ROOT                         │
+│                    (README.md)                           │
+└──────────────────────┬───────────────────────────────────┘
+                       │
+       ┌───────────────┼───────────────┐
+       │               │               │
+   ┌───▼────┐     ┌────▼────┐     ┌───▼────┐
+   │ POLICY │     │ MANUAL  │     │PROCESS │
+   │ Level1 │     │ Level2  │     │Level3-4│
+   └────────┘     └─────────┘     └────────┘
+       │               │               │
+   ┌───▼────────────────▼───────────────▼────┐
+   │                                          │
+┌──▼──┐  ┌────────┐  ┌──────────┐  ┌────────▼──┐
+│ QP  │  │   QM   │  │  PR│WI   │  │  REC│REF  │
+│ 3   │  │   2    │  │  3 │ 6    │  │  9 │  8  │
+└─────┘  └────────┘  └──────────┘  └───────────┘
+```
+
+---
+
+## 🔍 **FILE SIZE ANALYSIS**
+
+### **📊 Size Distribution:**
+```
+📦 LARGEST FILES (Top 10):
+1. REF-005_API_Complete_Documentation.md    3557 lines  (🔥 Mega)
+2. REF-007_Safety_Architecture.md            771 lines  (📚 Large)
+3. REF-006_LiDAR_HAL_API.md                  645 lines  (📚 Large)
+4. REC-008_CTO_Refactor_Order.md             623 lines  (📚 Large)
+5. REC-002_Migration_Log_v1.0.1.md           565 lines  (📚 Large)
+6. PR-001_Build_Procedure.md                 540 lines  (📚 Large)
+7. WI-001_Installation_Guide.md              540 lines  (📚 Large)
+8. QM-001_Project_Overview.md                500+ lines (📚 Large)
+9. PR-002_Contributing_Procedure.md          450 lines  (📄 Medium)
+10. REC-003_Domain_Driven_Migration          450 lines  (📄 Medium)
+```
+
+### **📈 Size Categories:**
+- 🔥 **Mega (>3000 lines):** 1 file (REF-005 API Complete)
+- 📚 **Large (500-800 lines):** 7 files
+- 📄 **Medium (200-499 lines):** 12 files
+- 📝 **Small (<200 lines):** 20 files
+
+---
+
+## 🎯 **USAGE PATTERNS**
+
+### **👨‍💻 For Developers:**
+```
+START HERE:
+1. README.md                     → Overview & navigation
+2. QM-001_Project_Overview.md    → Understand project
+3. WI-003_Development_Guide.md   → Setup environment
+4. PR-001_Build_Procedure.md     → Build firmware
+5. REF-001_Control_Loop_Guide.md → Development guide
+```
+
+### **🔧 For DevOps:**
+```
+START HERE:
+1. README.md                     → Overview
+2. WI-001_Installation_Guide.md  → Install guide
+3. WI-006_Network_Deployment.md  → Network setup
+4. PR-001_Build_Procedure.md     → Build process
+5. WI-004_Troubleshooting_Guide.md → Debug issues
+```
+
+### **📊 For PM/QA:**
+```
+START HERE:
+1. README.md                     → Overview
+2. QP-003_Quality_Policy.md      → Quality objectives
+3. REC-001_Change_Log.md         → Version history
+4. 05-FORMS_RECORDS/             → All records
+5. 06-REFERENCE/                 → Technical docs
+```
+
+### **🎨 For Frontend:**
+```
+START HERE:
+1. README.md                     → Overview
+2. REF-005_API_Complete_Documentation.md → Complete API guide
+3. Section: FRONTEND INTEGRATION READY   → React/Vue examples
+4. Section: WEBSOCKET REAL-TIME APIs     → Real-time data
+5. REF-003_Documentation_Index.md        → Quick navigation
+```
+
+### **🔌 For Backend:**
+```
+START HERE:
+1. README.md                     → Overview
+2. REF-005_API_Complete_Documentation.md → Complete API guide
+3. Section: BACKEND IMPLEMENTATION       → Python examples
+4. Section: CONNECTION & HEALTH          → Health checks
+5. REF-008_Network_Technical.md          → Network details
+```
+
+---
+
+## 🌈 **COLOR CODING GUIDE**
+
+### **By Document Type:**
+- 📜 **Policy Documents** (QP-xxx) → Red/Orange (Critical)
+- 📘 **Manual Documents** (QM-xxx) → Blue (Important)
+- 🔧 **Procedures** (PR-xxx) → Green (Process)
+- 📚 **Instructions** (WI-xxx) → Purple (Guidance)
+- 📋 **Records** (REC-xxx) → Yellow (History)
+- 📚 **Reference** (REF-xxx) → Cyan (Technical)
+
+### **By Priority:**
+- 🔴 **Critical (Must Read):** QP-001, QP-002, QM-001, REF-005
+- 🟡 **Important (Should Read):** PR-001, WI-001, WI-002, REF-001
+- 🟢 **Reference (Read When Needed):** All REC-xxx, most REF-xxx
+
+### **By Audience:**
+- 👨‍💻 **Developers:** WI-003, REF-001, REF-002, PR-001
+- 🔧 **DevOps:** WI-001, WI-006, PR-001, REF-008
+- 📊 **PM/QA:** QP-003, REC-001, all REC-xxx
+- 🎨 **Frontend:** REF-005 (Frontend sections)
+- 🔌 **Backend:** REF-005 (Backend sections)
+
+---
+
+## 📍 **DOCUMENT RELATIONSHIPS**
+
+### **🔗 Dependency Map:**
+```mermaid
+graph TD
+    A[README.md<br/>Master Index] --> B[01-QUALITY_POLICY]
+    A --> C[02-QUALITY_MANUAL]
+    A --> D[03-PROCEDURES]
+    A --> E[04-WORK_INSTRUCTIONS]
+    A --> F[05-FORMS_RECORDS]
+    A --> G[06-REFERENCE]
+    
+    B --> B1[QP-001 Security]
+    B --> B2[QP-002 License]
+    B --> B3[QP-003 Quality]
+    
+    C --> C1[QM-001 Overview]
+    C --> C2[QM-002 Structure]
+    
+    D --> D1[PR-001 Build]
+    D --> D2[PR-002 Contributing]
+    D --> D3[PR-003 Quality]
+    
+    E --> E1[WI-001 Install]
+    E --> E2[WI-002 Usage]
+    E --> E3[WI-003 Development]
+    E --> E4[WI-004 Troubleshoot]
+    E --> E5[WI-005 LiDAR Debug]
+    E --> E6[WI-006 Network Deploy]
+    
+    F --> F1[REC-001 Changelog]
+    F --> F2[REC-002→009 Records]
+    
+    G --> G1[REF-001 Control Loop]
+    G --> G2[REF-002 Architecture]
+    G --> G3[REF-005 API Complete]
+    G --> G4[REF-006 LiDAR API]
+    G --> G5[REF-007 Safety]
+    G --> G6[REF-008 Network]
+```
+
+---
+
+## 🎯 **QUICK ACCESS TABLE**
+
+### **📖 Most Frequently Used (Top 10):**
+
+| **Rank** | **File** | **Category** | **Use Case** | **Size** |
+|----------|----------|--------------|--------------|----------|
+| 1️⃣ | REF-005_API_Complete | Reference | **API Development** | 3557 lines |
+| 2️⃣ | WI-001_Installation | Work Instruction | **Setup** | 540 lines |
+| 3️⃣ | WI-002_Usage | Work Instruction | **Daily Use** | 420 lines |
+| 4️⃣ | PR-001_Build | Procedure | **Building** | 540 lines |
+| 5️⃣ | QM-001_Project_Overview | Manual | **Onboarding** | 500+ lines |
+| 6️⃣ | WI-004_Troubleshooting | Work Instruction | **Debug** | 380 lines |
+| 7️⃣ | REF-001_Control_Loop | Reference | **Development** | 70 lines |
+| 8️⃣ | REF-006_LiDAR_HAL_API | Reference | **LiDAR Dev** | 645 lines |
+| 9️⃣ | REC-001_Change_Log | Record | **History** | 211 lines |
+| 🔟 | REF-002_Architecture | Reference | **Architecture** | 320 lines |
+
+---
+
+## 🔄 **DOCUMENT LIFECYCLE**
+
+### **📅 Review Schedule:**
+```
+MONTHLY REVIEW:
+└── README files         (All 7 README.md files)
+
+QUARTERLY REVIEW:
+├── 01-QUALITY_POLICY/   (Policies: QP-xxx)
+├── 02-QUALITY_MANUAL/   (Manual: QM-xxx)
+└── 03-PROCEDURES/       (Procedures: PR-xxx)
+
+ON-DEMAND REVIEW:
+├── 04-WORK_INSTRUCTIONS/ (Instructions: WI-xxx)
+├── 05-FORMS_RECORDS/     (Records: REC-xxx)  
+└── 06-REFERENCE/         (Reference: REF-xxx)
+
+ANNUAL REVIEW:
+└── Complete documentation audit và compliance check
+```
+
+---
+
+## 📊 **STATISTICS**
+
+### **📈 Overall Metrics:**
+- **Total Files:** 40 .md files
+- **Total Lines:** ~15,000+ lines of documentation
+- **Total Folders:** 12 directories
+- **ISO Categories:** 6 main categories
+- **Technical Specs:** 1 implementation folder
+- **README Files:** 7 index files
+- **ISO Compliance:** 100%
+
+### **📑 File Distribution:**
+```
+┌─────────────────────────────────────────┐
+│  ISO DOCUMENT DISTRIBUTION              │
+├─────────────────────────────────────────┤
+│  06-REFERENCE:          23% (9 files)   │ ████████
+│  05-FORMS_RECORDS:      25% (10 files)  │ █████████
+│  04-WORK_INSTRUCTIONS:  18% (7 files)   │ ███████
+│  03-PROCEDURES:         10% (4 files)   │ ████
+│  02-QUALITY_MANUAL:     8% (3 files)    │ ███
+│  01-QUALITY_POLICY:     10% (4 files)   │ ████
+│  02-IMPLEMENTATION:     [Separate]      │ 
+└─────────────────────────────────────────┘
+```
+
+---
+
+## 🏆 **SUCCESS METRICS**
+
+### **✅ Compliance:**
+- **ISO 9001:2015:** ✅ 100%
+- **ISO/IEC 12207:** ✅ 100%
+- **MISRA C:2012:** ✅ Referenced
+- **Documentation Standards:** ✅ 100%
+
+### **✅ Quality:**
+- **No Duplicates:** ✅ 100%
+- **No Empty Folders:** ✅ 100%
+- **Sequential Numbering:** ✅ 100%
+- **Updated READMEs:** ✅ 100%
+
+### **✅ Usability:**
+- **Easy Navigation:** ✅ Excellent
+- **Clear Structure:** ✅ Excellent
+- **Professional:** ✅ Excellent
+- **Maintainable:** ✅ Excellent
+
+---
+
+## 🎓 **KEY IMPROVEMENTS**
+
+### **Before:**
+- ❌ Mixed structure (old + ISO)
+- ❌ 4 empty folders
+- ❌ Duplicate files
+- ❌ Loose files at root
+- ❌ Inconsistent naming
+- ❌ Broken links
+- ❌ Hard to navigate
+
+### **After:**
+- ✅ 100% ISO structure
+- ✅ No empty folders
+- ✅ No duplicates
+- ✅ All files organized
+- ✅ Consistent ISO naming
+- ✅ All links working
+- ✅ Easy navigation
+
+---
+
+## 📚 **MASTER INDEX QUICK LINKS**
+
+### **🚀 Getting Started:**
+1. [README.md](./README.md) - Master documentation index
+2. [QM-001_Project_Overview](./02-QUALITY_MANUAL/QM-001_Project_Overview.md) - Project overview
+3. [WI-001_Installation_Guide](./04-WORK_INSTRUCTIONS/WI-001_Installation_Guide.md) - Installation
+4. [WI-002_Usage_Guide](./04-WORK_INSTRUCTIONS/WI-002_Usage_Guide.md) - Usage
+
+### **🔧 Development:**
+1. [WI-003_Development_Guide](./04-WORK_INSTRUCTIONS/WI-003_Development_Guide.md) - Development
+2. [PR-001_Build_Procedure](./03-PROCEDURES/PR-001_Build_Procedure.md) - Building
+3. [REF-001_Control_Loop_Guide](./06-REFERENCE/REF-001_Control_Loop_Guide.md) - Control loop
+4. [REF-002_Architecture_Quick_Reference](./06-REFERENCE/REF-002_Architecture_Quick_Reference.md) - Architecture
+
+### **🌐 API Integration:**
+1. [REF-005_API_Complete_Documentation](./06-REFERENCE/REF-005_API_Complete_Documentation.md) - Complete API
+2. [REF-006_LiDAR_HAL_API](./06-REFERENCE/REF-006_LiDAR_HAL_API.md) - LiDAR API
+3. [REF-008_Network_Technical](./06-REFERENCE/REF-008_Network_Technical.md) - Network
+
+### **📋 Records & History:**
+1. [REC-001_Change_Log](./05-FORMS_RECORDS/REC-001_Change_Log.md) - Changelog
+2. [REC-002_Migration_Log_v1.0.1](./05-FORMS_RECORDS/REC-002_Migration_Log_v1.0.1.md) - Migration
+3. [REC-007_LiDAR_HAL_Implementation](./05-FORMS_RECORDS/REC-007_LiDAR_HAL_Implementation.md) - LiDAR
+
+---
+
+**🎊 ISO STRUCTURE VISUAL GUIDE - COMPLETE!**
+
+**📅 Created:** 2025-10-07  
+**✅ Status:** Ready for use  
+**🏆 Quality:** Professional & Maintainable  
+**📚 Coverage:** 100% Documentation
+
+---
+
+**Maintained By:** PM & QA Team  
+**Version:** 1.0.0
+

--- a/firmware_new/docs/README.md
+++ b/firmware_new/docs/README.md
@@ -1,0 +1,255 @@
+# 📚 OHT-50 Firmware Documentation
+
+**Version:** 1.0.1  
+**Standard:** ISO 9001:2015 Document Control  
+**Last Updated:** 2025-10-07
+
+---
+
+## 🎯 **GIỚI THIỆU**
+
+Đây là **hệ thống tài liệu ISO chuẩn** cho OHT-50 Firmware, được tổ chức theo **ISO 9001:2015 Quality Management System**.
+
+---
+
+## 📁 **CẤU TRÚC TÀI LIỆU ISO**
+
+### **Theo ISO 9001:2015 Document Hierarchy:**
+
+```
+docs/
+├── 📜 01-QUALITY_POLICY/           # Chính sách chất lượng
+│   ├── QP-001_Security_Policy.md
+│   ├── QP-002_License.md
+│   ├── QP-003_Quality_Policy.md
+│   └── README.md
+│
+├── 📘 02-QUALITY_MANUAL/           # Sổ tay chất lượng
+│   ├── QM-001_Project_Overview.md
+│   ├── QM-002_Code_Structure.md
+│   └── README.md
+│
+├── 🔧 03-PROCEDURES/               # Thủ tục
+│   ├── PR-001_Build_Procedure.md
+│   ├── PR-002_Contributing_Procedure.md
+│   ├── PR-003_Code_Quality_Procedure.md
+│   └── README.md
+│
+├── 📚 04-WORK_INSTRUCTIONS/        # Hướng dẫn công việc
+│   ├── WI-001_Installation_Guide.md
+│   ├── WI-002_Usage_Guide.md
+│   ├── WI-003_Development_Guide.md
+│   ├── WI-004_Troubleshooting_Guide.md
+│   ├── WI-005_LiDAR_Debug_Guide.md
+│   ├── WI-006_Network_Deployment.md
+│   └── README.md
+│
+├── 📋 05-FORMS_RECORDS/            # Biểu mẫu và hồ sơ
+│   ├── REC-001_Change_Log.md
+│   ├── REC-002_Migration_Log_v1.0.1.md
+│   ├── REC-003_Domain_Driven_Migration_Summary.md
+│   ├── REC-004_Cleanup_Summary.md
+│   ├── REC-005_Final_Cleanup_Report.md
+│   ├── REC-006_Documentation_Update_Summary.md
+│   ├── REC-007_LiDAR_HAL_Implementation.md
+│   ├── REC-008_CTO_Refactor_Order.md
+│   ├── REC-009_Network_Tracking.md
+│   └── README.md
+│
+├── 📚 06-REFERENCE/                # Tài liệu tham khảo
+│   ├── REF-001_Control_Loop_Guide.md
+│   ├── REF-002_Architecture_Quick_Reference.md
+│   ├── REF-003_Documentation_Index.md
+│   ├── REF-004_Documentation_Navigation.md
+│   ├── REF-005_API_Complete.md
+│   ├── REF-006_LiDAR_HAL_API.md
+│   ├── REF-007_Safety_Architecture.md
+│   ├── REF-008_Network_Technical.md
+│   └── README.md
+│
+└── 🏗️ 02-IMPLEMENTATION/          # Technical Implementation (Keep)
+    ├── 01-QMS/                     # Quality Management System
+    ├── 03-REQUIREMENTS/            # Requirements Specifications
+    ├── 04-SLC/                     # System Life Cycle
+    ├── 05-SAFETY/                  # Safety Systems
+    └── 06-QUALITY/                 # Quality Assurance
+```
+
+---
+
+## 🗂️ **ISO DOCUMENT NAMING CONVENTION**
+
+### **Format chuẩn:**
+
+```
+<Category>-<Number>_<Name>.md
+
+Categories:
+- QP = Quality Policy (Chính sách chất lượng)
+- QM = Quality Manual (Sổ tay chất lượng)
+- PR = Procedure (Thủ tục)
+- WI = Work Instruction (Hướng dẫn công việc)
+- REC = Record (Hồ sơ)
+- REF = Reference (Tham khảo)
+
+Examples:
+- QP-001_Security_Policy.md
+- PR-001_Build_Procedure.md
+- WI-001_Installation_Guide.md
+```
+
+---
+
+## 🎯 **HƯỚNG DẪN SỬ DỤNG THEO VAI TRÒ**
+
+### **👤 Người dùng mới (New User)**
+
+**Đọc theo thứ tự:**
+
+1. 📘 **QM-001** - Project Overview
+2. 📚 **WI-001** - Installation Guide
+3. 📖 **WI-002** - Usage Guide
+4. 🐛 **WI-004** - Troubleshooting (khi cần)
+
+**Thời gian:** ~1-2 giờ
+
+---
+
+### **👨‍💻 Developer**
+
+**Đọc theo thứ tự:**
+
+1. 📘 **QM-001** - Project Overview
+2. 🏗️ **QM-002** - Code Structure
+3. 🔧 **PR-001** - Build Procedure
+4. 🤝 **PR-002** - Contributing Procedure
+5. 🛠️ **WI-003** - Development Guide
+6. 🌐 **REF-001** - API Reference
+
+**Thời gian:** ~2-3 giờ
+
+---
+
+### **🏢 PM / QA / Auditor**
+
+**Đọc theo thứ tự:**
+
+1. 📜 **QP-001** - Security Policy
+2. ⚖️ **QP-002** - License
+3. 📘 **QM-001** - Project Overview
+4. 🏗️ **QM-002** - Code Structure
+5. 📊 **REC-001** - Change Log
+6. 📋 **REC-003** - Migration Summary
+
+**Thời gian:** ~1-2 giờ
+
+---
+
+## 📊 **DOCUMENT MATRIX**
+
+### **Compliance Mapping:**
+
+| **ISO Clause** | **Document** | **Purpose** |
+|----------------|--------------|-------------|
+| **5.2** Quality Policy | QP-001, QP-002 | Chính sách |
+| **7.5** Documented Info | QM-001, QM-002 | Quality Manual |
+| **8.0** Operation | PR-001, PR-002, PR-003 | Procedures |
+| **7.1.6** Knowledge | WI-001 → WI-004 | Work Instructions |
+| **7.5.3** Records | REC-001 → REC-006 | Forms & Records |
+| **7.5** External Docs | REF-001 → REF-004 | References |
+
+---
+
+## 🔄 **DOCUMENT CONTROL**
+
+### **Version Control:**
+
+| **Category** | **Version Format** | **Example** |
+|--------------|-------------------|-------------|
+| Quality Policy | Major.Minor | 1.0, 1.1, 2.0 |
+| Procedures | Major.Minor.Patch | 1.0.1, 1.1.0 |
+| Work Instructions | Major.Minor.Patch | 1.0.1 |
+| Records | Major.Minor + Date | 1.0.1 (2025-10-07) |
+
+### **Review & Approval:**
+
+| **Document Type** | **Review Frequency** | **Approver** |
+|-------------------|---------------------|--------------|
+| Quality Policy | Yearly | CTO |
+| Quality Manual | Quarterly | PM |
+| Procedures | Semi-annual | Team Lead |
+| Work Instructions | As needed | Author |
+| Records | Archive only | QA |
+| References | As needed | Author |
+
+---
+
+## 🔍 **TÌM TÀI LIỆU NHANH**
+
+### **Theo chủ đề:**
+
+| **Chủ đề** | **Document** | **Location** |
+|------------|--------------|--------------|
+| 🔐 **Security** | QP-001 | 01-QUALITY_POLICY/ |
+| ⚖️ **License** | QP-002 | 01-QUALITY_POLICY/ |
+| 📖 **Getting Started** | WI-001, WI-002 | 04-WORK_INSTRUCTIONS/ |
+| 🔧 **Build** | PR-001 | 03-PROCEDURES/ |
+| 🌐 **API** | REF-001 | 06-REFERENCE/ |
+| 🏗️ **Architecture** | QM-002, REF-002 | 02-QUALITY_MANUAL/, 06-REFERENCE/ |
+| 🐛 **Troubleshooting** | WI-004 | 04-WORK_INSTRUCTIONS/ |
+| 📊 **Changelog** | REC-001 | 05-FORMS_RECORDS/ |
+
+---
+
+## ✅ **QUALITY CHECKLIST**
+
+Trước khi release version mới:
+
+- [ ] Update REC-001 (Change Log)
+- [ ] Review QP-001 (Security Policy)
+- [ ] Update QM-001 (Project Overview)
+- [ ] Verify all REF documents current
+- [ ] Archive old records
+- [ ] Update version numbers
+
+---
+
+## 📞 **DOCUMENT OWNERSHIP**
+
+| **Category** | **Owner** | **Contact** |
+|--------------|-----------|-------------|
+| Quality Policy | Legal/Security Team | legal@oht50.com |
+| Quality Manual | PM Team | pm@oht50.com |
+| Procedures | Process Team | process@oht50.com |
+| Work Instructions | Operations Team | ops@oht50.com |
+| Forms/Records | QA Team | qa@oht50.com |
+| Reference | Documentation Team | docs@oht50.com |
+
+---
+
+## 🎓 **TRAINING MATERIALS**
+
+Cho team members mới:
+
+1. **Day 1:** QM-001 (Overview) + WI-001 (Installation)
+2. **Week 1:** WI-002 (Usage) + WI-003 (Development)
+3. **Week 2:** PR-002 (Contributing) + REF-001 (API)
+4. **Month 1:** QM-002 (Code Structure) + REF-002 (Architecture)
+
+---
+
+## 📈 **METRICS**
+
+| **Metric** | **Value** | **Target** | **Status** |
+|------------|-----------|------------|------------|
+| **Total Documents** | 16 files | 15+ | ✅ Met |
+| **ISO Categories** | 6 categories | 6 | ✅ Met |
+| **Documentation Coverage** | 95% | 90%+ | ✅ Exceeded |
+| **Review Compliance** | 100% | 100% | ✅ Met |
+
+---
+
+**Version:** 1.0  
+**Last Updated:** 2025-10-07  
+**Maintained By:** Documentation Team  
+**ISO Compliance:** ✅ ISO 9001:2015 Compliant


### PR DESCRIPTION
- Remove symlink firmware_new/docs that doesn't work on Windows
- Create actual firmware_new/docs folder with all documentation
- Copy all docs content from 05-IMPLEMENTATION/FIRMWARE
- Ensure docs folder works on all platforms (Linux, Windows, macOS)
- Fix issue where Windows users couldn't access docs after clone

This resolves the issue where cloned repository on Windows PC doesn't have accessible docs folder.